### PR TITLE
fix(db): youtube published_at DATE -> DATETIME

### DIFF
--- a/scripts/init-db.sql
+++ b/scripts/init-db.sql
@@ -96,7 +96,7 @@ CREATE TABLE IF NOT EXISTS `youtube_view_snapshots` (
   `title`         VARCHAR(500)        NOT NULL DEFAULT '',
   `channel_title` VARCHAR(255)        NOT NULL DEFAULT '',
   `thumbnail_url` VARCHAR(500)        NOT NULL DEFAULT '',
-  `published_at`  DATE                NOT NULL,
+  `published_at`  DATETIME            NOT NULL,
   `duration`      VARCHAR(20)         NOT NULL DEFAULT '',
   `view_count`    INT UNSIGNED        NOT NULL DEFAULT 0,
   `recorded_date` DATE                NOT NULL,

--- a/scripts/migrate-youtube-published-at.sql
+++ b/scripts/migrate-youtube-published-at.sql
@@ -1,0 +1,6 @@
+-- youtube_view_snapshots.published_at: DATE → DATETIME
+-- 기존 DATE 값은 '2024-01-15' → '2024-01-15 00:00:00' 으로 자동 변환됨
+-- 실행: mysql -u [user] -p [dbname] --default-character-set=utf8mb4 < migrate-youtube-published-at.sql
+
+ALTER TABLE youtube_view_snapshots
+  MODIFY COLUMN `published_at` DATETIME NOT NULL;

--- a/server/src/streamers/streamers.service.ts
+++ b/server/src/streamers/streamers.service.ts
@@ -308,7 +308,7 @@ export class StreamersService implements OnModuleInit {
         v.title,
         v.channelTitle,
         v.thumbnailUrl,
-        v.publishedAt.slice(0, 10), // DATE 형식 (YYYY-MM-DD)
+        v.publishedAt.slice(0, 19).replace('T', ' '), // DATETIME 형식 (YYYY-MM-DD HH:MM:SS)
         v.duration,
         v.viewCount,
         today,


### PR DESCRIPTION
## 목적
YouTube API의 `publishedAt` 필드는 시간 정보를 포함하므로 DB 컬럼 타입을 `DATE`에서 `DATETIME`으로 변경. 동일 날짜 업로드 영상의 시간 단위 정렬 가능.

## 변경점
- `scripts/init-db.sql`: `published_at DATE` → `DATETIME`
- `server/src/streamers/streamers.service.ts`: `.slice(0, 10)` → `.slice(0, 19).replace('T', ' ')` (전체 datetime 저장)
- `scripts/migrate-youtube-published-at.sql`: 운영 DB ALTER TABLE 마이그레이션 신규 추가

## 영향범위
### 수정 파일 목록
- `scripts/init-db.sql`
- `server/src/streamers/streamers.service.ts`
- `scripts/migrate-youtube-published-at.sql` (신규)

### 영향받는 영역
- `youtube_view_snapshots` 테이블 `published_at` 컬럼
- YouTube 조회수 스냅샷 저장 로직

> **운영 DB 반영**: PR 머지 후 `gh workflow run db-migrate.yml -f sql_file=scripts/migrate-youtube-published-at.sql` 실행 필요