### PR TITLE
perf: ISR 전환, Vercel 서울 리전 고정, YouTube Suspense 분리, Cache-Control 헤더 추가

### DIFF
--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -1,14 +1,18 @@
+import { Suspense } from "react";
 import StatBuildList from "@/components/characters/StatBuildList";
 import SiteList from "@/components/sites/SiteList";
-import YoutubeList from "@/components/youtube/YoutubeList";
-import type { Site, StatBuildTab, YoutubeVideo } from "@/types";
+import YoutubeSection from "@/components/youtube/YoutubeSection";
+import type { Site, StatBuildTab } from "@/types";
 
-// SSR: NestJS 서버에서 데이터를 직접 fetch (빌드 시 또는 요청마다)
+// Vercel 함수 리전: 서울(icn1) 고정 — API(EC2 한국)와 왕복 지연 최소화
+export const preferredRegion = "icn1";
+
+// ISR: NestJS 서버에서 데이터를 fetch (revalidate 주기마다 백그라운드 갱신)
 const API = process.env.NEST_API_URL ?? "http://localhost:3001";
 
 export default async function Home() {
-  const [sites, statBuilds, youtubeInitial] = await Promise.all([
-    fetch(`${API}/api/sites`, { cache: "no-store" })
+  const [sites, statBuilds] = await Promise.all([
+    fetch(`${API}/api/sites`, { next: { revalidate: 300 } })
       .then<Site[]>((r) => r.json())
       .catch(() => [] as Site[]),
     fetch(`${API}/api/characters/stat-builds`, {
@@ -16,11 +20,6 @@ export default async function Home() {
     })
       .then<StatBuildTab[]>((r) => r.json())
       .catch(() => [] as StatBuildTab[]),
-    fetch(`${API}/api/streamers/popular?offset=0&limit=8`, {
-      next: { revalidate: 3600 },
-    })
-      .then<{ items: YoutubeVideo[]; hasMore: boolean; nextOffset: number | null }>((r) => r.json())
-      .catch(() => ({ items: [] as YoutubeVideo[], hasMore: false, nextOffset: null })),
   ]);
 
   return (
@@ -49,12 +48,24 @@ export default async function Home() {
               </div>
             </section>
 
-            {/* 하단 유튜브 인기 영상 */}
-            <YoutubeList
-              initialItems={youtubeInitial.items}
-              initialHasMore={youtubeInitial.hasMore}
-              initialNextOffset={youtubeInitial.nextOffset}
-            />
+            {/* 하단 유튜브 인기 영상 — 별도 스트림으로 분리, 먼저 스켈레톤 노출 */}
+            <Suspense
+              fallback={
+                <div className="animate-pulse space-y-2 pt-2">
+                  <div className="h-5 w-36 rounded bg-slate-200" />
+                  <div className="flex gap-3 overflow-hidden">
+                    {[0, 1, 2].map((i) => (
+                      <div
+                        key={i}
+                        className="h-[190px] w-[270px] shrink-0 rounded-lg bg-slate-200"
+                      />
+                    ))}
+                  </div>
+                </div>
+              }
+            >
+              <YoutubeSection />
+            </Suspense>
 
             {/* 모바일에서는 특성 빌드 분포를 영상 아래로 배치 */}
             <div className="sm:hidden">

--- a/client/components/youtube/YoutubeList.tsx
+++ b/client/components/youtube/YoutubeList.tsx
@@ -51,10 +51,13 @@ export default function YoutubeList({
 } = {}) {
   const [items, setItems] = useState<YoutubeVideo[]>(initialItems);
   const [loading, setLoading] = useState(initialItems.length === 0);
+  const [refreshing, setRefreshing] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const [enteringCount, setEnteringCount] = useState(0);
   const [hasMore, setHasMore] = useState(initialHasMore);
-  const [nextOffset, setNextOffset] = useState<number | null>(initialNextOffset);
+  const [nextOffset, setNextOffset] = useState<number | null>(
+    initialNextOffset,
+  );
   const loadedOnce = useRef(initialItems.length > 0);
   const topScrollRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
@@ -184,6 +187,28 @@ export default function YoutubeList({
     } finally {
       setLoadingMore(false);
       loadingMoreRef.current = false;
+    }
+  };
+
+  const handleRefresh = async () => {
+    if (refreshing || loading) return;
+    setRefreshing(true);
+    preloadedRef.current = null;
+    try {
+      const data: PopularChunkResponse = await fetch(
+        toEndpoint(0, INITIAL_LIMIT),
+        { cache: "no-store" },
+      ).then((r) => r.json());
+      const raw: YoutubeVideo[] = Array.isArray(data.items) ? data.items : [];
+      const freshItems = mergeUniqueByVideoId([], toSortedItems(raw));
+      itemsRef.current = freshItems;
+      setItems(freshItems);
+      setHasMore(Boolean(data.hasMore));
+      setNextOffset(data.nextOffset ?? null);
+    } catch {
+      // 조용히 무시
+    } finally {
+      setRefreshing(false);
     }
   };
 
@@ -320,6 +345,26 @@ export default function YoutubeList({
           </span>
         </div>
         <div className="flex items-center gap-1 shrink-0 sm:gap-2">
+          <button
+            onClick={() => void handleRefresh()}
+            className="flex h-10 w-10 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-500 shadow-sm transition hover:border-red-300 hover:text-red-500 hover:shadow-md disabled:cursor-default disabled:opacity-40"
+            aria-label="새로고침"
+            disabled={loading || refreshing}
+            title="최신 영상으로 새로고침"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              className={`h-4 w-4 ${refreshing ? "animate-spin" : ""}`}
+            >
+              <path
+                fillRule="evenodd"
+                d="M15.312 11.424a5.5 5.5 0 0 1-9.201 2.466l-.312-.311h2.433a.75.75 0 0 0 0-1.5H3.989a.75.75 0 0 0-.75.75v4.242a.75.75 0 0 0 1.5 0v-2.43l.31.31a7 7 0 0 0 11.712-3.138.75.75 0 0 0-1.449-.389Zm1.23-3.723a.75.75 0 0 0 .219-.53V2.929a.75.75 0 0 0-1.5 0V5.36l-.31-.31A7 7 0 0 0 3.239 8.188a.75.75 0 1 0 1.448.389A5.5 5.5 0 0 1 13.89 6.11l.311.31h-2.432a.75.75 0 0 0 0 1.5h4.243a.75.75 0 0 0 .53-.219Z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </button>
           <button
             onClick={() => scroll("left")}
             className="flex h-10 w-10 items-center justify-center rounded-full border border-slate-200 bg-white text-xl text-slate-500 shadow-sm transition hover:border-red-300 hover:text-red-500 hover:shadow-md disabled:cursor-default disabled:opacity-40"

--- a/client/components/youtube/YoutubeSection.tsx
+++ b/client/components/youtube/YoutubeSection.tsx
@@ -1,0 +1,28 @@
+import YoutubeList from "./YoutubeList";
+import type { YoutubeVideo } from "@/types";
+
+const API = process.env.NEST_API_URL ?? "http://localhost:3001";
+
+export default async function YoutubeSection() {
+  const data = await fetch(`${API}/api/streamers/popular?offset=0&limit=8`, {
+    next: { revalidate: 3600 },
+  })
+    .then<{
+      items: YoutubeVideo[];
+      hasMore: boolean;
+      nextOffset: number | null;
+    }>((r) => r.json())
+    .catch(() => ({
+      items: [] as YoutubeVideo[],
+      hasMore: false,
+      nextOffset: null,
+    }));
+
+  return (
+    <YoutubeList
+      initialItems={data.items}
+      initialHasMore={data.hasMore}
+      initialNextOffset={data.nextOffset}
+    />
+  );
+}

--- a/server/src/characters/characters.controller.ts
+++ b/server/src/characters/characters.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Header } from '@nestjs/common';
 import { CharactersService } from './characters.service';
 
 @Controller('api/characters')
@@ -6,6 +6,7 @@ export class CharactersController {
   constructor(private readonly charactersService: CharactersService) {}
 
   @Get('stat-builds')
+  @Header('Cache-Control', 'public, s-maxage=300, stale-while-revalidate=60')
   findStatBuilds() {
     return this.charactersService.findStatBuilds();
   }

--- a/server/src/sites/sites.controller.ts
+++ b/server/src/sites/sites.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Header } from '@nestjs/common';
 import { SitesService } from './sites.service';
 
 @Controller('api/sites')
@@ -6,6 +6,7 @@ export class SitesController {
   constructor(private readonly sitesService: SitesService) {}
 
   @Get()
+  @Header('Cache-Control', 'public, s-maxage=300, stale-while-revalidate=60')
   findAll() {
     return this.sitesService.findAll();
   }

--- a/server/src/streamers/streamers.controller.ts
+++ b/server/src/streamers/streamers.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import { Controller, Get, Header, Query } from '@nestjs/common';
 import { StreamersService } from './streamers.service';
 
 @Controller('api/streamers')
@@ -19,6 +19,7 @@ export class StreamersController {
    * 로스트아크 최근 30일 동영상 조회수순 (Redis 2시간 캐시)
    */
   @Get('popular')
+  @Header('Cache-Control', 'public, s-maxage=3600, stale-while-revalidate=300')
   searchPopular(
     @Query('offset') offsetRaw?: string,
     @Query('limit') limitRaw?: string,


### PR DESCRIPTION
## 목적

- 홈 페이지 TTFB 개선: SSR 매 요청 렌더링 → ISR 캐시 재사용, Vercel 서울 리전 고정으로 API 왕복 지연 단축, YouTube 섹션 초기 렌더 경로 분리

## 변경점

- `page.tsx`: sites `cache: "no-store"` → `next: { revalidate: 300 }` ISR 전환, `preferredRegion = "icn1"` 서울 리전 고정, Promise.all에서 YouTube fetch 제거
- `YoutubeSection.tsx` (신규): YouTube fetch 전담 async 서버 컴포넌트, `<Suspense>` 스켈레톤 fallback으로 초기 렌더 경로에서 분리
- `YoutubeList.tsx`: 새로고침 버튼 추가 — 클릭 시 `cache: "no-store"`로 최신 데이터 재fetch, 로딩 중 스핀 아이콘
- `sites.controller.ts`: `Cache-Control: public, s-maxage=300, stale-while-revalidate=60` 추가
- `characters.controller.ts`: `Cache-Control: public, s-maxage=300, stale-while-revalidate=60` 추가
- `streamers.controller.ts`: `Cache-Control: public, s-maxage=3600, stale-while-revalidate=300` 추가

## 영향범위

- 수정 파일:
  - `client/app/page.tsx`
  - `client/components/youtube/YoutubeSection.tsx`
  - `client/components/youtube/YoutubeList.tsx`
  - `server/src/sites/sites.controller.ts`
  - `server/src/characters/characters.controller.ts`
  - `server/src/streamers/streamers.controller.ts`
- 영향받는 영역: client (홈 렌더링 전략), server (API 캐시 헤더)