### PR TITLE
#fix: main post-merge 배포를 SSM으로 전환

### DIFF
--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   prepare-and-check:
     runs-on: ubuntu-latest
@@ -32,15 +36,37 @@ jobs:
         working-directory: server
         run: npm run build
 
-      - name: Deploy to EC2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Deploy to EC2 via SSM
         env:
-          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          EC2_INSTANCE_ID: ${{ secrets.EC2_INSTANCE_ID }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
         run: |
-          mkdir -p ~/.ssh
-          echo "$SSH_PRIVATE_KEY" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no ubuntu@3.39.239.9 "cd /home/ubuntu/daloa && git pull && cd server && npm run build && cd .. && docker compose up -d --build nest"
-          rm ~/.ssh/deploy_key
+          command_id=$(aws ssm send-command \
+            --region "$AWS_REGION" \
+            --document-name "AWS-RunShellScript" \
+            --instance-ids "$EC2_INSTANCE_ID" \
+            --comment "main-post-merge auto deploy" \
+            --parameters 'commands=["set -e","cd /home/ubuntu/daloa","git pull origin main","cd server && npm run build","cd ..","docker compose up -d --build nest"]' \
+            --query 'Command.CommandId' \
+            --output text)
+
+          aws ssm wait command-executed \
+            --region "$AWS_REGION" \
+            --command-id "$command_id" \
+            --instance-id "$EC2_INSTANCE_ID"
+
+          aws ssm get-command-invocation \
+            --region "$AWS_REGION" \
+            --command-id "$command_id" \
+            --instance-id "$EC2_INSTANCE_ID" \
+            --query '{Status:Status,StdOut:StandardOutputContent,StdErr:StandardErrorContent}' \
+            --output json
 
       - name: Health check (optional)
         env:


### PR DESCRIPTION
목적
- main 머지 후 자동 배포를 SSH 방식에서 AWS SSM 방식으로 전환해 키 기반 접속 의존도를 제거하고 배포 안정성을 높입니다.

변경점
- main post-merge 워크플로우에 OIDC 권한 설정(contents: read, id-token: write) 추가
- AWS 자격 구성 단계 추가(AWS_ROLE_TO_ASSUME, AWS_REGION 사용)
- 배포 단계를 SSH 실행에서 SSM SendCommand 기반으로 교체
- 배포 결과 대기 및 실행 결과 조회 단계 추가(command-executed wait, get-command-invocation)
- 기존 SSH_PRIVATE_KEY 기반 배포 로직 제거

영향범위
- 수정 파일 목록
  - .github/workflows/main-post-merge.yml
- 영향받는 영역
  - GitHub Actions main 후속 배포 파이프라인
  - EC2 배포 실행 경로(SSH -> SSM)