### PR TITLE
fix: 어드민 로그인 사이드바 제거 및 게스트 리다이렉트 수정

### DIFF
--- a/client/app/admin/layout.tsx
+++ b/client/app/admin/layout.tsx
@@ -22,6 +22,10 @@ export default function AdminLayout({
     router.push("/admin/login");
   }
 
+  if (pathname === "/admin/login") {
+    return <>{children}</>;
+  }
+
   return (
     <div className="h-screen bg-gray-950 text-gray-100 flex overflow-hidden">
       {/* Sidebar */}

--- a/client/app/admin/login/page.tsx
+++ b/client/app/admin/login/page.tsx
@@ -1,10 +1,8 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
 
 export default function AdminLoginPage() {
-  const router = useRouter();
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
@@ -24,8 +22,7 @@ export default function AdminLoginPage() {
         setError(data.message ?? "로그인 실패");
         return;
       }
-      router.push("/admin/sites");
-      router.refresh();
+      window.location.href = "/admin/sites";
     } catch {
       setError("네트워크 오류가 발생했습니다");
     } finally {


### PR DESCRIPTION
## 목적
어드민 로그인 페이지에서 사이드바가 노출되어 발생하는 게스트 로그인 무반응 버그 수정

## 변경점
- `admin/layout.tsx`: `/admin/login` 경로에서는 사이드바 없이 `children`만 렌더링
- `admin/login/page.tsx`: 로그인 성공 후 `router.push` + `router.refresh()` 조합을 `window.location.href`로 교체 (미들웨어 redirect 후 라우터 상태 충돌 제거)

## 영향범위
**수정 파일 목록**
- `client/app/admin/layout.tsx`
- `client/app/admin/login/page.tsx`

**영향받는 영역**
- 어드민 로그인 페이지 UI (사이드바 미노출)
- 로그인 후 `/admin/sites` 리다이렉트 동작