### PR TITLE
fix: korean-encoding spec에서 mysql 타입 캐스트 제거

### DIFF
--- a/server/test/korean-encoding.integration-spec.ts
+++ b/server/test/korean-encoding.integration-spec.ts
@@ -139,7 +139,7 @@ describe('한글 인코딩 통합 테스트 (loa_sites)', () => {
       'SELECT name, description FROM loa_sites_enc_test',
     );
 
-    for (const row of rows as mysql.RowDataPacket[]) {
+    for (const row of rows) {
       expect(row.name).not.toMatch(/\?{2,}/);
       expect(row.description ?? '').not.toMatch(/\?{2,}/);
     }


### PR DESCRIPTION
## 변경 내용

`server/test/korean-encoding.integration-spec.ts`에서 불필요한 `mysql.RowDataPacket[]` 타입 캐스트를 제거합니다.

### 변경 전
for (const row of rows as mysql.RowDataPacket[]) {

### 변경 후
for (const row of rows) {

### 이유
타입 캐스트 없이도 동작하며, CI 실행 오류의 원인이 되었던 불필요한 캐스트 제거