### PR TITLE
fix: correct admin_users role ENUM and guard onModuleInit crash

### DIFF
--- a/scripts/migrate-admin-role.sql
+++ b/scripts/migrate-admin-role.sql
@@ -1,0 +1,15 @@
+-- admin_users.role ENUM 불일치 수정
+-- 기존: ENUM('owner','demo')  →  변경: ENUM('master','guest')
+-- 실행: db-migrate.yml 워크플로우로 실행
+
+-- Step 1: ENUM → VARCHAR (자유롭게 UPDATE 가능하도록)
+ALTER TABLE admin_users
+  MODIFY COLUMN role VARCHAR(20) NOT NULL DEFAULT 'guest';
+
+-- Step 2: 구 값 → 신 값 매핑
+UPDATE admin_users SET role = 'master' WHERE role = 'owner';
+UPDATE admin_users SET role = 'guest'  WHERE role = 'demo';
+
+-- Step 3: 올바른 ENUM으로 변경
+ALTER TABLE admin_users
+  MODIFY COLUMN role ENUM('master','guest') NOT NULL DEFAULT 'guest';

--- a/server/src/admin/admin-auth.service.ts
+++ b/server/src/admin/admin-auth.service.ts
@@ -44,7 +44,13 @@ export class AdminAuthService implements OnModuleInit {
 
   async onModuleInit() {
     await this.ensureTable();
-    await this.seedAccounts();
+    try {
+      await this.seedAccounts();
+    } catch (err: unknown) {
+      this.logger.error(
+        `관리자 계정 시딩 실패 (서버는 정상 기동): ${String(err)}`,
+      );
+    }
   }
 
   private async ensureTable() {
@@ -53,7 +59,7 @@ export class AdminAuthService implements OnModuleInit {
         id            INT AUTO_INCREMENT PRIMARY KEY,
         username      VARCHAR(50)  NOT NULL UNIQUE,
         password_hash VARCHAR(255) NOT NULL,
-        role          ENUM('owner','demo') NOT NULL DEFAULT 'demo',
+        role          ENUM('master','guest') NOT NULL DEFAULT 'guest',
         created_at    TIMESTAMP DEFAULT CURRENT_TIMESTAMP
       ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci
     `);


### PR DESCRIPTION
## 목적\ndmin_users.role 컬럼 ENUM 불일치로 NestJS가 크래시하는 버그 수정.\n\n## 변경점\n- dmin-auth.service.ts: ensureTable()의 ENUM을 ('owner','demo') → ('master','guest')로 수정\n- dmin-auth.service.ts: onModuleInit()에 try/catch 추가 — 시딩 실패 시 앱 크래시 방지\n- scripts/migrate-admin-role.sql 추가 — 기존 EC2 DB ENUM 수정용\n\n## 영향범위\n- 수정 파일 목록: server/src/admin/admin-auth.service.ts, scripts/migrate-admin-role.sql\n- 영향받는 영역: NestJS 부팅 안정성, EC2 서버 복구