### PR TITLE
fix: LOCAL_DISABLE_QUOTA_APIS 플래그로 로컬 YouTube/Gemini quota 소모 방지

### DIFF
--- a/context/env-config.md
+++ b/context/env-config.md
@@ -6,24 +6,25 @@
 
 ## 서버 (NestJS)
 
-| 변수명                | 기본값                  | 필수     | 설명                                 |
-| --------------------- | ----------------------- | -------- | ------------------------------------ |
-| `PORT`                | `3001`                  | -        | NestJS 리스닝 포트                   |
-| `CLIENT_ORIGIN`       | `http://localhost:3000` | -        | CORS 허용 출처 (쉼표 구분 복수 허용) |
-| `DB_HOST`             | `127.0.0.1`             | -        | MariaDB 호스트                       |
-| `DB_PORT`             | `3306`                  | -        | MariaDB 포트                         |
-| `DB_NAME`             | `lost_ark`              | -        | DB 이름                              |
-| `DB_USER`             | `root`                  | -        | DB 유저                              |
-| `DB_PASS`             | `''`                    | **필수** | DB 비밀번호                          |
-| `REDIS_HOST`          | `127.0.0.1`             | -        | Redis 호스트                         |
-| `REDIS_PORT`          | `6379`                  | -        | Redis 포트                           |
-| `REDIS_PASSWORD`      | (없음)                  | -        | Redis 비밀번호 (없으면 미설정)       |
-| `REDIS_DB`            | `0`                     | -        | Redis DB 번호                        |
-| `LOSTARK_API_KEY`     | -                       | **필수** | LostArk Open API 키                  |
-| `YOUTUBE_API_KEY`     | -                       | **필수** | YouTube Data API v3 키               |
-| `GEMINI_API_KEY`      | -                       | **필수** | Google Gemini API 키                 |
-| `KAKAO_REST_API_KEY`  | -                       | **필수** | 카카오 REST API 키                   |
-| `KAKAO_REFRESH_TOKEN` | -                       | **필수** | 카카오 OAuth 리프레시 토큰           |
+| 변수명                     | 기본값                  | 필수     | 설명                                        |
+| -------------------------- | ----------------------- | -------- | ------------------------------------------- |
+| `PORT`                     | `3001`                  | -        | NestJS 리스닝 포트                          |
+| `CLIENT_ORIGIN`            | `http://localhost:3000` | -        | CORS 허용 출처 (쉼표 구분 복수 허용)        |
+| `DB_HOST`                  | `127.0.0.1`             | -        | MariaDB 호스트                              |
+| `DB_PORT`                  | `3306`                  | -        | MariaDB 포트                                |
+| `DB_NAME`                  | `lost_ark`              | -        | DB 이름                                     |
+| `DB_USER`                  | `root`                  | -        | DB 유저                                     |
+| `DB_PASS`                  | `''`                    | **필수** | DB 비밀번호                                 |
+| `REDIS_HOST`               | `127.0.0.1`             | -        | Redis 호스트                                |
+| `REDIS_PORT`               | `6379`                  | -        | Redis 포트                                  |
+| `REDIS_PASSWORD`           | (없음)                  | -        | Redis 비밀번호 (없으면 미설정)              |
+| `REDIS_DB`                 | `0`                     | -        | Redis DB 번호                               |
+| `LOCAL_DISABLE_QUOTA_APIS` | `false`                 | -        | 로컬 개발에서 YouTube/Gemini 외부 호출 차단 |
+| `LOSTARK_API_KEY`          | -                       | **필수** | LostArk Open API 키                         |
+| `YOUTUBE_API_KEY`          | -                       | **필수** | YouTube Data API v3 키                      |
+| `GEMINI_API_KEY`           | -                       | **필수** | Google Gemini API 키                        |
+| `KAKAO_REST_API_KEY`       | -                       | **필수** | 카카오 REST API 키                          |
+| `KAKAO_REFRESH_TOKEN`      | -                       | **필수** | 카카오 OAuth 리프레시 토큰                  |
 
 ### CORS 설정 주의
 
@@ -51,6 +52,9 @@ DB_PASS=1234
 
 # Redis (로컬은 패스워드 없음)
 REDIS_HOST=127.0.0.1
