### PR TITLE
fix(ci): vercel.json 위치 수정 및 ignoreCommand 개선

### DIFF
--- a/client/vercel.json
+++ b/client/vercel.json
@@ -1,0 +1,3 @@
+{
+  "ignoreCommand": "git diff --quiet ${VERCEL_GIT_PREVIOUS_SHA:-HEAD~1} HEAD -- client/"
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,0 @@
-{
-  "ignoreCommand": "git diff HEAD~1 --quiet -- client/"
-}


### PR DESCRIPTION
## 문제
- Root Directory가 \client\로 설정돼 있어 루트의 \ercel.json\은 Vercel이 읽지 않음

## 수정
- \ercel.json\ → \client/vercel.json\으로 이동
- \HEAD~1\ → \\\로 변경
  - 여러 커밋이 한 번에 push될 때 중간 변경을 놓치지 않음
  - 미설정 시 HEAD~1으로 폴백