### PR TITLE
feat: NestJS 재기동 시 Vercel ISR 캐시 자동 무효화

### DIFF
--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -46,13 +46,25 @@ jobs:
         env:
           EC2_INSTANCE_ID: ${{ secrets.EC2_INSTANCE_ID }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
+          NEXT_REVALIDATE_SECRET: ${{ secrets.NEXT_REVALIDATE_SECRET }}
         run: |
+          remote_script="set -e
+          cd /home/ubuntu/daloa
+          git pull origin main
+          grep -q '^NEXT_REVALIDATE_URL=' .env || echo 'NEXT_REVALIDATE_URL=https://www.daloa.kr/api/revalidate' >> .env
+          sed -i '/^NEXT_REVALIDATE_SECRET=/d' .env
+          echo 'NEXT_REVALIDATE_SECRET=${NEXT_REVALIDATE_SECRET}' >> .env
+          cd server && npm run build && cd ..
+          docker compose up -d --build nest"
+
+          encoded=$(printf '%s' "$remote_script" | base64 -w0)
+
           command_id=$(aws ssm send-command \
             --region "$AWS_REGION" \
             --document-name "AWS-RunShellScript" \
             --instance-ids "$EC2_INSTANCE_ID" \
             --comment "main-post-merge auto deploy" \
-            --parameters 'commands=["set -e","sudo -u ubuntu -H bash -lc '\''cd /home/ubuntu/daloa && git pull origin main && cd server && npm run build && cd .. && docker compose up -d --build nest'\''"]' \
+            --parameters "commands=[\"set -e\",\"sudo -u ubuntu -H bash -lc \\\"echo $encoded | base64 -d | bash\\\"\"]" \
             --query 'Command.CommandId' \
             --output text)
 

--- a/client/app/api/revalidate/route.ts
+++ b/client/app/api/revalidate/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
+
+export async function POST(req: NextRequest) {
+  const secret = process.env.REVALIDATE_SECRET;
+  if (!secret) {
+    return NextResponse.json({ error: "Not configured" }, { status: 500 });
+  }
+
+  const authHeader = req.headers.get("authorization");
+  if (authHeader !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  revalidatePath("/");
+  return NextResponse.json({
+    revalidated: true,
+    timestamp: new Date().toISOString(),
+  });
+}

--- a/context/env-config.md
+++ b/context/env-config.md
@@ -31,6 +31,8 @@
 | `GEMINI_API_KEY`           | -                       | **필수** | Google Gemini API 키                        |
 | `KAKAO_REST_API_KEY`       | -                       | **필수** | 카카오 REST API 키                          |
 | `KAKAO_REFRESH_TOKEN`      | -                       | **필수** | 카카오 OAuth 리프레시 토큰                  |
+| `NEXT_REVALIDATE_URL`      | (없음)                  | -        | Vercel ISR 무효화 엔드포인트 URL (`https://www.daloa.kr/api/revalidate`) |
+| `NEXT_REVALIDATE_SECRET`   | (없음)                  | -        | Vercel ISR 무효화 시크릿 (Vercel `REVALIDATE_SECRET`과 동일값) |
 
 ### CORS 설정 주의
 
@@ -43,7 +45,8 @@
 
 | 변수명         | 기본값                  | 필수 | 설명                      |
 | -------------- | ----------------------- | ---- | ------------------------- |
-| `NEST_API_URL` | `http://localhost:3001` | -    | SSR fetch 대상 NestJS URL |
+| `NEST_API_URL`        | `http://localhost:3001` | -        | SSR fetch 대상 NestJS URL |
+| `REVALIDATE_SECRET`   | (없음)                  | **필수** | ISR 캐시 무효화 인증 시크릿 (NestJS `NEXT_REVALIDATE_SECRET`과 동일값) |
 
 > Next.js에서 서버 전용 변수는 `NEXT_PUBLIC_` 접두사 없이 사용.  
 > 브라우저에서 NestJS를 직접 호출하는 코드 없음.

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -11,6 +11,7 @@ import { StreamersModule } from './streamers/streamers.module';
 import { UsersModule } from './users/users.module';
 import { ClassSummaryModule } from './class-summary/class-summary.module';
 import { AdminModule } from './admin/admin.module';
+import { RevalidateService } from './revalidate/revalidate.service';
 
 @Module({
   imports: [
@@ -27,5 +28,6 @@ import { AdminModule } from './admin/admin.module';
     ClassSummaryModule,
     AdminModule,
   ],
+  providers: [RevalidateService],
 })
 export class AppModule {}

--- a/server/src/revalidate/revalidate.service.spec.ts
+++ b/server/src/revalidate/revalidate.service.spec.ts
@@ -1,0 +1,73 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RevalidateService } from './revalidate.service';
+
+describe('RevalidateService', () => {
+  let service: RevalidateService;
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [RevalidateService],
+    }).compile();
+
+    service = module.get<RevalidateService>(RevalidateService);
+  });
+
+  afterEach(() => {
+    fetchSpy?.mockRestore();
+    delete process.env.NEXT_REVALIDATE_URL;
+    delete process.env.NEXT_REVALIDATE_SECRET;
+  });
+
+  it('환경변수 미설정 시 fetch를 호출하지 않는다', async () => {
+    fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+    } as Response);
+
+    await service.onApplicationBootstrap();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('환경변수 설정 시 올바른 URL과 Authorization 헤더로 POST 요청한다', async () => {
+    process.env.NEXT_REVALIDATE_URL = 'https://www.daloa.kr/api/revalidate';
+    process.env.NEXT_REVALIDATE_SECRET = 'test-secret';
+
+    fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+    } as Response);
+
+    await service.onApplicationBootstrap();
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://www.daloa.kr/api/revalidate',
+      {
+        method: 'POST',
+        headers: { Authorization: 'Bearer test-secret' },
+      },
+    );
+  });
+
+  it('서버가 비성공 응답을 반환해도 예외를 던지지 않는다', async () => {
+    process.env.NEXT_REVALIDATE_URL = 'https://www.daloa.kr/api/revalidate';
+    process.env.NEXT_REVALIDATE_SECRET = 'test-secret';
+
+    fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 401,
+    } as Response);
+
+    await expect(service.onApplicationBootstrap()).resolves.not.toThrow();
+  });
+
+  it('네트워크 오류가 발생해도 예외를 던지지 않는다', async () => {
+    process.env.NEXT_REVALIDATE_URL = 'https://www.daloa.kr/api/revalidate';
+    process.env.NEXT_REVALIDATE_SECRET = 'test-secret';
+
+    fetchSpy = jest
+      .spyOn(global, 'fetch')
+      .mockRejectedValue(new Error('Network error'));
+
+    await expect(service.onApplicationBootstrap()).resolves.not.toThrow();
+  });
+});