+
+# 로컬 개발 중 YouTube/Gemini 할당량 보호
+LOCAL_DISABLE_QUOTA_APIS=true
 
 # API Keys
 LOSTARK_API_KEY=eyJ0eXAiOiJKV1Q...

--- a/server/src/class-summary/class-summary.service.spec.ts
+++ b/server/src/class-summary/class-summary.service.spec.ts
@@ -1,0 +1,77 @@
+import { ConfigService } from '@nestjs/config';
+import { ClassSummaryService } from './class-summary.service';
+
+type MockPool = {
+  execute: jest.Mock;
+};
+
+type MockRedis = {
+  get: jest.Mock;
+  set: jest.Mock;
+  incr: jest.Mock;
+  expire: jest.Mock;
+};
+
+function createService(localDisable = 'true') {
+  const pool: MockPool = {
+    execute: jest.fn(),
+  };
+
+  const redis: MockRedis = {
+    get: jest.fn(),
+    set: jest.fn(),
+    incr: jest.fn(),
+    expire: jest.fn(),
+  };
+
+  const config = {
+    get: jest.fn((key: string) => {
+      const values: Record<string, string | undefined> = {
+        GEMINI_API_KEY: 'dummy-key',
+        LOCAL_DISABLE_QUOTA_APIS: localDisable,
+      };
+      return values[key];
+    }),
+  } as unknown as ConfigService;
+
+  const service = new ClassSummaryService(
+    pool as never,
+    redis as never,
+    config,
+  );
+  return { service, pool };
+}
+
+describe('ClassSummaryService', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('LOCAL_DISABLE_QUOTA_APIS=true면 초기 직업 크롤링을 시작하지 않는다', async () => {
+    const { service, pool } = createService();
+    const runAllSpy = jest.spyOn(service, 'runAll').mockResolvedValue();
+
+    await service.onModuleInit();
+
+    expect(pool.execute).not.toHaveBeenCalled();
+    expect(runAllSpy).not.toHaveBeenCalled();
+  });
+
+  it('LOCAL_DISABLE_QUOTA_APIS=true면 스케줄 직업 크롤링을 시작하지 않는다', async () => {
+    const { service } = createService();
+    const runAllSpy = jest.spyOn(service, 'runAll').mockResolvedValue();
+
+    await service.scheduledRun();
+
+    expect(runAllSpy).not.toHaveBeenCalled();
+  });
+
+  it('LOCAL_DISABLE_QUOTA_APIS=true면 수동 runAll도 내부 처리 없이 종료한다', async () => {
+    const { service } = createService();
+    const processSpy = jest.spyOn(service as never, 'processClass');
+
+    await service.runAll();
+
+    expect(processSpy).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/class-summary/class-summary.service.ts
+++ b/server/src/class-summary/class-summary.service.ts
@@ -10,6 +10,7 @@ import { REDIS_CLIENT } from '../redis/redis.module';
 import axios from 'axios';
 import * as cheerio from 'cheerio';
 import { GoogleGenerativeAI } from '@google/generative-ai';
+import { isLocalQuotaApisDisabled } from '../common/local-dev-flags';
 
 // 직업별 인벤 게시판 ID (기획.md 기준)
 const CLASS_BOARD: Record<string, number> = {
@@ -73,6 +74,7 @@ interface SummaryRow extends RowDataPacket {
 export class ClassSummaryService implements OnModuleInit {
   private readonly logger = new Logger(ClassSummaryService.name);
   private readonly genAI: GoogleGenerativeAI | null;
+  private readonly quotaApisDisabled: boolean;
   private isRunning = false; // 동시 실행 방지
 
   constructor(
@@ -80,6 +82,7 @@ export class ClassSummaryService implements OnModuleInit {
     @Inject(REDIS_CLIENT) private readonly redis: Redis,
     private readonly config: ConfigService,
   ) {
+    this.quotaApisDisabled = isLocalQuotaApisDisabled(config);
     const apiKey = this.config.get<string>('GEMINI_API_KEY');
     if (apiKey) {
       this.genAI = new GoogleGenerativeAI(apiKey);
@@ -90,6 +93,13 @@ export class ClassSummaryService implements OnModuleInit {
   }
 
   async onModuleInit() {
+    if (this.quotaApisDisabled) {
+      this.logger.log(
+        'LOCAL_DISABLE_QUOTA_APIS 활성화 — 초기 직업 크롤링 스킵',
+      );
+      return;
+    }
+
     const [rows] = await this.pool.execute<CountRow[]>(
       'SELECT COUNT(*) as cnt FROM loa_class_summaries',
     );
@@ -107,12 +117,26 @@ export class ClassSummaryService implements OnModuleInit {
   /** 매 시간 정각 실행 — 29개 직업을 60분에 걸쳐 분산 처리 */
   @Cron('0 0 * * * *')
   async scheduledRun() {
+    if (this.quotaApisDisabled) {
+      this.logger.log(
+        'LOCAL_DISABLE_QUOTA_APIS 활성화 — 시간별 직업 크롤링 스킵',
+      );
+      return;
+    }
+
     this.logger.log('시간별 스케줄 크롤링 시작');
     await this.runAll();
   }
 
   /** 전체 직업 순차 처리 */
   async runAll() {
+    if (this.quotaApisDisabled) {
+      this.logger.log(
+        'LOCAL_DISABLE_QUOTA_APIS 활성화 — Gemini 직업 요약 갱신 스킵',
+      );
+      return;
+    }
+
     if (!this.genAI) {
       this.logger.warn('GEMINI_API_KEY 없음 — 스킵');
       return;

--- a/server/src/common/local-dev-flags.ts
+++ b/server/src/common/local-dev-flags.ts
@@ -1,0 +1,9 @@
+import { ConfigService } from '@nestjs/config';
+
+const TRUE_VALUES = new Set(['1', 'true', 'yes', 'on']);
+
+export function isLocalQuotaApisDisabled(config: ConfigService): boolean {
+  const raw = config.get<string>('LOCAL_DISABLE_QUOTA_APIS');
+  if (!raw) return false;
+  return TRUE_VALUES.has(raw.trim().toLowerCase());
+}

--- a/server/src/streamers/streamers.service.spec.ts
+++ b/server/src/streamers/streamers.service.spec.ts
@@ -13,17 +13,19 @@ function createService(options?: {
   popularCache?: { items: YoutubeVideoItem[] };
 }) {
   const redis: MockRedis = {
-    get: jest.fn(async (key: string) => {
+    get: jest.fn((key: string) => {
       if (key === 'youtube:videos:page:first') {
-        return options?.cache ? JSON.stringify(options.cache) : null;
+        return Promise.resolve(
+          options?.cache ? JSON.stringify(options.cache) : null,
+        );
       }
       if (key === 'youtube:popular:first') {
-        return options?.popularCache
-          ? JSON.stringify(options.popularCache)
-          : null;
+        return Promise.resolve(
+          options?.popularCache ? JSON.stringify(options.popularCache) : null,
+        );
       }
-      if (key === 'youtube:quota_exceeded') return null;
-      return null;
+      if (key === 'youtube:quota_exceeded') return Promise.resolve(null);
+      return Promise.resolve(null);
     }),
     set: jest.fn(),
     ttl: jest.fn(),

--- a/server/src/streamers/streamers.service.spec.ts
+++ b/server/src/streamers/streamers.service.spec.ts
@@ -1,0 +1,111 @@
+import { ConfigService } from '@nestjs/config';
+import { StreamersService, type YoutubeVideoItem } from './streamers.service';
+
+type MockRedis = {
+  get: jest.Mock;
+  set: jest.Mock;
+  ttl: jest.Mock;
+};
+
+function createService(options?: {
+  localDisable?: string;
+  cache?: { items: YoutubeVideoItem[]; nextPageToken: string | null };
+  popularCache?: { items: YoutubeVideoItem[] };
+}) {
+  const redis: MockRedis = {
+    get: jest.fn(async (key: string) => {
+      if (key === 'youtube:videos:page:first') {
+        return options?.cache ? JSON.stringify(options.cache) : null;
+      }
+      if (key === 'youtube:popular:first') {
+        return options?.popularCache
+          ? JSON.stringify(options.popularCache)
+          : null;
+      }
+      if (key === 'youtube:quota_exceeded') return null;
+      return null;
+    }),
+    set: jest.fn(),
+    ttl: jest.fn(),
+  };
+
+  const config = {
+    get: jest.fn((key: string, defaultValue?: string) => {
+      const values: Record<string, string | undefined> = {
+        YOUTUBE_API_KEY: 'dummy-key',
+        LOCAL_DISABLE_QUOTA_APIS: options?.localDisable,
+      };
+      return values[key] ?? defaultValue;
+    }),
+  } as unknown as ConfigService;
+
+  const service = new StreamersService(redis as never, config);
+  return { service, redis };
+}
+
+describe('StreamersService', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('LOCAL_DISABLE_QUOTA_APIS=true면 시작 시 YouTube 갱신을 스킵한다', async () => {
+    const { service } = createService({ localDisable: 'true' });
+    const refreshSpy = jest.spyOn(service, 'refresh').mockResolvedValue();
+
+    await service.onModuleInit();
+
+    expect(refreshSpy).not.toHaveBeenCalled();
+  });
+
+  it('LOCAL_DISABLE_QUOTA_APIS=true여도 캐시된 영상은 반환한다', async () => {
+    const cached = {
+      items: [
+        {
+          videoId: 'abc123',
+          title: '테스트 영상',
+          channelTitle: '테스트 채널',
+          thumbnailUrl: 'https://example.com/thumb.jpg',
+          publishedAt: '2026-04-28T00:00:00Z',
+          duration: '10:00',
+          viewCount: 999,
+        },
+      ],
+      nextPageToken: null,
+    };
+    const { service } = createService({
+      localDisable: 'true',
+      cache: cached,
+    });
+    const fetchSpy = jest.spyOn(service as never, 'fetchFromYouTube');
+
+    const result = await service.searchVideos();
+
+    expect(result).toEqual(cached);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('LOCAL_DISABLE_QUOTA_APIS=true고 캐시가 없으면 빈 영상 결과를 반환한다', async () => {
+    const { service } = createService({ localDisable: 'true' });
+    const fetchSpy = jest.spyOn(service as never, 'fetchFromYouTube');
+
+    const result = await service.searchVideos();
+
+    expect(result).toEqual({ items: [], nextPageToken: null });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('LOCAL_DISABLE_QUOTA_APIS=true고 인기 영상 캐시가 없으면 빈 인기 목록을 반환한다', async () => {
+    const { service } = createService({ localDisable: 'true' });
+    const fetchSpy = jest.spyOn(service as never, 'fetchFromYouTube');
+
+    const result = await service.searchPopularVideos();
+
+    expect(result).toEqual({
+      items: [],
+      nextOffset: null,
+      hasMore: false,
+      total: 0,
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/streamers/streamers.service.ts
+++ b/server/src/streamers/streamers.service.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { google } from 'googleapis';
 import type { Redis } from 'ioredis';
+import { isLocalQuotaApisDisabled } from '../common/local-dev-flags';
 import { REDIS_CLIENT } from '../redis/redis.module';
 
 const CACHE_PREFIX = 'youtube:videos:page:';
@@ -90,6 +91,7 @@ function formatDuration(iso: string): string {
 export class StreamersService implements OnModuleInit {
   private readonly logger = new Logger(StreamersService.name);
   private readonly youtubeKeys: ReturnType<typeof google.youtube>[];
+  private readonly quotaApisDisabled: boolean;
   private currentKeyIdx = 0;
 
   private get youtube() {
@@ -107,9 +109,17 @@ export class StreamersService implements OnModuleInit {
     this.youtubeKeys = keys.map((k) =>
       google.youtube({ version: 'v3', auth: k }),
     );
+    this.quotaApisDisabled = isLocalQuotaApisDisabled(config);
   }
 
   async onModuleInit() {
+    if (this.quotaApisDisabled) {
+      this.logger.log(
+        'LOCAL_DISABLE_QUOTA_APIS 활성화 — 시작 시 YouTube 갱신 스킵',
+      );
+      return;
+    }
+
     // Redis에 캐시가 이미 있으면 API 호출 스킵 (서버 재시작 보호)
     try {
       const cached = await this.redis.get(CACHE_PREFIX + 'first');
@@ -126,6 +136,13 @@ export class StreamersService implements OnModuleInit {
   /** 매시 정각 갱신 */
   @Cron(CronExpression.EVERY_HOUR)
   async refresh() {
+    if (this.quotaApisDisabled) {
+      this.logger.log(
+        'LOCAL_DISABLE_QUOTA_APIS 활성화 — 스케줄 YouTube 갱신 스킵',
+      );
+      return;
+    }
+
     // 할당량 초과 플래그 확인
     try {
       const blocked = await this.redis.get(QUOTA_KEY);
@@ -190,6 +207,13 @@ export class StreamersService implements OnModuleInit {
       this.logger.warn('Redis get 실패', (err as Error).message);
     }
 
+    if (this.quotaApisDisabled) {
+      this.logger.log(
+        'LOCAL_DISABLE_QUOTA_APIS 활성화 — YouTube API 호출 없이 빈 결과 반환',
+      );
+      return { items: [], nextPageToken: null };
+    }
+
     // 2. 할당량 초과 상태면 빈 결과 반환
     try {
       const blocked = await this.redis.get(QUOTA_KEY);
@@ -236,6 +260,13 @@ export class StreamersService implements OnModuleInit {
       this.logger.debug(
         `popular 캐시 조회 실패(무시): ${toErrorMessage(error)}`,
       );
+    }
+
+    if (this.quotaApisDisabled) {
+      this.logger.log(
+        'LOCAL_DISABLE_QUOTA_APIS 활성화 — 인기 영상 API 호출 없이 빈 결과 반환',
+      );
+      return { items: [], nextOffset: null, hasMore: false, total: 0 };
     }
 
     try {

--- a/server/test/app.e2e-spec.ts
+++ b/server/test/app.e2e-spec.ts
@@ -10,6 +10,7 @@ import { AppModule } from '../src/app.module';
  */
 describe('AppController (e2e)', () => {
   let app: INestApplication;
+  let httpServer: Parameters<typeof request>[0];
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -18,6 +19,7 @@ describe('AppController (e2e)', () => {
 
     app = moduleFixture.createNestApplication();
     await app.init();
+    httpServer = app.getHttpServer() as Parameters<typeof request>[0];
   });
 
   afterAll(async () => {
@@ -25,7 +27,7 @@ describe('AppController (e2e)', () => {
   });
 
   it('GET /api/sites → 200 + 배열 반환', () => {
-    return request(app.getHttpServer())
+    return request(httpServer)
       .get('/api/sites')
       .expect(200)
       .expect((res) => {
@@ -34,7 +36,7 @@ describe('AppController (e2e)', () => {
   });
 
   it('GET /api/characters/stat-builds → 200 + 7개 탭', () => {
-    return request(app.getHttpServer())
+    return request(httpServer)
       .get('/api/characters/stat-builds')
       .expect(200)
       .expect((res) => {
@@ -44,6 +46,6 @@ describe('AppController (e2e)', () => {
   });
 
   it('존재하지 않는 경로 → 404', () => {
-    return request(app.getHttpServer()).get('/api/not-found').expect(404);
+    return request(httpServer).get('/api/not-found').expect(404);
   });
 });


### PR DESCRIPTION
## 변경 내용

로컬 개발 환경에서 YouTube API / Gemini API quota를 불필요하게 소모하지 않도록 환경변수 플래그를 추가합니다.

### 추가된 파일
- `server/src/common/local-dev-flags.ts` — `isLocalQuotaApisDisabled()` 공통 헬퍼
- `server/src/streamers/streamers.service.spec.ts` — YouTube quota 가드 단위 테스트
- `server/src/class-summary/class-summary.service.spec.ts` — Gemini quota 가드 단위 테스트

### 변경된 파일
- `server/src/streamers/streamers.service.ts` — `onModuleInit` / `refresh` / `searchVideos` 에 가드 추가
- `server/src/class-summary/class-summary.service.ts` — `onModuleInit` / `scheduledRun` / `summarize` 에 가드 추가
- `context/env-config.md` — `LOCAL_DISABLE_QUOTA_APIS` 항목 문서화

### 동작
- `LOCAL_DISABLE_QUOTA_APIS=true` (server/.env) → YouTube/Gemini API 호출 스킵, 캐시만 사용
- CI 환경에서는 해당 env 없음 → 플래그 false → 기존 동작 유지 (테스트는 mock 사용으로 실제 API 호출 없음)