### PR TITLE
chore(ci): EC2 자동 배포 활성화 (GitHub Secrets)

### DIFF
--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -32,9 +32,15 @@ jobs:
         working-directory: server
         run: npm run build
 
-      - name: Deploy trigger (placeholder)
+      - name: Deploy to EC2
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
         run: |
-          echo "배포 트리거 단계를 여기에 연결하세요. 예: SSH, webhook, cloud deploy action"
+          mkdir -p ~/.ssh
+          echo "$SSH_PRIVATE_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no ubuntu@3.39.239.9 "cd /home/ubuntu/daloa && git pull && cd server && npm run build && cd .. && docker compose up -d --build nest"
+          rm ~/.ssh/deploy_key
 
       - name: Health check (optional)
         env:


### PR DESCRIPTION
## 목적
- main 머지 후 GitHub Actions에서 자동으로 EC2 서버에 배포

## 변경점
- main-post-merge.yml Deploy trigger를 실제 SSH 배포 명령으로 교체
- SSH 키는 GitHub Secrets SSH_PRIVATE_KEY에서 안전하게 로드
- EC2에서: git pull → server build → docker compose up nest 자동 실행

## 테스트 결과
- [x] GitHub Actions SSH 연결 테스트 필요 (머지 후 확인)