### PR TITLE
feat: admin 유튜브 스냅샷 수동 저장 버튼 추가

### DIFF
--- a/client/app/admin/youtube/page.tsx
+++ b/client/app/admin/youtube/page.tsx
@@ -184,6 +184,32 @@ export default function AdminYoutubePage() {
     setTimeout(() => setPurgeResult("idle"), 3000);
   }
 
+  const [snapshotting, setSnapshotting] = useState(false);
+  const [snapshotResult, setSnapshotResult] = useState<
+    "idle" | "done" | "empty" | "error"
+  >("idle");
+
+  async function handleSnapshot() {
+    setSnapshotting(true);
+    setSnapshotResult("idle");
+    try {
+      const res = await fetch("/api/admin/cache/snapshot-youtube", {
+        method: "POST",
+      });
+      if (!res.ok) {
+        setSnapshotResult("error");
+        return;
+      }
+      const data = (await res.json()) as { saved: number; cached: boolean };
+      setSnapshotResult(data.cached && data.saved > 0 ? "done" : "empty");
+    } catch {
+      setSnapshotResult("error");
+    } finally {
+      setSnapshotting(false);
+      setTimeout(() => setSnapshotResult("idle"), 3000);
+    }
+  }
+
   // 정렬된 목록
   const filtered = useMemo(() => {
     const arr = [...items];
@@ -255,6 +281,23 @@ export default function AdminYoutubePage() {
           {purgeResult === "error" && (
             <span className="text-xs text-red-400">✗ 오류</span>
           )}
+          {snapshotResult === "done" && (
+            <span className="text-xs text-green-400">✓ 스냅샷 저장 완료</span>
+          )}
+          {snapshotResult === "empty" && (
+            <span className="text-xs text-yellow-400">⚠ 캐시 없음</span>
+          )}
+          {snapshotResult === "error" && (
+            <span className="text-xs text-red-400">✗ 스냅샷 오류</span>
+          )}
+          <button
+            onClick={handleSnapshot}
+            disabled={snapshotting}
+            className="text-sm bg-indigo-700 hover:bg-indigo-600 disabled:opacity-50 text-white px-3 py-1.5 rounded transition-colors"
+            title="현재 Redis 캐시의 인기 영상 조회수를 DB에 즉시 스냅샷 저장 (UPSERT)"
+          >
+            {snapshotting ? "저장 중..." : "스냅샷 저장"}
+          </button>
           <button
             onClick={handlePurge}
             disabled={purging}

--- a/client/app/api/admin/cache/snapshot-youtube/route.ts
+++ b/client/app/api/admin/cache/snapshot-youtube/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+const NEST_API = process.env.NEST_API_URL ?? "http://localhost:3001";
+
+async function getToken(): Promise<string> {
+  const store = await cookies();
+  return store.get("admin_token")?.value ?? "";
+}
+
+export async function POST() {
+  const token = await getToken();
+  const res = await fetch(`${NEST_API}/api/admin/cache/snapshot-youtube`, {
+    method: "POST",
+    headers: { "x-admin-session": token },
+  });
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/server/src/admin/admin-cache.controller.ts
+++ b/server/src/admin/admin-cache.controller.ts
@@ -9,6 +9,7 @@ import {
 import type { Redis } from 'ioredis';
 import { REDIS_CLIENT } from '../redis/redis.module';
 import { AdminWriteGuard } from './admin.guard';
+import { StreamersService } from '../streamers/streamers.service';
 
 const CACHE_KEYS: Record<string, string> = {
   sites: 'sites:all',
@@ -19,7 +20,10 @@ const CACHE_KEYS: Record<string, string> = {
 @Controller('api/admin/cache')
 @UseGuards(AdminWriteGuard)
 export class AdminCacheController {
-  constructor(@Inject(REDIS_CLIENT) private readonly redis: Redis) {}
+  constructor(
+    @Inject(REDIS_CLIENT) private readonly redis: Redis,
+    private readonly streamersService: StreamersService,
+  ) {}
 
   @Post('purge')
   async purge(@Body() body: { key?: string }) {
@@ -45,5 +49,16 @@ export class AdminCacheController {
       deleted: results.reduce((a, b) => a + b, 0),
       keys,
     };
+  }
+
+  /**
+   * POST /api/admin/cache/snapshot-youtube
+   * Redis youtube:popular:first 캐시를 읽어 즉시 DB에 조회수 스냅샷 저장.
+   * 같은 날 재실행 시 view_count만 갱신 (UPSERT).
+   */
+  @Post('snapshot-youtube')
+  async snapshotYoutube() {
+    const result = await this.streamersService.snapshotFromCache();
+    return { ok: true, ...result };
   }
 }

--- a/server/src/admin/admin.module.ts
+++ b/server/src/admin/admin.module.ts
@@ -5,9 +5,10 @@ import { AdminSitesController } from './admin-sites.controller';
 import { AdminCacheController } from './admin-cache.controller';
 import { AdminCharactersController } from './admin-characters.controller';
 import { AdminGuard, AdminWriteGuard } from './admin.guard';
+import { StreamersModule } from '../streamers/streamers.module';
 
 @Module({
-  imports: [],
+  imports: [StreamersModule],
   controllers: [
     AdminAuthController,
     AdminSitesController,

--- a/server/src/streamers/streamers.module.ts
+++ b/server/src/streamers/streamers.module.ts
@@ -8,5 +8,6 @@ import { RedisModule } from '../redis/redis.module';
   imports: [DbModule, RedisModule],
   controllers: [StreamersController],
   providers: [StreamersService],
+  exports: [StreamersService],
 })
 export class StreamersModule {}

--- a/server/src/streamers/streamers.service.ts
+++ b/server/src/streamers/streamers.service.ts
@@ -282,6 +282,22 @@ export class StreamersService implements OnModuleInit {
     }
   }
 
+  /**
+   * Redis 인기 영상 캐시를 읽어 즉시 스냅샷 저장.
+   * LOCAL_DISABLE_QUOTA_APIS=true 환경에서 수동으로 스냅샷 데이터 생성용.
+   */
+  async snapshotFromCache(): Promise<{ saved: number; cached: boolean }> {
+    const cached = await this.youtubeRedis.get(POPULAR_CACHE_KEY);
+    if (!cached) {
+      this.logger.warn('YouTube 스냅샷 수동 저장: Redis 캐시 없음');
+      return { saved: 0, cached: false };
+    }
+    const parsed = JSON.parse(cached) as { items: YoutubeVideoItem[] };
+    const items = parsed.items ?? [];
+    await this.snapshotViewCounts(items);
+    return { saved: items.length, cached: true };
+  }
+
   /** 현재 인기 영상의 조회수를 오늘 날짜로 DB에 저장 (UPSERT) */
   async snapshotViewCounts(items: YoutubeVideoItem[]): Promise<void> {
     if (items.length === 0) return;


### PR DESCRIPTION
## 목적
LOCAL_DISABLE_QUOTA_APIS=true 환경(로컬)에서도 유튜브 조회수 스냅샷 데이터를 DB에 쌓을 수 있도록 수동 스냅샷 저장 기능 추가.

## 변경점
- `StreamersService.snapshotFromCache()` 신규 — Redis `youtube:popular:first` 캐시를 읽어 즉시 `snapshotViewCounts()` 호출 (UPSERT)
- `POST /api/admin/cache/snapshot-youtube` 엔드포인트 추가 (AdminWriteGuard 적용)
- admin 유튜브 탭에 "스냅샷 저장" 버튼 + 결과 상태 표시 (완료/캐시 없음/오류)
- StreamersModule이 StreamersService를 export, AdminModule이 StreamersModule을 import
- 클라이언트 Next.js route handler 추가 (`/api/admin/cache/snapshot-youtube`)
- 중복 처리: UNIQUE KEY `(video_id, recorded_date)` 기준 `ON DUPLICATE KEY UPDATE view_count` — 같은 날 여러 번 눌러도 view_count만 갱신

## 영향범위
**수정 파일 목록**
- `server/src/streamers/streamers.service.ts`
- `server/src/streamers/streamers.module.ts`
- `server/src/admin/admin.module.ts`
- `server/src/admin/admin-cache.controller.ts`
- `client/app/admin/youtube/page.tsx`
- `client/app/api/admin/cache/snapshot-youtube/route.ts` (신규)

**영향받는 영역**: admin 유튜브 탭, streamers/admin 모듈 연결, DB `youtube_view_snapshots`