### PR TITLE
#fix: SSM 배포 실패 처리 보강 (ubuntu 실행 + stderr 출력)

### DIFF
--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -52,14 +52,17 @@ jobs:
             --document-name "AWS-RunShellScript" \
             --instance-ids "$EC2_INSTANCE_ID" \
             --comment "main-post-merge auto deploy" \
-            --parameters 'commands=["set -e","cd /home/ubuntu/daloa","git pull origin main","cd server && npm run build","cd ..","docker compose up -d --build nest"]' \
+            --parameters 'commands=["set -e","sudo -u ubuntu -H bash -lc '\''cd /home/ubuntu/daloa && git pull origin main && cd server && npm run build && cd .. && docker compose up -d --build nest'\''"]' \
             --query 'Command.CommandId' \
             --output text)
 
+          set +e
           aws ssm wait command-executed \
             --region "$AWS_REGION" \
             --command-id "$command_id" \
             --instance-id "$EC2_INSTANCE_ID"
+          wait_exit=$?
+          set -e
 
           aws ssm get-command-invocation \
             --region "$AWS_REGION" \
@@ -67,6 +70,10 @@ jobs:
             --instance-id "$EC2_INSTANCE_ID" \
             --query '{Status:Status,StdOut:StandardOutputContent,StdErr:StandardErrorContent}' \
             --output json
+
+          if [ "$wait_exit" -ne 0 ]; then
+            exit "$wait_exit"
+          fi
 
       - name: Health check (optional)
         env:


### PR DESCRIPTION
##목적

- SSM 배포 단계가 Failed로 끝날 때 원인 파악이 어려운 문제를 해결하고, 원격 실행 사용자 권한 이슈 가능성을 줄입니다.

##변경점

- SSM 실행 명령을 ubuntu 사용자 컨텍스트로 실행하도록 변경
- wait 실패 시에도 get-command-invocation 결과를 먼저 출력하도록 변경
- wait 종료 코드를 보존해서 최종 실패 상태는 그대로 반환

##영향범위

#수정 파일 목록
-  [main-post-merge.yml](vscode-file://vscode-app/c:/Users/tjdtn/AppData/Local/Programs/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

#영향받는 영역
- main 후속 배포 워크플로우의 SSM 실행 안정성 및 장애 가시성