### PR TITLE
fix(ci): main-post-merge 워크플로우 YAML 문법 오류 수정

### DIFF
--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -33,7 +33,8 @@ jobs:
         run: npm run build
 
       - name: Deploy trigger (placeholder)
-        run: echo "배포 트리거 단계를 여기에 연결하세요. 예: SSH, webhook, cloud deploy action"
+        run: |
+          echo "배포 트리거 단계를 여기에 연결하세요. 예: SSH, webhook, cloud deploy action"
 
       - name: Health check (optional)
         env:


### PR DESCRIPTION
목적
main-post-merge 워크플로우 파싱 실패를 유발하던 YAML 문법 오류를 해결합니다.
변경점
Deploy trigger 단계의 run 한 줄 문자열을 블록 스칼라 형식으로 변경
콜론이 포함된 문장으로 인해 발생하던 YAML 파싱 오류 제거
테스트 결과
 GitHub Actions 워크플로우 문법 오류 해소 확인
 PR CI 통과 확인
영향 범위
 client
 server
 crawlers
 infra/nginx/scripts
롤백 방법
되돌릴 커밋: 4c95347
롤백 절차: 해당 커밋 revert 후 재푸시
체크리스트
 PR 제목 형식 준수
 민감정보(.env, 키) 미포함 확인