### PR TITLE
chore(ci): main push 워크플로우 paths 필터 + Vercel Ignored Build Step

### DIFF
--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -3,6 +3,9 @@ name: Main Post Merge
 on:
   push:
     branches: [main]
+    paths:
+      - 'server/**'
+      - 'client/**'
 
 permissions:
   contents: read

--- a/.github/workflows/server-e2e.yml
+++ b/.github/workflows/server-e2e.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
+    paths:
+      - 'server/**'
 
 jobs:
   e2e:

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "ignoreCommand": "git diff HEAD~1 --quiet -- client/"
+}


### PR DESCRIPTION
## 변경 내용

### server-e2e.yml
- \server/**\ 변경 시에만 E2E 실행 (기존: 모든 main push)

### main-post-merge.yml
- \server/**\ 또는 \client/**\ 변경 시에만 빌드/배포 (기존: 모든 main push)

### vercel.json
- \client/**\ 변경 없을 시 Vercel 빌드 스킵 (\ignoreCommand\ 추가)

## 목적
docs, workflow 파일만 변경해도 불필요한 CI/CD가 실행되던 문제 해결