### PR TITLE
fix(ci): vercel ignoreCommand 경로 수정 (client/ to .)

### DIFF
--- a/client/vercel.json
+++ b/client/vercel.json
@@ -1,3 +1,3 @@
 {
-  "ignoreCommand": "git diff --quiet ${VERCEL_GIT_PREVIOUS_SHA:-HEAD~1} HEAD -- client/"
+  "ignoreCommand": "git diff --quiet ${VERCEL_GIT_PREVIOUS_SHA:-HEAD~1} HEAD -- ."
 }


### PR DESCRIPTION
Root Directory가 client이므로 ignoreCommand가 client/ 안에서 실행됨. client/ 경로는 client/client/를 가리켜 항상 exit 0(스킵)로 동작하던 버그 수정. PR #63에서 client/vercel.json 추가에도 Canceled by Ignore가 나온 원인.