### PR TITLE
#33 perf: ISR 캐시 최적화, 서울 리전 고정, 유튜브 조회수 필터 상향

### DIFF
--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -12,11 +12,11 @@ const API = process.env.NEST_API_URL ?? "http://localhost:3001";
 
 export default async function Home() {
   const [sites, statBuilds] = await Promise.all([
-    fetch(`${API}/api/sites`, { next: { revalidate: 300 } })
+    fetch(`${API}/api/sites`, { next: { revalidate: 1000 } })
       .then<Site[]>((r) => r.json())
       .catch(() => [] as Site[]),
     fetch(`${API}/api/characters/stat-builds`, {
-      next: { revalidate: 300 },
+      next: { revalidate: 1000 },
     })
       .then<StatBuildTab[]>((r) => r.json())
       .catch(() => [] as StatBuildTab[]),

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -12,11 +12,11 @@ const API = process.env.NEST_API_URL ?? "http://localhost:3001";
 
 export default async function Home() {
   const [sites, statBuilds] = await Promise.all([
-    fetch(`${API}/api/sites`, { next: { revalidate: 300 } })
+    fetch(`${API}/api/sites`, { next: { revalidate: 86400 } })
       .then<Site[]>((r) => r.json())
       .catch(() => [] as Site[]),
     fetch(`${API}/api/characters/stat-builds`, {
-      next: { revalidate: 300 },
+      next: { revalidate: 86400 },
     })
       .then<StatBuildTab[]>((r) => r.json())
       .catch(() => [] as StatBuildTab[]),

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -12,11 +12,11 @@ const API = process.env.NEST_API_URL ?? "http://localhost:3001";
 
 export default async function Home() {
   const [sites, statBuilds] = await Promise.all([
-    fetch(`${API}/api/sites`, { next: { revalidate: 1000 } })
+    fetch(`${API}/api/sites`, { next: { revalidate: 300 } })
       .then<Site[]>((r) => r.json())
       .catch(() => [] as Site[]),
     fetch(`${API}/api/characters/stat-builds`, {
-      next: { revalidate: 1000 },
+      next: { revalidate: 300 },
     })
       .then<StatBuildTab[]>((r) => r.json())
       .catch(() => [] as StatBuildTab[]),

--- a/client/components/youtube/YoutubeList.test.tsx
+++ b/client/components/youtube/YoutubeList.test.tsx
@@ -72,8 +72,10 @@ describe("YoutubeList", () => {
     await waitFor(() => {
       const prevBtn = screen.getByRole("button", { name: "이전" });
       const nextBtn = screen.getByRole("button", { name: "다음" });
+      const refreshBtn = screen.getByRole("button", { name: "새로고침" });
       expect(prevBtn).toBeDisabled();
       expect(nextBtn).toBeDisabled();
+      expect(refreshBtn).toBeDisabled();
     });
   });
 

--- a/server/src/characters/characters.controller.ts
+++ b/server/src/characters/characters.controller.ts
@@ -6,7 +6,7 @@ export class CharactersController {
   constructor(private readonly charactersService: CharactersService) {}
 
   @Get('stat-builds')
-  @Header('Cache-Control', 'public, s-maxage=300, stale-while-revalidate=60')
+  @Header('Cache-Control', 'public, s-maxage=86400, stale-while-revalidate=3600')
   findStatBuilds() {
     return this.charactersService.findStatBuilds();
   }

--- a/server/src/characters/characters.controller.ts
+++ b/server/src/characters/characters.controller.ts
@@ -6,7 +6,7 @@ export class CharactersController {
   constructor(private readonly charactersService: CharactersService) {}
 
   @Get('stat-builds')
-  @Header('Cache-Control', 'public, s-maxage=300, stale-while-revalidate=60')
+  @Header('Cache-Control', 'public, s-maxage=1000, stale-while-revalidate=60')
   findStatBuilds() {
     return this.charactersService.findStatBuilds();
   }

--- a/server/src/characters/characters.controller.ts
+++ b/server/src/characters/characters.controller.ts
@@ -6,7 +6,7 @@ export class CharactersController {
   constructor(private readonly charactersService: CharactersService) {}
 
   @Get('stat-builds')
-  @Header('Cache-Control', 'public, s-maxage=1000, stale-while-revalidate=60')
+  @Header('Cache-Control', 'public, s-maxage=300, stale-while-revalidate=60')
   findStatBuilds() {
     return this.charactersService.findStatBuilds();
   }

--- a/server/src/characters/characters.controller.ts
+++ b/server/src/characters/characters.controller.ts
@@ -6,7 +6,10 @@ export class CharactersController {
   constructor(private readonly charactersService: CharactersService) {}
 
   @Get('stat-builds')
-  @Header('Cache-Control', 'public, s-maxage=86400, stale-while-revalidate=3600')
+  @Header(
+    'Cache-Control',
+    'public, s-maxage=86400, stale-while-revalidate=3600',
+  )
   findStatBuilds() {
     return this.charactersService.findStatBuilds();
   }

--- a/server/src/sites/sites.controller.ts
+++ b/server/src/sites/sites.controller.ts
@@ -6,7 +6,7 @@ export class SitesController {
   constructor(private readonly sitesService: SitesService) {}
 
   @Get()
-  @Header('Cache-Control', 'public, s-maxage=300, stale-while-revalidate=60')
+  @Header('Cache-Control', 'public, s-maxage=1000, stale-while-revalidate=60')
   findAll() {
     return this.sitesService.findAll();
   }

--- a/server/src/sites/sites.controller.ts
+++ b/server/src/sites/sites.controller.ts
@@ -6,7 +6,7 @@ export class SitesController {
   constructor(private readonly sitesService: SitesService) {}
 
   @Get()
-  @Header('Cache-Control', 'public, s-maxage=300, stale-while-revalidate=60')
+  @Header('Cache-Control', 'public, s-maxage=86400, stale-while-revalidate=3600')
   findAll() {
     return this.sitesService.findAll();
   }

--- a/server/src/sites/sites.controller.ts
+++ b/server/src/sites/sites.controller.ts
@@ -6,7 +6,7 @@ export class SitesController {
   constructor(private readonly sitesService: SitesService) {}
 
   @Get()
-  @Header('Cache-Control', 'public, s-maxage=1000, stale-while-revalidate=60')
+  @Header('Cache-Control', 'public, s-maxage=300, stale-while-revalidate=60')
   findAll() {
     return this.sitesService.findAll();
   }

--- a/server/src/sites/sites.controller.ts
+++ b/server/src/sites/sites.controller.ts
@@ -6,7 +6,10 @@ export class SitesController {
   constructor(private readonly sitesService: SitesService) {}
 
   @Get()
-  @Header('Cache-Control', 'public, s-maxage=86400, stale-while-revalidate=3600')
+  @Header(
+    'Cache-Control',
+    'public, s-maxage=86400, stale-while-revalidate=3600',
+  )
   findAll() {
     return this.sitesService.findAll();
   }

--- a/server/src/streamers/streamers.service.spec.ts
+++ b/server/src/streamers/streamers.service.spec.ts
@@ -69,7 +69,7 @@ describe('StreamersService', () => {
           thumbnailUrl: 'https://example.com/thumb.jpg',
           publishedAt: '2026-04-28T00:00:00Z',
           duration: '10:00',
-          viewCount: 999,
+          viewCount: 1500,
         },
       ],
       nextPageToken: null,

--- a/server/src/streamers/streamers.service.ts
+++ b/server/src/streamers/streamers.service.ts
@@ -557,7 +557,7 @@ export class StreamersService implements OnModuleInit {
         const minSec = 300; // 5분 이상 (숏츠 제외)
         if (sec < minSec) return false;
         if (sec >= 3600) return false; // 1시간 이상 제외
-        if (parseInt(v.statistics?.viewCount ?? '0', 10) < 500) return false; // 조회수 500 미만 제외
+        if (parseInt(v.statistics?.viewCount ?? '0', 10) < 1000) return false; // 조회수 1000 미만 제외
         // 로스트아크 무관 키워드가 제목/채널에 포함된 영상 제외
         const text =
           `${v.snippet?.title ?? ''} ${v.snippet?.channelTitle ?? ''}`.toLowerCase();


### PR DESCRIPTION
## 목적

- 홈 페이지 TTFB 개선: ISR 캐시 주기 최적화, Vercel 서울 리전 고정, 유튜브 조회수 기준 상향

## 변경점

- `page.tsx`: ISR revalidate 86400초(24h), `preferredRegion = "icn1"` 서울 리전 고정
- `sites.controller.ts`: `Cache-Control: public, s-maxage=86400, stale-while-revalidate=3600`
- `characters.controller.ts`: `Cache-Control: public, s-maxage=86400, stale-while-revalidate=3600`
- `streamers.service.ts`: 유튜브 조회수 필터 500 → 1000 상향
- `YoutubeList.test.tsx`: 새로고침 버튼 비활성화 검증 추가
- `streamers.service.spec.ts`: viewCount 테스트 데이터 999 → 1500 (필터 기준 반영)

## 영향범위

- 수정 파일:
  - `client/app/page.tsx`
  - `client/components/youtube/YoutubeList.test.tsx`
  - `server/src/sites/sites.controller.ts`
  - `server/src/characters/characters.controller.ts`
  - `server/src/streamers/streamers.service.ts`
  - `server/src/streamers/streamers.service.spec.ts`
- 영향받는 영역: client (홈 캐시 전략), server (API 캐시 헤더, 영상 필터)