### PR TITLE
fix(admin): 사이트 CRUD 후 캐시 즉시 무효화

### DIFF
--- a/client/app/api/admin/sites/[id]/route.ts
+++ b/client/app/api/admin/sites/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { cookies } from "next/headers";
+import { revalidatePath } from "next/cache";
 
 const NEST_API = process.env.NEST_API_URL ?? "http://localhost:3001";
 
@@ -24,6 +25,7 @@ export async function PUT(
     body: JSON.stringify(body),
   });
   const data = await res.json();
+  if (res.ok) revalidatePath("/");
   return NextResponse.json(data, { status: res.status });
 }
 
@@ -38,5 +40,6 @@ export async function DELETE(
     headers: { "x-admin-session": token },
   });
   const data = await res.json();
+  if (res.ok) revalidatePath("/");
   return NextResponse.json(data, { status: res.status });
 }

--- a/client/app/api/admin/sites/route.ts
+++ b/client/app/api/admin/sites/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { cookies } from "next/headers";
+import { revalidatePath } from "next/cache";
 
 const NEST_API = process.env.NEST_API_URL ?? "http://localhost:3001";
 

--- a/server/src/admin/admin-sites.controller.ts
+++ b/server/src/admin/admin-sites.controller.ts
@@ -16,6 +16,7 @@ import type { Pool } from 'mysql2/promise';
 import type { RowDataPacket, ResultSetHeader } from 'mysql2';
 import { DB_POOL } from '../db/db.module';
 import { AdminGuard, AdminWriteGuard } from './admin.guard';
+import { SitesService } from '../sites/sites.service';
 
 interface SiteRow extends RowDataPacket {
   seq: number;
@@ -30,7 +31,10 @@ interface SiteRow extends RowDataPacket {
 @Controller('api/admin/sites')
 @UseGuards(AdminGuard)
 export class AdminSitesController {
-  constructor(@Inject(DB_POOL) private readonly pool: Pool) {}
+  constructor(
+    @Inject(DB_POOL) private readonly pool: Pool,
+    private readonly sitesService: SitesService,
+  ) {}
 
   @Get()
   async findAll() {
@@ -65,6 +69,7 @@ export class AdminSitesController {
         body.icon ?? null,
       ],
     );
+    await this.sitesService.invalidateCache();
     return { seq: result.insertId };
   }
 
@@ -124,6 +129,7 @@ export class AdminSitesController {
       `UPDATE loa_sites SET ${fields.join(', ')} WHERE seq = ?`,
       values as (string | number | boolean | null)[],
     );
+    await this.sitesService.invalidateCache();
     return { ok: true };
   }
 
@@ -137,6 +143,7 @@ export class AdminSitesController {
     if (!rows[0]) throw new NotFoundException('사이트를 찾을 수 없습니다');
 
     await this.pool.execute('DELETE FROM loa_sites WHERE seq = ?', [id]);
+    await this.sitesService.invalidateCache();
     return { ok: true };
   }
 }

--- a/server/src/admin/admin.module.ts
+++ b/server/src/admin/admin.module.ts
@@ -6,9 +6,10 @@ import { AdminCacheController } from './admin-cache.controller';
 import { AdminCharactersController } from './admin-characters.controller';
 import { AdminGuard, AdminWriteGuard } from './admin.guard';
 import { StreamersModule } from '../streamers/streamers.module';
+import { SitesModule } from '../sites/sites.module';
 
 @Module({
-  imports: [StreamersModule],
+  imports: [StreamersModule, SitesModule],
   controllers: [
     AdminAuthController,
     AdminSitesController,

--- a/server/src/sites/sites.module.ts
+++ b/server/src/sites/sites.module.ts
@@ -8,5 +8,6 @@ import { KakaoModule } from '../kakao/kakao.module';
   imports: [DbModule, KakaoModule],
   controllers: [SitesController],
   providers: [SitesService],
+  exports: [SitesService],
 })
 export class SitesModule {}

--- a/server/src/sites/sites.service.ts
+++ b/server/src/sites/sites.service.ts
@@ -159,6 +159,12 @@ export class SitesService {
     return rows;
   }
 
+  /** 캐시 수동 무효화 (admin 쓰기 작업 후 호출) */
+  async invalidateCache(): Promise<void> {
+    await this.redis.del(CACHE_KEY);
+    this.logger.debug('sites: 캐시 수동 무효화');
+  }
+
   /**
    * 매일 오전 9시 — 각 사이트 상태·타이틀 점검
    * 변경 감지 시 카카오톡 알림 전송


### PR DESCRIPTION
## 문제

admin에서 사이트 추가/수정/삭제 후 새로고침해도 즉시 반영되지 않음

**원인**: 캐시가 두 겹으로 적용되어 무효화 누락
- NestJS Redis 캐시 (TTL 10분)
- Next.js ISR fetch 캐시 (revalidate 24시간)

## 수정 내용

### 서버 (NestJS)
- \SitesService.invalidateCache()\ 추가
- \AdminSitesController\: create / update / delete 성공 후 \invalidateCache()\ 호출
- \SitesModule\: \exports: [SitesService]\ 추가
- \AdminModule\: \SitesModule\ import 추가

### 클라이언트 (Next.js)
- admin sites API 라우트: 쓰기 성공 시 \evalidatePath('/')\ 호출 → Next.js 페이지 캐시 즉시 무효화

## 결과

admin 사이트 변경 → 새로고침 시 즉시 반영