### PR TITLE
hotfix: preferredRegion 제거 (Vercel Hobby 플랜 미지원)

### DIFF
--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -4,9 +4,6 @@ import SiteList from "@/components/sites/SiteList";
 import YoutubeSection from "@/components/youtube/YoutubeSection";
 import type { Site, StatBuildTab } from "@/types";
 
-// Vercel 함수 리전: 서울(icn1) 고정 — API(EC2 한국)와 왕복 지연 최소화
-export const preferredRegion = "icn1";
-
 // ISR: NestJS 서버에서 데이터를 fetch (revalidate 주기마다 백그라운드 갱신)
 const API = process.env.NEST_API_URL ?? "http://localhost:3001";
 


### PR DESCRIPTION
## 목적

- Vercel Hobby 플랜은 preferredRegion을 지원하지 않아 홈 페이지 렌더링 실패 긴급 수정

## 변경점

- `page.tsx`: `export const preferredRegion = "icn1"` 제거

## 영향범위

- 수정 파일:
  - `client/app/page.tsx`
- 영향받는 영역: client (홈 페이지 렌더링)