--- a/server/src/revalidate/revalidate.service.ts
+++ b/server/src/revalidate/revalidate.service.ts
@@ -1,0 +1,33 @@
+import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
+
+@Injectable()
+export class RevalidateService implements OnApplicationBootstrap {
+  private readonly logger = new Logger(RevalidateService.name);
+
+  async onApplicationBootstrap(): Promise<void> {
+    const url = process.env.NEXT_REVALIDATE_URL;
+    const secret = process.env.NEXT_REVALIDATE_SECRET;
+
+    if (!url || !secret) {
+      this.logger.warn(
+        'NEXT_REVALIDATE_URL 또는 NEXT_REVALIDATE_SECRET 미설정 — Vercel ISR 캐시 무효화 건너뜀',
+      );
+      return;
+    }
+
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${secret}` },
+      });
+
+      if (res.ok) {
+        this.logger.log('Vercel ISR 캐시 무효화 성공');
+      } else {
+        this.logger.warn(`Vercel ISR 캐시 무효화 실패: HTTP ${res.status}`);
+      }
+    } catch (err: unknown) {
+      this.logger.warn(`Vercel ISR 캐시 무효화 오류: ${String(err)}`);
+    }
+  }
+}


### PR DESCRIPTION
## 목적
NestJS가 재시작될 때 Vercel ISR 캐시(사이트 모음·특성빌드)가 빈 배열로 24시간 고착되는 문제를 해결.
서버 재기동 시 자동으로 Vercel revalidation API를 호출하여 즉시 최신 데이터를 렌더링하도록 함.

## 변경점
- \client/app/api/revalidate/route.ts\: POST 핸들러 추가 — \Authorization: Bearer\ 시크릿 검증 후 \evalidatePath('/')\ 실행
- \server/src/revalidate/revalidate.service.ts\: \OnApplicationBootstrap\ 구현 — NestJS 부팅 완료 시 Vercel revalidate 엔드포인트 호출 (실패해도 서버 기동 중단 없음)
- \server/src/revalidate/revalidate.service.spec.ts\: 단위 테스트 4개 (환경변수 미설정/정상/비성공응답/네트워크오류)
- \server/src/app.module.ts\: \RevalidateService\ providers 등록
- \.github/workflows/main-post-merge.yml\: EC2 \.env\에 \NEXT_REVALIDATE_URL\ / \NEXT_REVALIDATE_SECRET\ 자동 주입 (배포 시 항상 최신값 유지)

## 영향범위
- 수정 파일: \client/app/api/revalidate/route.ts\, \server/src/revalidate/revalidate.service.ts\, \server/src/revalidate/revalidate.service.spec.ts\, \server/src/app.module.ts\, \.github/workflows/main-post-merge.yml\
- 영향 영역: Vercel ISR 캐시 갱신 흐름, NestJS 부팅 라이프사이클, EC2 배포 워크플로우

> **Vercel 환경변수 설정 필요**: Vercel 대시보드 → Environment Variables → \REVALIDATE_SECRET=daloa-live-secret\ 추가 후 Redeploy