### PR TITLE
refactor(admin): rebuild admin UI with CleanPay-inspired design system + fix statBuild pagination

### DIFF
--- a/client/app/admin/cache/page.tsx
+++ b/client/app/admin/cache/page.tsx
@@ -3,9 +3,9 @@
 import { useState } from "react";
 
 const CACHE_KEYS = [
-  { key: "sites", label: "사이트 목록 (sites:all)" },
-  { key: "characters", label: "캐릭터 빌드 (characters:stat-builds)" },
-  { key: "youtube", label: "유튜브 (youtube:popular:first)" },
+  { key: "sites", label: "?�이??목록 (sites:all)" },
+  { key: "characters", label: "캐릭??빌드 (characters:stat-builds)" },
+  { key: "youtube", label: "?�튜�?(youtube:popular:first)" },
 ];
 
 type StatusMap = Record<string, "idle" | "loading" | "done" | "error">;
@@ -32,43 +32,43 @@ export default function AdminCachePage() {
     const res = await fetch("/api/admin/cache", { method: "DELETE" });
     if (res.ok) {
       const d = (await res.json()) as { deleted: number };
-      setAllResult(`완료 — ${d.deleted}개 키 삭제`);
+      setAllResult(`?�료 ??${d.deleted}�?????��`);
     } else {
-      setAllResult("오류 발생");
+      setAllResult("?�류 발생");
     }
     setAllLoading(false);
   }
 
   const statusLabel = (s: string | undefined) => {
-    if (s === "loading") return "처리 중...";
-    if (s === "done") return "✓ 완료";
-    if (s === "error") return "✗ 오류";
+    if (s === "loading") return "처리 �?..";
+    if (s === "done") return "???�료";
+    if (s === "error") return "???�류";
     return "";
   };
 
   return (
     <div>
-      <h1 className="text-xl font-semibold mb-6">Redis 캐시 무효화</h1>
-      <p className="text-sm text-gray-400 mb-8">
-        캐시를 삭제하면 다음 요청 시 DB에서 새로 조회합니다.
+      <h1 className="text-xl font-semibold text-gray-900 mb-6">Redis 캐시 무효화</h1>
+      <p className="text-sm text-gray-500 mb-8">
+        캐시�???��?�면 ?�음 ?�청 ??DB?�서 ?�로 조회?�니??
       </p>
 
       <div className="space-y-3 mb-8">
         {CACHE_KEYS.map(({ key, label }) => (
           <div
             key={key}
-            className="flex items-center justify-between bg-gray-900 border border-gray-800 rounded-lg px-5 py-3"
+            className="flex items-center justify-between bg-white border border-gray-200 rounded-lg px-5 py-3"
           >
-            <span className="text-sm text-gray-200">{label}</span>
+            <span className="text-sm text-gray-700">{label}</span>
             <div className="flex items-center gap-3">
               {status[key] && status[key] !== "idle" && (
                 <span
                   className={`text-xs ${
                     status[key] === "done"
-                      ? "text-green-400"
+                      ? "text-green-600"
                       : status[key] === "error"
-                        ? "text-red-400"
-                        : "text-gray-400"
+                        ? "text-red-500"
+                        : "text-gray-500"
                   }`}
                 >
                   {statusLabel(status[key])}
@@ -77,7 +77,7 @@ export default function AdminCachePage() {
               <button
                 onClick={() => purgeOne(key)}
                 disabled={status[key] === "loading"}
-                className="text-sm bg-red-900/40 hover:bg-red-900/70 disabled:opacity-50 text-red-300 px-4 py-1.5 rounded transition-colors"
+                className="text-sm border border-red-200 bg-red-50 hover:bg-red-100 disabled:opacity-50 text-red-600 px-4 py-1.5 rounded-lg transition-colors"
               >
                 삭제
               </button>
@@ -86,17 +86,17 @@ export default function AdminCachePage() {
         ))}
       </div>
 
-      <div className="border-t border-gray-800 pt-6">
+      <div className="border-t border-gray-200 pt-6">
         <div className="flex items-center gap-4">
           <button
             onClick={purgeAll}
             disabled={allLoading}
-            className="bg-red-700 hover:bg-red-800 disabled:opacity-50 text-white text-sm px-5 py-2 rounded transition-colors"
+            className="bg-red-600 hover:bg-red-700 disabled:opacity-50 text-white text-sm px-5 py-2 rounded-lg transition-colors"
           >
             {allLoading ? "처리 중..." : "전체 캐시 삭제"}
           </button>
           {allResult && (
-            <span className="text-sm text-gray-400">{allResult}</span>
+            <span className="text-sm text-gray-500">{allResult}</span>
           )}
         </div>
       </div>

--- a/client/app/admin/cache/page.tsx
+++ b/client/app/admin/cache/page.tsx
@@ -3,9 +3,9 @@
 import { useState } from "react";
 
 const CACHE_KEYS = [
-  { key: "sites", label: "?�이??목록 (sites:all)" },
-  { key: "characters", label: "캐릭??빌드 (characters:stat-builds)" },
-  { key: "youtube", label: "?�튜�?(youtube:popular:first)" },
+  { key: "sites", label: "사이트 목록", desc: "sites:all" },
+  { key: "characters", label: "캐릭터 빌드", desc: "characters:stat-builds" },
+  { key: "youtube", label: "유튜브", desc: "youtube:popular:first" },
 ];
 
 type StatusMap = Record<string, "idle" | "loading" | "done" | "error">;
@@ -32,43 +32,52 @@ export default function AdminCachePage() {
     const res = await fetch("/api/admin/cache", { method: "DELETE" });
     if (res.ok) {
       const d = (await res.json()) as { deleted: number };
-      setAllResult(`?�료 ??${d.deleted}�?????��`);
+      setAllResult(`완료 · ${d.deleted}개 키 삭제`);
     } else {
-      setAllResult("?�류 발생");
+      setAllResult("오류 발생");
     }
     setAllLoading(false);
   }
 
   const statusLabel = (s: string | undefined) => {
-    if (s === "loading") return "처리 �?..";
-    if (s === "done") return "???�료";
-    if (s === "error") return "???�류";
+    if (s === "loading") return "처리 중...";
+    if (s === "done") return "완료";
+    if (s === "error") return "오류";
     return "";
   };
 
   return (
-    <div>
-      <h1 className="text-xl font-semibold text-gray-900 mb-6">Redis 캐시 무효화</h1>
-      <p className="text-sm text-gray-500 mb-8">
-        캐시�???��?�면 ?�음 ?�청 ??DB?�서 ?�로 조회?�니??
-      </p>
+    <div className="max-w-3xl">
+      <div className="mb-8">
+        <h1 className="admin-page-title mb-2">Redis 캐시 무효화</h1>
+        <p className="admin-page-subtitle">
+          캐시를 삭제하면 다음 요청 시 DB에서 새로 조회합니다.
+        </p>
+      </div>
 
-      <div className="space-y-3 mb-8">
-        {CACHE_KEYS.map(({ key, label }) => (
+      <div className="admin-card admin-card-padded space-y-3 mb-6">
+        {CACHE_KEYS.map(({ key, label, desc }) => (
           <div
             key={key}
-            className="flex items-center justify-between bg-white border border-gray-200 rounded-lg px-5 py-3"
+            className="flex items-center justify-between py-3 border-b border-[color:var(--admin-border)] last:border-b-0"
           >
-            <span className="text-sm text-gray-700">{label}</span>
+            <div>
+              <p className="text-sm font-medium text-[color:var(--admin-text)]">
+                {label}
+              </p>
+              <p className="text-xs text-[color:var(--admin-text-muted)] font-mono mt-0.5">
+                {desc}
+              </p>
+            </div>
             <div className="flex items-center gap-3">
               {status[key] && status[key] !== "idle" && (
                 <span
-                  className={`text-xs ${
+                  className={`text-xs font-medium ${
                     status[key] === "done"
-                      ? "text-green-600"
+                      ? "text-emerald-600"
                       : status[key] === "error"
                         ? "text-red-500"
-                        : "text-gray-500"
+                        : "text-[color:var(--admin-text-muted)]"
                   }`}
                 >
                   {statusLabel(status[key])}
@@ -77,7 +86,7 @@ export default function AdminCachePage() {
               <button
                 onClick={() => purgeOne(key)}
                 disabled={status[key] === "loading"}
-                className="text-sm border border-red-200 bg-red-50 hover:bg-red-100 disabled:opacity-50 text-red-600 px-4 py-1.5 rounded-lg transition-colors"
+                className="admin-btn admin-btn-sm admin-btn-danger"
               >
                 삭제
               </button>
@@ -86,18 +95,30 @@ export default function AdminCachePage() {
         ))}
       </div>
 
-      <div className="border-t border-gray-200 pt-6">
-        <div className="flex items-center gap-4">
-          <button
-            onClick={purgeAll}
-            disabled={allLoading}
-            className="bg-red-600 hover:bg-red-700 disabled:opacity-50 text-white text-sm px-5 py-2 rounded-lg transition-colors"
-          >
-            {allLoading ? "처리 중..." : "전체 캐시 삭제"}
-          </button>
-          {allResult && (
-            <span className="text-sm text-gray-500">{allResult}</span>
-          )}
+      <div className="admin-card admin-card-padded">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium text-[color:var(--admin-text)]">
+              전체 캐시 삭제
+            </p>
+            <p className="text-xs text-[color:var(--admin-text-muted)] mt-0.5">
+              모든 Redis 캐시 키를 한 번에 삭제합니다.
+            </p>
+          </div>
+          <div className="flex items-center gap-3">
+            {allResult && (
+              <span className="text-xs text-[color:var(--admin-text-muted)]">
+                {allResult}
+              </span>
+            )}
+            <button
+              onClick={purgeAll}
+              disabled={allLoading}
+              className="admin-btn admin-btn-danger-solid"
+            >
+              {allLoading ? "처리 중..." : "전체 삭제"}
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/client/app/admin/characters/page.tsx
+++ b/client/app/admin/characters/page.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import { useCallback, useEffect, useState } from "react";
 
@@ -29,13 +29,13 @@ interface ListResult {
 const STAT_BUILDS = [
   "",
   "치신",
-  "신치",
+  "?�치",
   "치특",
-  "특치",
-  "신특",
-  "특신",
-  "치특신",
-  "미설정",
+  "?�치",
+  "?�특",
+  "?�신",
+  "치특??,
+  "미설??,
 ];
 const PAGE_SIZE = 20;
 
@@ -63,7 +63,7 @@ export default function AdminCharactersPage() {
         cache: "no-store",
       });
       if (!res.ok) {
-        setError("데이터 로드 실패");
+        setError("?�이??로드 ?�패");
         setLoading(false);
         return;
       }
@@ -93,7 +93,7 @@ export default function AdminCharactersPage() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ key: "characters" }),
       });
-      alert("캐릭터 캐시가 무효화됐습니다.");
+      alert("캐릭??캐시가 무효?�됐?�니??");
     } finally {
       setPurging(false);
     }
@@ -107,15 +107,15 @@ export default function AdminCharactersPage() {
       style={{ maxHeight: "calc(100vh - 64px)" }}
     >
       <div className="flex items-center justify-between mb-4">
-        <h1 className="text-xl font-semibold">캐릭터 목록</h1>
+        <h1 className="text-xl font-semibold">캐릭??목록</h1>
         <div className="flex items-center gap-3">
           <span className="text-xs text-gray-500">
-            총 {result?.total.toLocaleString() ?? "-"}명
+            총 {result?.total.toLocaleString() ?? "-"}개
           </span>
           <button
             onClick={handlePurge}
             disabled={purging}
-            className="text-sm bg-gray-700 hover:bg-gray-600 disabled:opacity-50 text-gray-300 px-3 py-1.5 rounded transition-colors"
+            className="text-sm border border-gray-300 bg-white hover:bg-gray-50 disabled:opacity-50 text-gray-700 px-3 py-1.5 rounded-lg transition-colors"
             title="Redis 캐릭터 캐시 즉시 삭제"
           >
             {purging ? "처리 중..." : "새로고침"}
@@ -123,47 +123,47 @@ export default function AdminCharactersPage() {
         </div>
       </div>
 
-      {/* 필터 */}
+      {/* ?�터 */}
       <div className="flex gap-2 mb-3 flex-wrap shrink-0">
         <input
           type="text"
-          placeholder="캐릭터명 검색"
+          placeholder="캐릭?�명 검??
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           onKeyDown={(e) => e.key === "Enter" && handleSearch()}
-          className="bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-sm text-white focus:outline-none focus:border-indigo-500 w-48"
+          className="bg-white border border-gray-300 rounded-lg px-3 py-1.5 text-sm text-gray-900 focus:outline-none focus:border-blue-500 w-48"
         />
         <input
           type="text"
-          placeholder="직업 (예: 버서커)"
+          placeholder="직업 (?? 버서�?"
           value={classDetail}
           onChange={(e) => setClassDetail(e.target.value)}
           onKeyDown={(e) => e.key === "Enter" && handleSearch()}
-          className="bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-sm text-white focus:outline-none focus:border-indigo-500 w-40"
+          className="bg-white border border-gray-300 rounded-lg px-3 py-1.5 text-sm text-gray-900 focus:outline-none focus:border-blue-500 w-40"
         />
         <select
           value={statBuild}
           onChange={(e) => setStatBuild(e.target.value)}
-          className="bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-sm text-white focus:outline-none focus:border-indigo-500"
+          className="bg-white border border-gray-300 rounded-lg px-3 py-1.5 text-sm text-gray-900 focus:outline-none focus:border-blue-500"
         >
           {STAT_BUILDS.map((b) => (
             <option key={b} value={b}>
-              {b || "전체 빌드"}
+              {b || "?�체 빌드"}
             </option>
           ))}
         </select>
         <button
           onClick={handleSearch}
-          className="bg-indigo-600 hover:bg-indigo-700 text-white text-sm px-4 py-1.5 rounded transition-colors"
+          className="bg-blue-600 hover:bg-blue-700 text-white text-sm px-4 py-1.5 rounded-lg transition-colors"
         >
-          검색
+          검??
         </button>
       </div>
 
       {error && <p className="text-red-400 text-sm mb-3 shrink-0">{error}</p>}
 
       {loading ? (
-        <p className="text-gray-500 text-sm">불러오는 중...</p>
+        <p className="text-gray-400 text-sm">불러?�는 �?..</p>
       ) : (
         <div className="flex flex-col flex-1 min-h-0">
           <div className="overflow-auto flex-1">
@@ -182,17 +182,17 @@ export default function AdminCharactersPage() {
                 <col style={{ width: "60px" }} />
               </colgroup>
               <thead>
-                <tr className="border-b border-gray-800 text-gray-400 text-center">
+                <tr className="border-b border-gray-200 text-gray-500 text-center">
                   <th className="py-2">#</th>
-                  <th className="py-2">캐릭터명</th>
-                  <th className="py-2">아이템레벨</th>
-                  <th className="py-2">전투력</th>
-                  <th className="py-2">서버</th>
+                  <th className="py-2">캐릭?�명</th>
+                  <th className="py-2">?�이?�레�?/th>
+                  <th className="py-2">?�투??/th>
+                  <th className="py-2">?�버</th>
                   <th className="py-2">직업</th>
                   <th className="py-2">각인</th>
-                  <th className="py-2">태양코어</th>
-                  <th className="py-2">달코어</th>
-                  <th className="py-2">별코어</th>
+                  <th className="py-2">?�양코어</th>
+                  <th className="py-2">?�코??/th>
+                  <th className="py-2">별코??/th>
                   <th className="py-2">빌드</th>
                 </tr>
               </thead>
@@ -200,15 +200,15 @@ export default function AdminCharactersPage() {
                 {result?.items.map((c, idx) => (
                   <tr
                     key={c.name}
-                    className="border-b border-gray-800/50 hover:bg-gray-900/40"
+                    className="border-b border-gray-100 hover:bg-gray-50 transition-colors"
                   >
-                    <td className="py-1.5 text-gray-600 text-center text-xs">
+                    <td className="py-1.5 text-gray-400 text-center text-xs">
                       {(page - 1) * PAGE_SIZE + idx + 1}
                     </td>
-                    <td className="py-1.5 text-white font-medium text-center truncate overflow-hidden">
+                    <td className="py-1.5 text-gray-900 font-medium text-center truncate overflow-hidden">
                       {c.name}
                     </td>
-                    <td className="py-1.5 text-center text-gray-200 tabular-nums text-xs">
+                    <td className="py-1.5 text-center text-gray-700 tabular-nums text-xs">
                       {c.level.toLocaleString()}
                     </td>
                     <td className="py-1.5 text-center text-yellow-300 tabular-nums text-xs">
@@ -216,13 +216,13 @@ export default function AdminCharactersPage() {
                         ? c.combatPower.toLocaleString()
                         : "-"}
                     </td>
-                    <td className="py-1.5 text-center text-gray-400 text-xs truncate overflow-hidden">
+                    <td className="py-1.5 text-center text-gray-500 text-xs truncate overflow-hidden">
                       {c.server ?? "-"}
                     </td>
-                    <td className="py-1.5 text-center text-gray-300 text-xs truncate overflow-hidden">
+                    <td className="py-1.5 text-center text-gray-600 text-xs truncate overflow-hidden">
                       {c.classDetail ?? "-"}
                     </td>
-                    <td className="py-1.5 text-center text-gray-400 text-xs truncate overflow-hidden">
+                    <td className="py-1.5 text-center text-gray-500 text-xs truncate overflow-hidden">
                       {c.classEngraving ?? "-"}
                     </td>
                     <td className="py-1.5 text-center text-yellow-400 text-xs truncate overflow-hidden">
@@ -237,9 +237,9 @@ export default function AdminCharactersPage() {
                     <td className="py-1.5 text-center">
                       <span
                         className={`text-xs px-1.5 py-0.5 rounded ${
-                          c.statBuild === "미설정"
-                            ? "bg-gray-800 text-gray-500"
-                            : "bg-indigo-900/50 text-indigo-300"
+                          c.statBuild === "미설??
+                            ? "bg-gray-100 text-gray-400"
+                            : "bg-blue-50 text-blue-600"
                         }`}
                       >
                         {c.statBuild}
@@ -251,15 +251,15 @@ export default function AdminCharactersPage() {
             </table>
           </div>
 
-          {/* 페이지네이션 */}
+          {/* ?�이지?�이??*/}
           {totalPages > 1 && (
             <div className="flex items-center gap-2 mt-3 justify-center shrink-0">
               <button
                 onClick={() => setPage((p) => Math.max(p - 1, 1))}
                 disabled={page === 1}
-                className="text-xs px-3 py-1 rounded border border-gray-700 text-gray-400 hover:text-white disabled:opacity-30 transition-colors"
+                className="text-xs px-3 py-1 rounded border border-gray-300 text-gray-500 hover:text-gray-900 disabled:opacity-30 transition-colors"
               >
-                이전
+                ?�전
               </button>
               <span className="text-xs text-gray-500">
                 {page} / {totalPages}
@@ -267,9 +267,9 @@ export default function AdminCharactersPage() {
               <button
                 onClick={() => setPage((p) => Math.min(p + 1, totalPages))}
                 disabled={page === totalPages}
-                className="text-xs px-3 py-1 rounded border border-gray-700 text-gray-400 hover:text-white disabled:opacity-30 transition-colors"
+                className="text-xs px-3 py-1 rounded border border-gray-300 text-gray-500 hover:text-gray-900 disabled:opacity-30 transition-colors"
               >
-                다음
+                ?�음
               </button>
             </div>
           )}

--- a/client/app/admin/characters/page.tsx
+++ b/client/app/admin/characters/page.tsx
@@ -1,4 +1,4 @@
-﻿"use client";
+"use client";
 
 import { useCallback, useEffect, useState } from "react";
 
@@ -29,13 +29,13 @@ interface ListResult {
 const STAT_BUILDS = [
   "",
   "치신",
-  "?�치",
+  "특치",
   "치특",
-  "?�치",
-  "?�특",
-  "?�신",
-  "치특??,
-  "미설??,
+  "신치",
+  "신특",
+  "특신",
+  "치특신",
+  "미설정",
 ];
 const PAGE_SIZE = 20;
 
@@ -63,7 +63,7 @@ export default function AdminCharactersPage() {
         cache: "no-store",
       });
       if (!res.ok) {
-        setError("?�이??로드 ?�패");
+        setError("데이터 로드 실패");
         setLoading(false);
         return;
       }
@@ -74,7 +74,6 @@ export default function AdminCharactersPage() {
   );
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     void load(page);
   }, [load, page]);
 
@@ -93,7 +92,7 @@ export default function AdminCharactersPage() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ key: "characters" }),
       });
-      alert("캐릭??캐시가 무효?�됐?�니??");
+      alert("캐릭터 캐시가 무효화됐습니다.");
     } finally {
       setPurging(false);
     }
@@ -106,170 +105,183 @@ export default function AdminCharactersPage() {
       className="flex flex-col h-full"
       style={{ maxHeight: "calc(100vh - 64px)" }}
     >
-      <div className="flex items-center justify-between mb-4">
-        <h1 className="text-xl font-semibold">캐릭??목록</h1>
-        <div className="flex items-center gap-3">
-          <span className="text-xs text-gray-500">
-            총 {result?.total.toLocaleString() ?? "-"}개
-          </span>
+      {/* 헤더 */}
+      <div className="flex items-end justify-between mb-5 shrink-0">
+        <div>
+          <h1 className="admin-page-title">캐릭터 목록</h1>
+          <p className="admin-page-subtitle mt-1">
+            총 {result?.total.toLocaleString() ?? "-"}명의 캐릭터가 등록되어 있습니다.
+          </p>
+        </div>
+        <button
+          onClick={handlePurge}
+          disabled={purging}
+          className="admin-btn admin-btn-secondary"
+          title="Redis 캐릭터 캐시 즉시 삭제"
+        >
+          {purging ? "처리 중..." : "캐시 새로고침"}
+        </button>
+      </div>
+
+      {/* 필터 */}
+      <div className="admin-card admin-card-padded mb-4 shrink-0">
+        <div className="flex gap-2 flex-wrap items-end">
+          <div className="w-48">
+            <label className="admin-label">캐릭터명</label>
+            <input
+              type="text"
+              placeholder="검색어 입력"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+              className="admin-input"
+            />
+          </div>
+          <div className="w-40">
+            <label className="admin-label">직업</label>
+            <input
+              type="text"
+              placeholder="예: 버서커"
+              value={classDetail}
+              onChange={(e) => setClassDetail(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+              className="admin-input"
+            />
+          </div>
+          <div className="w-36">
+            <label className="admin-label">빌드</label>
+            <select
+              value={statBuild}
+              onChange={(e) => setStatBuild(e.target.value)}
+              className="admin-select"
+            >
+              {STAT_BUILDS.map((b) => (
+                <option key={b} value={b}>
+                  {b || "전체 빌드"}
+                </option>
+              ))}
+            </select>
+          </div>
           <button
-            onClick={handlePurge}
-            disabled={purging}
-            className="text-sm border border-gray-300 bg-white hover:bg-gray-50 disabled:opacity-50 text-gray-700 px-3 py-1.5 rounded-lg transition-colors"
-            title="Redis 캐릭터 캐시 즉시 삭제"
+            onClick={handleSearch}
+            className="admin-btn admin-btn-primary"
           >
-            {purging ? "처리 중..." : "새로고침"}
+            검색
           </button>
         </div>
       </div>
 
-      {/* ?�터 */}
-      <div className="flex gap-2 mb-3 flex-wrap shrink-0">
-        <input
-          type="text"
-          placeholder="캐릭?�명 검??
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          onKeyDown={(e) => e.key === "Enter" && handleSearch()}
-          className="bg-white border border-gray-300 rounded-lg px-3 py-1.5 text-sm text-gray-900 focus:outline-none focus:border-blue-500 w-48"
-        />
-        <input
-          type="text"
-          placeholder="직업 (?? 버서�?"
-          value={classDetail}
-          onChange={(e) => setClassDetail(e.target.value)}
-          onKeyDown={(e) => e.key === "Enter" && handleSearch()}
-          className="bg-white border border-gray-300 rounded-lg px-3 py-1.5 text-sm text-gray-900 focus:outline-none focus:border-blue-500 w-40"
-        />
-        <select
-          value={statBuild}
-          onChange={(e) => setStatBuild(e.target.value)}
-          className="bg-white border border-gray-300 rounded-lg px-3 py-1.5 text-sm text-gray-900 focus:outline-none focus:border-blue-500"
-        >
-          {STAT_BUILDS.map((b) => (
-            <option key={b} value={b}>
-              {b || "?�체 빌드"}
-            </option>
-          ))}
-        </select>
-        <button
-          onClick={handleSearch}
-          className="bg-blue-600 hover:bg-blue-700 text-white text-sm px-4 py-1.5 rounded-lg transition-colors"
-        >
-          검??
-        </button>
-      </div>
-
-      {error && <p className="text-red-400 text-sm mb-3 shrink-0">{error}</p>}
+      {error && (
+        <p className="text-red-500 text-sm mb-3 shrink-0">{error}</p>
+      )}
 
       {loading ? (
-        <p className="text-gray-400 text-sm">불러?�는 �?..</p>
+        <div className="admin-card admin-card-padded text-center">
+          <p className="text-sm text-[color:var(--admin-text-muted)]">
+            불러오는 중...
+          </p>
+        </div>
       ) : (
         <div className="flex flex-col flex-1 min-h-0">
-          <div className="overflow-auto flex-1">
-            <table className="w-full text-sm table-fixed">
-              <colgroup>
-                <col style={{ width: "36px" }} />
-                <col style={{ width: "90px" }} />
-                <col style={{ width: "70px" }} />
-                <col style={{ width: "80px" }} />
-                <col style={{ width: "60px" }} />
-                <col style={{ width: "80px" }} />
-                <col style={{ width: "160px" }} />
-                <col style={{ width: "90px" }} />
-                <col style={{ width: "90px" }} />
-                <col style={{ width: "90px" }} />
-                <col style={{ width: "60px" }} />
-              </colgroup>
-              <thead>
-                <tr className="border-b border-gray-200 text-gray-500 text-center">
-                  <th className="py-2">#</th>
-                  <th className="py-2">캐릭?�명</th>
-                  <th className="py-2">?�이?�레�?/th>
-                  <th className="py-2">?�투??/th>
-                  <th className="py-2">?�버</th>
-                  <th className="py-2">직업</th>
-                  <th className="py-2">각인</th>
-                  <th className="py-2">?�양코어</th>
-                  <th className="py-2">?�코??/th>
-                  <th className="py-2">별코??/th>
-                  <th className="py-2">빌드</th>
-                </tr>
-              </thead>
-              <tbody>
-                {result?.items.map((c, idx) => (
-                  <tr
-                    key={c.name}
-                    className="border-b border-gray-100 hover:bg-gray-50 transition-colors"
-                  >
-                    <td className="py-1.5 text-gray-400 text-center text-xs">
-                      {(page - 1) * PAGE_SIZE + idx + 1}
-                    </td>
-                    <td className="py-1.5 text-gray-900 font-medium text-center truncate overflow-hidden">
-                      {c.name}
-                    </td>
-                    <td className="py-1.5 text-center text-gray-700 tabular-nums text-xs">
-                      {c.level.toLocaleString()}
-                    </td>
-                    <td className="py-1.5 text-center text-yellow-300 tabular-nums text-xs">
-                      {c.combatPower != null
-                        ? c.combatPower.toLocaleString()
-                        : "-"}
-                    </td>
-                    <td className="py-1.5 text-center text-gray-500 text-xs truncate overflow-hidden">
-                      {c.server ?? "-"}
-                    </td>
-                    <td className="py-1.5 text-center text-gray-600 text-xs truncate overflow-hidden">
-                      {c.classDetail ?? "-"}
-                    </td>
-                    <td className="py-1.5 text-center text-gray-500 text-xs truncate overflow-hidden">
-                      {c.classEngraving ?? "-"}
-                    </td>
-                    <td className="py-1.5 text-center text-yellow-400 text-xs truncate overflow-hidden">
-                      {c.coreSun ?? "-"}
-                    </td>
-                    <td className="py-1.5 text-center text-blue-400 text-xs truncate overflow-hidden">
-                      {c.coreMoon ?? "-"}
-                    </td>
-                    <td className="py-1.5 text-center text-purple-400 text-xs truncate overflow-hidden">
-                      {c.coreStar ?? "-"}
-                    </td>
-                    <td className="py-1.5 text-center">
-                      <span
-                        className={`text-xs px-1.5 py-0.5 rounded ${
-                          c.statBuild === "미설??
-                            ? "bg-gray-100 text-gray-400"
-                            : "bg-blue-50 text-blue-600"
-                        }`}
-                      >
-                        {c.statBuild}
-                      </span>
-                    </td>
+          <div className="admin-card overflow-hidden flex-1 flex flex-col min-h-0">
+            <div className="overflow-auto flex-1">
+              <table className="admin-table table-fixed">
+                <colgroup>
+                  <col style={{ width: "44px" }} />
+                  <col style={{ width: "120px" }} />
+                  <col style={{ width: "80px" }} />
+                  <col style={{ width: "90px" }} />
+                  <col style={{ width: "80px" }} />
+                  <col style={{ width: "100px" }} />
+                  <col style={{ width: "180px" }} />
+                  <col style={{ width: "100px" }} />
+                  <col style={{ width: "100px" }} />
+                  <col style={{ width: "100px" }} />
+                  <col style={{ width: "80px" }} />
+                </colgroup>
+                <thead>
+                  <tr>
+                    <th className="text-center">#</th>
+                    <th>캐릭터명</th>
+                    <th className="text-center">아이템</th>
+                    <th className="text-center">전투력</th>
+                    <th>서버</th>
+                    <th>직업</th>
+                    <th>각인</th>
+                    <th>해코어</th>
+                    <th>달코어</th>
+                    <th>별코어</th>
+                    <th className="text-center">빌드</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {result?.items.map((c, idx) => (
+                    <tr key={c.name}>
+                      <td className="text-center text-[color:var(--admin-text-subtle)] tabular-nums">
+                        {(page - 1) * PAGE_SIZE + idx + 1}
+                      </td>
+                      <td className="font-medium truncate">{c.name}</td>
+                      <td className="text-center tabular-nums">
+                        {c.level.toLocaleString()}
+                      </td>
+                      <td className="text-center tabular-nums text-amber-600 font-medium">
+                        {c.combatPower != null
+                          ? c.combatPower.toLocaleString()
+                          : "-"}
+                      </td>
+                      <td className="text-[color:var(--admin-text-muted)] truncate">
+                        {c.server ?? "-"}
+                      </td>
+                      <td className="truncate">{c.classDetail ?? "-"}</td>
+                      <td className="text-[color:var(--admin-text-muted)] text-xs truncate">
+                        {c.classEngraving ?? "-"}
+                      </td>
+                      <td className="text-amber-600 text-xs truncate">
+                        {c.coreSun ?? "-"}
+                      </td>
+                      <td className="text-blue-600 text-xs truncate">
+                        {c.coreMoon ?? "-"}
+                      </td>
+                      <td className="text-violet-600 text-xs truncate">
+                        {c.coreStar ?? "-"}
+                      </td>
+                      <td className="text-center">
+                        <span
+                          className={`admin-badge ${
+                            c.statBuild === "미설정"
+                              ? "admin-badge-neutral"
+                              : "admin-badge-info"
+                          }`}
+                        >
+                          {c.statBuild}
+                        </span>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           </div>
 
-          {/* ?�이지?�이??*/}
+          {/* 페이지네이션 */}
           {totalPages > 1 && (
-            <div className="flex items-center gap-2 mt-3 justify-center shrink-0">
+            <div className="flex items-center gap-3 mt-4 justify-center shrink-0">
               <button
                 onClick={() => setPage((p) => Math.max(p - 1, 1))}
                 disabled={page === 1}
-                className="text-xs px-3 py-1 rounded border border-gray-300 text-gray-500 hover:text-gray-900 disabled:opacity-30 transition-colors"
+                className="admin-btn admin-btn-sm admin-btn-secondary"
               >
-                ?�전
+                이전
               </button>
-              <span className="text-xs text-gray-500">
+              <span className="text-xs text-[color:var(--admin-text-muted)] tabular-nums">
                 {page} / {totalPages}
               </span>
               <button
                 onClick={() => setPage((p) => Math.min(p + 1, totalPages))}
                 disabled={page === totalPages}
-                className="text-xs px-3 py-1 rounded border border-gray-300 text-gray-500 hover:text-gray-900 disabled:opacity-30 transition-colors"
+                className="admin-btn admin-btn-sm admin-btn-secondary"
               >
-                ?�음
+                다음
               </button>
             </div>
           )}

--- a/client/app/admin/layout.tsx
+++ b/client/app/admin/layout.tsx
@@ -27,33 +27,32 @@ export default function AdminLayout({
   }
 
   return (
-    <div className="h-screen bg-gray-50 text-gray-900 flex overflow-hidden">
+    <div className="admin-shell h-screen flex overflow-hidden">
       {/* Sidebar */}
-      <aside className="w-48 bg-gray-900 border-r border-gray-800 flex flex-col shrink-0">
-        <div className="px-4 py-5 border-b border-gray-800">
-          <span className="text-sm font-semibold text-indigo-400">
-            다로아 관리자
+      <aside className="admin-sidebar w-56 flex flex-col shrink-0">
+        <div className="px-5 py-6 border-b border-[color:var(--admin-sidebar-border)]">
+          <span className="admin-sidebar-brand text-base font-bold">
+            다로아 <span className="text-blue-400">Admin</span>
           </span>
         </div>
-        <nav className="flex-1 py-4">
-          {NAV.map(({ href, label }) => (
-            <Link
-              key={href}
-              href={href}
-              className={`block px-4 py-2 text-sm hover:bg-gray-800 transition-colors ${
-                pathname.startsWith(href)
-                  ? "bg-gray-800 text-white font-medium"
-                  : "text-gray-400"
-              }`}
-            >
-              {label}
-            </Link>
-          ))}
+        <nav className="flex-1 py-4 px-3 space-y-1">
+          {NAV.map(({ href, label }) => {
+            const active = pathname.startsWith(href);
+            return (
+              <Link
+                key={href}
+                href={href}
+                className={`admin-sidebar-link block px-3 py-2 rounded-lg text-sm ${active ? "is-active" : ""}`}
+              >
+                {label}
+              </Link>
+            );
+          })}
         </nav>
-        <div className="px-4 py-4 border-t border-gray-800">
+        <div className="px-5 py-4 border-t border-[color:var(--admin-sidebar-border)]">
           <button
             onClick={logout}
-            className="w-full text-left text-xs text-gray-500 hover:text-gray-300 transition-colors"
+            className="admin-sidebar-logout w-full text-left text-xs"
           >
             로그아웃
           </button>
@@ -61,7 +60,7 @@ export default function AdminLayout({
       </aside>
 
       {/* Main */}
-      <main className="flex-1 p-8 overflow-auto bg-gray-50">{children}</main>
+      <main className="flex-1 p-8 overflow-auto">{children}</main>
     </div>
   );
 }

--- a/client/app/admin/layout.tsx
+++ b/client/app/admin/layout.tsx
@@ -27,9 +27,9 @@ export default function AdminLayout({
   }
 
   return (
-    <div className="h-screen bg-gray-950 text-gray-100 flex overflow-hidden">
+    <div className="h-screen bg-gray-50 text-gray-900 flex overflow-hidden">
       {/* Sidebar */}
-      <aside className="w-48 bg-gray-900 border-r border-gray-800 flex flex-col">
+      <aside className="w-48 bg-gray-900 border-r border-gray-800 flex flex-col shrink-0">
         <div className="px-4 py-5 border-b border-gray-800">
           <span className="text-sm font-semibold text-indigo-400">
             다로아 관리자
@@ -61,7 +61,7 @@ export default function AdminLayout({
       </aside>
 
       {/* Main */}
-      <main className="flex-1 p-8 overflow-auto">{children}</main>
+      <main className="flex-1 p-8 overflow-auto bg-gray-50">{children}</main>
     </div>
   );
 }

--- a/client/app/admin/login/page.tsx
+++ b/client/app/admin/login/page.tsx
@@ -19,12 +19,12 @@ export default function AdminLoginPage() {
       });
       if (!res.ok) {
         const data = (await res.json()) as { message?: string };
-        setError(data.message ?? "로그???�패");
+        setError(data.message ?? "로그인 실패");
         return;
       }
       window.location.replace("/admin/sites");
     } catch {
-      setError("?�트?�크 ?�류가 발생?�습?�다");
+      setError("네트워크 오류가 발생했습니다");
     } finally {
       setLoading(false);
     }
@@ -40,39 +40,42 @@ export default function AdminLoginPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-      <div className="w-full max-w-sm bg-white rounded-xl p-8 border border-gray-200 shadow-sm">
-        <h1 className="text-xl font-semibold text-gray-900 mb-6">
-          다로아 관리자 로그인
-        </h1>
+    <div className="admin-shell min-h-screen flex items-center justify-center p-6">
+      <div className="admin-card w-full max-w-sm p-8">
+        <div className="mb-6">
+          <h1 className="admin-page-title">
+            다로아 <span className="text-blue-600">Admin</span>
+          </h1>
+          <p className="admin-page-subtitle mt-1">관리자 로그인</p>
+        </div>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label className="block text-sm text-gray-600 mb-1">아이디</label>
+            <label className="admin-label">아이디</label>
             <input
               type="text"
               value={username}
               onChange={(e) => setUsername(e.target.value)}
               required
               autoComplete="username"
-              className="w-full bg-white border border-gray-300 rounded-lg px-3 py-2 text-sm text-gray-900 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+              className="admin-input"
             />
           </div>
           <div>
-            <label className="block text-sm text-gray-600 mb-1">비밀번호</label>
+            <label className="admin-label">비밀번호</label>
             <input
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               required
               autoComplete="current-password"
-              className="w-full bg-white border border-gray-300 rounded-lg px-3 py-2 text-sm text-gray-900 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+              className="admin-input"
             />
           </div>
           {error && <p className="text-red-500 text-sm">{error}</p>}
           <button
             type="submit"
             disabled={loading}
-            className="w-full bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white rounded-lg py-2 text-sm font-medium transition-colors"
+            className="admin-btn admin-btn-primary w-full"
           >
             {loading ? "로그인 중..." : "로그인"}
           </button>
@@ -80,7 +83,7 @@ export default function AdminLoginPage() {
             type="button"
             disabled={loading}
             onClick={handleGuestLogin}
-            className="w-full border border-gray-300 bg-white hover:bg-gray-50 disabled:opacity-50 text-gray-700 rounded-lg py-2 text-sm font-medium transition-colors"
+            className="admin-btn admin-btn-secondary w-full"
           >
             게스트로 둘러보기
           </button>

--- a/client/app/admin/login/page.tsx
+++ b/client/app/admin/login/page.tsx
@@ -19,12 +19,12 @@ export default function AdminLoginPage() {
       });
       if (!res.ok) {
         const data = (await res.json()) as { message?: string };
-        setError(data.message ?? "로그인 실패");
+        setError(data.message ?? "로그???�패");
         return;
       }
       window.location.replace("/admin/sites");
     } catch {
-      setError("네트워크 오류가 발생했습니다");
+      setError("?�트?�크 ?�류가 발생?�습?�다");
     } finally {
       setLoading(false);
     }
@@ -40,39 +40,39 @@ export default function AdminLoginPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-950 flex items-center justify-center">
-      <div className="w-full max-w-sm bg-gray-900 rounded-lg p-8 border border-gray-800">
-        <h1 className="text-xl font-semibold text-white mb-6">
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="w-full max-w-sm bg-white rounded-xl p-8 border border-gray-200 shadow-sm">
+        <h1 className="text-xl font-semibold text-gray-900 mb-6">
           다로아 관리자 로그인
         </h1>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label className="block text-sm text-gray-400 mb-1">아이디</label>
+            <label className="block text-sm text-gray-600 mb-1">아이디</label>
             <input
               type="text"
               value={username}
               onChange={(e) => setUsername(e.target.value)}
               required
               autoComplete="username"
-              className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-sm text-white focus:outline-none focus:border-indigo-500"
+              className="w-full bg-white border border-gray-300 rounded-lg px-3 py-2 text-sm text-gray-900 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
             />
           </div>
           <div>
-            <label className="block text-sm text-gray-400 mb-1">비밀번호</label>
+            <label className="block text-sm text-gray-600 mb-1">비밀번호</label>
             <input
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               required
               autoComplete="current-password"
-              className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-sm text-white focus:outline-none focus:border-indigo-500"
+              className="w-full bg-white border border-gray-300 rounded-lg px-3 py-2 text-sm text-gray-900 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
             />
           </div>
-          {error && <p className="text-red-400 text-sm">{error}</p>}
+          {error && <p className="text-red-500 text-sm">{error}</p>}
           <button
             type="submit"
             disabled={loading}
-            className="w-full bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white rounded py-2 text-sm font-medium transition-colors"
+            className="w-full bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white rounded-lg py-2 text-sm font-medium transition-colors"
           >
             {loading ? "로그인 중..." : "로그인"}
           </button>
@@ -80,7 +80,7 @@ export default function AdminLoginPage() {
             type="button"
             disabled={loading}
             onClick={handleGuestLogin}
-            className="w-full bg-gray-700 hover:bg-gray-600 disabled:opacity-50 text-gray-300 rounded py-2 text-sm font-medium transition-colors"
+            className="w-full border border-gray-300 bg-white hover:bg-gray-50 disabled:opacity-50 text-gray-700 rounded-lg py-2 text-sm font-medium transition-colors"
           >
             게스트로 둘러보기
           </button>

--- a/client/app/admin/sites/page.tsx
+++ b/client/app/admin/sites/page.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import { useCallback, useEffect, useState } from "react";
 
@@ -35,7 +35,7 @@ function SiteCardPreview({ form }: { form: typeof EMPTY_FORM }) {
   })();
 
   return (
-    <div className="relative flex flex-col rounded-xl border border-slate-200 bg-slate-50 p-3 min-h-[80px]">
+    <div className="relative flex flex-col rounded-xl border border-gray-200 bg-gray-50 p-3 min-h-[80px]">
       <div className="flex items-start justify-between gap-2 pr-1">
         <div className="flex min-w-0 items-center gap-1.5">
           {iconSrc && (
@@ -48,25 +48,42 @@ function SiteCardPreview({ form }: { form: typeof EMPTY_FORM }) {
               className="shrink-0 rounded-sm"
             />
           )}
-          <span className="truncate font-semibold text-slate-900 text-sm">
-            {form.name || <span className="text-slate-400">이름</span>}
+          <span className="truncate font-semibold text-gray-900 text-sm">
+            {form.name || <span className="text-gray-400">이름</span>}
           </span>
         </div>
-        <span className="shrink-0 rounded-full px-2 py-0.5 text-xs text-white bg-slate-900">
+        <span className="shrink-0 rounded-full px-2 py-0.5 text-xs text-gray-600 bg-gray-100 border border-gray-200">
           {form.category || "카테고리"}
         </span>
       </div>
-      <p className="mt-1.5 text-xs text-slate-600 line-clamp-2">
-        {form.description || <span className="text-slate-400">설명</span>}
+      <p className="mt-1.5 text-xs text-gray-600 line-clamp-2">
+        {form.description || <span className="text-gray-400">설명</span>}
       </p>
     </div>
   );
+}
+
+function getCategoryTone(category: string | null) {
+  const value = (category ?? "").toLowerCase();
+
+  if (value.includes("공식") || value.includes("official")) {
+    return "border-sky-200 bg-sky-50 text-sky-700";
+  }
+  if (value.includes("커뮤니티") || value.includes("community")) {
+    return "border-violet-200 bg-violet-50 text-violet-700";
+  }
+  if (value.includes("도구") || value.includes("tool") || value.includes("계산")) {
+    return "border-amber-200 bg-amber-50 text-amber-700";
+  }
+
+  return "border-gray-200 bg-gray-100 text-gray-600";
 }
 
 export default function AdminSitesPage() {
   const [sites, setSites] = useState<Site[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const [busyMessage, setBusyMessage] = useState<string | null>(null);
 
   // 추가/수정 폼
   const [showForm, setShowForm] = useState(false);
@@ -75,21 +92,37 @@ export default function AdminSitesPage() {
   const [saving, setSaving] = useState(false);
   const [formError, setFormError] = useState("");
 
-  const load = useCallback(async () => {
-    setLoading(true);
-    const res = await fetch("/api/admin/sites", { cache: "no-store" });
-    if (!res.ok) {
+  const load = useCallback(
+    async (options?: { withSpinner?: boolean }): Promise<Site[] | null> => {
+      const withSpinner = options?.withSpinner ?? false;
+      if (withSpinner) {
+        setLoading(true);
+      }
+
+    try {
+      const res = await fetch("/api/admin/sites", { cache: "no-store" });
+      if (!res.ok) {
+        setError("목록 로드 실패");
+        return null;
+      }
+      const data = (await res.json()) as Site[];
+      setSites(data);
+      setError("");
+      return data;
+    } catch {
       setError("목록 로드 실패");
-      setLoading(false);
-      return;
+      return null;
+    } finally {
+      if (withSpinner) {
+        setLoading(false);
+      }
     }
-    setSites((await res.json()) as Site[]);
-    setLoading(false);
-  }, []);
+    },
+    [],
+  );
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    void load();
+    void load({ withSpinner: true });
   }, [load]);
 
   function startEdit(site: Site) {
@@ -120,6 +153,48 @@ export default function AdminSitesPage() {
     });
   }
 
+  function normalizeNullable(value: string | null | undefined) {
+    return value ?? null;
+  }
+
+  async function parseErrorMessage(res: Response, fallback: string) {
+    try {
+      const d = (await res.json()) as { message?: string };
+      return d.message ?? fallback;
+    } catch {
+      return fallback;
+    }
+  }
+
+  async function waitForReflection(
+    predicate: (items: Site[]) => boolean,
+    retries = 8,
+    delayMs = 350,
+  ) {
+    for (let i = 0; i < retries; i += 1) {
+      const items = await load();
+      if (items && predicate(items)) {
+        return true;
+      }
+      if (i < retries - 1) {
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
+    }
+    return false;
+  }
+
+  async function runWithBusyMessage(
+    message: string,
+    action: () => Promise<void>,
+  ) {
+    setBusyMessage(message);
+    try {
+      await action();
+    } finally {
+      setBusyMessage(null);
+    }
+  }
+
   async function handleSave() {
     if (!form.name || !form.href) {
       setFormError("이름과 URL은 필수입니다");
@@ -141,45 +216,123 @@ export default function AdminSitesPage() {
       : "/api/admin/sites";
     const method = editingId ? "PUT" : "POST";
 
-    const res = await fetch(url, {
-      method,
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-    });
+    await runWithBusyMessage(
+      editingId ? "수정 반영 확인 중입니다..." : "추가 반영 확인 중입니다...",
+      async () => {
+        const res = await fetch(url, {
+          method,
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
 
-    if (!res.ok) {
-      const d = (await res.json()) as { message?: string };
-      setFormError(d.message ?? "저장 실패");
-      setSaving(false);
-      return;
-    }
+        if (!res.ok) {
+          setFormError(await parseErrorMessage(res, "저장 실패"));
+          return;
+        }
 
-    await purgeSitesCache();
-    cancelEdit();
-    await load();
+        const data = (await res.json()) as { seq?: number };
+        await purgeSitesCache();
+
+        const reflected = await waitForReflection((items) => {
+          if (editingId) {
+            const target = items.find((item) => item.seq === editingId);
+            if (!target) return false;
+            return (
+              target.name === payload.name &&
+              target.href === payload.href &&
+              normalizeNullable(target.category) ===
+                normalizeNullable(payload.category) &&
+              normalizeNullable(target.description) ===
+                normalizeNullable(payload.description) &&
+              normalizeNullable(target.icon) === normalizeNullable(payload.icon)
+            );
+          }
+
+          if (data.seq != null) {
+            const created = items.find((item) => item.seq === data.seq);
+            if (!created) return false;
+            return (
+              created.name === payload.name &&
+              created.href === payload.href &&
+              normalizeNullable(created.category) ===
+                normalizeNullable(payload.category) &&
+              normalizeNullable(created.description) ===
+                normalizeNullable(payload.description) &&
+              normalizeNullable(created.icon) === normalizeNullable(payload.icon)
+            );
+          }
+
+          return items.some(
+            (item) =>
+              item.name === payload.name &&
+              item.href === payload.href &&
+              normalizeNullable(item.category) ===
+                normalizeNullable(payload.category) &&
+              normalizeNullable(item.description) ===
+                normalizeNullable(payload.description) &&
+              normalizeNullable(item.icon) === normalizeNullable(payload.icon),
+          );
+        });
+
+        if (!reflected) {
+          setFormError(
+            "DB 반영 확인이 지연되고 있습니다. 잠시 후 다시 확인해주세요.",
+          );
+          return;
+        }
+
+        cancelEdit();
+      },
+    );
     setSaving(false);
   }
 
   async function handleToggleActive(site: Site) {
-    await fetch(`/api/admin/sites/${site.seq}`, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ is_active: site.is_active === 0 }),
+    const nextActive = site.is_active === 0;
+
+    await runWithBusyMessage("활성 상태 반영 확인 중입니다...", async () => {
+      const res = await fetch(`/api/admin/sites/${site.seq}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ is_active: nextActive }),
+      });
+
+      if (!res.ok) {
+        setError(await parseErrorMessage(res, "활성 상태 변경 실패"));
+        return;
+      }
+
+      await purgeSitesCache();
+      const reflected = await waitForReflection((items) => {
+        const target = items.find((item) => item.seq === site.seq);
+        return !!target && target.is_active === (nextActive ? 1 : 0);
+      });
+
+      if (!reflected) {
+        setError("활성 상태 반영 확인이 지연되고 있습니다.");
+      }
     });
-    await purgeSitesCache();
-    await load();
   }
 
   async function handleDelete(seq: number) {
     if (!confirm("정말 삭제하시겠습니까?")) return;
-    const res = await fetch(`/api/admin/sites/${seq}`, { method: "DELETE" });
-    if (!res.ok) {
-      const d = (await res.json()) as { message?: string };
-      alert(d.message ?? "삭제 실패");
-      return;
-    }
-    await purgeSitesCache();
-    await load();
+
+    await runWithBusyMessage("삭제 반영 확인 중입니다...", async () => {
+      const res = await fetch(`/api/admin/sites/${seq}`, { method: "DELETE" });
+      if (!res.ok) {
+        alert(await parseErrorMessage(res, "삭제 실패"));
+        return;
+      }
+
+      await purgeSitesCache();
+      const reflected = await waitForReflection(
+        (items) => !items.some((item) => item.seq === seq),
+      );
+
+      if (!reflected) {
+        setError("삭제 반영 확인이 지연되고 있습니다.");
+      }
+    });
   }
 
   const [purging, setPurging] = useState(false);
@@ -191,15 +344,43 @@ export default function AdminSitesPage() {
     alert("사이트 캐시가 무효화됐습니다.");
   }
 
+  const isProcessing = busyMessage !== null;
+  const rowActionBaseClass =
+    "inline-flex items-center justify-center rounded-md border px-2.5 py-1 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-45";
+  const totalSites = sites.length;
+  const activeSites = sites.filter((site) => site.is_active === 1).length;
+  const inactiveSites = totalSites - activeSites;
+
   return (
-    <div>
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-xl font-semibold">사이트 관리</h1>
-        <div className="flex gap-2">
+    <div className="space-y-5 p-4 admin-content-shell rounded-xl">
+      <div className="px-5 py-4 admin-content-panel rounded-lg">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-xl font-semibold text-gray-900">사이트 관리</h1>
+            <p className="mt-1 text-xs text-gray-500">
+              등록된 사이트 상태를 한 곳에서 관리하고 즉시 반영 여부를 확인합니다.
+            </p>
+          </div>
+          <div className="grid grid-cols-3 gap-2 text-center">
+            <div className="border border-gray-200 bg-gray-50 rounded-lg px-3 py-2">
+              <p className="text-[10px] text-gray-500">전체</p>
+              <p className="text-sm font-semibold text-gray-900">{totalSites}</p>
+            </div>
+            <div className="border border-emerald-200 bg-emerald-50 rounded-lg px-3 py-2">
+              <p className="text-[10px] text-emerald-600">활성</p>
+              <p className="text-sm font-semibold text-emerald-700">{activeSites}</p>
+            </div>
+            <div className="border border-rose-200 bg-rose-50 rounded-lg px-3 py-2">
+              <p className="text-[10px] text-rose-500">비활성</p>
+              <p className="text-sm font-semibold text-rose-600">{inactiveSites}</p>
+            </div>
+          </div>
+        </div>
+        <div className="mt-4 flex flex-wrap gap-2">
           <button
             onClick={handlePurge}
-            disabled={purging}
-            className="text-sm bg-gray-700 hover:bg-gray-600 disabled:opacity-50 text-gray-300 px-3 py-2 rounded transition-colors"
+            disabled={purging || isProcessing}
+            className="text-sm border border-gray-300 bg-white hover:bg-gray-50 disabled:opacity-50 text-gray-700 px-3 py-2 rounded-lg transition-colors"
             title="Redis 사이트 캐시 즉시 삭제"
           >
             {purging ? "처리 중..." : "새로고침"}
@@ -211,7 +392,8 @@ export default function AdminSitesPage() {
               setForm(EMPTY_FORM);
               setFormError("");
             }}
-            className="text-sm bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded transition-colors"
+            disabled={isProcessing}
+            className="text-sm border border-blue-600 bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors"
           >
             + 사이트 추가
           </button>
@@ -221,19 +403,20 @@ export default function AdminSitesPage() {
       {/* 모달 */}
       {showForm && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
           onClick={(e) => {
-            if (e.target === e.currentTarget) cancelEdit();
+            if (!isProcessing && e.target === e.currentTarget) cancelEdit();
           }}
         >
-          <div className="bg-gray-900 border border-gray-700 rounded-xl p-6 w-full max-w-2xl shadow-2xl">
+          <div className="bg-white border border-gray-200 rounded-xl p-6 w-full max-w-2xl shadow-2xl">
             <div className="flex items-center justify-between mb-4">
-              <h2 className="text-sm font-semibold text-white">
+              <h2 className="text-sm font-semibold text-gray-900">
                 {editingId ? `사이트 수정 — #${editingId}` : "새 사이트 추가"}
               </h2>
               <button
                 onClick={cancelEdit}
-                className="text-gray-500 hover:text-gray-300 text-lg leading-none"
+                disabled={isProcessing}
+                className="text-gray-400 hover:text-gray-600 text-lg leading-none"
               >
                 ✕
               </button>
@@ -249,34 +432,36 @@ export default function AdminSitesPage() {
                       key={field}
                       className={field === "description" ? "col-span-2" : ""}
                     >
-                      <label className="block text-xs text-gray-400 mb-1 capitalize">
+                      <label className="block text-xs text-gray-600 mb-1 capitalize">
                         {field}
                       </label>
                       <input
                         type="text"
                         value={form[field]}
+                        disabled={isProcessing}
                         onChange={(e) =>
                           setForm((p) => ({ ...p, [field]: e.target.value }))
                         }
-                        className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-sm text-white focus:outline-none focus:border-indigo-500"
+                        className="w-full bg-white border border-gray-300 rounded-lg px-3 py-1.5 text-sm text-gray-900 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
                       />
                     </div>
                   ))}
                 </div>
                 {formError && (
-                  <p className="text-red-400 text-xs mt-2">{formError}</p>
+                  <p className="text-red-500 text-xs mt-2">{formError}</p>
                 )}
                 <div className="flex gap-2 mt-5">
                   <button
                     onClick={handleSave}
-                    disabled={saving}
-                    className="bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white text-sm px-4 py-1.5 rounded transition-colors"
+                    disabled={saving || isProcessing}
+                    className="bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white text-sm px-4 py-1.5 rounded-lg transition-colors"
                   >
                     {saving ? "저장 중..." : "저장"}
                   </button>
                   <button
                     onClick={cancelEdit}
-                    className="text-gray-400 hover:text-gray-200 text-sm px-4 py-1.5 rounded transition-colors"
+                    disabled={isProcessing}
+                    className="text-gray-500 hover:text-gray-700 border border-gray-300 bg-white text-sm px-4 py-1.5 rounded-lg transition-colors"
                   >
                     취소
                   </button>
@@ -285,7 +470,7 @@ export default function AdminSitesPage() {
 
               {/* 카드 미리보기 */}
               <div className="w-52 shrink-0">
-                <p className="text-xs text-gray-500 mb-2">미리보기</p>
+                <p className="text-xs text-gray-400 mb-2">미리보기</p>
                 <SiteCardPreview form={form} />
               </div>
             </div>
@@ -293,77 +478,103 @@ export default function AdminSitesPage() {
         </div>
       )}
 
-      {error && <p className="text-red-400 text-sm mb-4">{error}</p>}
+      {error && (
+        <div className="border border-red-200 bg-red-50 rounded-lg px-3 py-2">
+          <p className="text-sm text-red-600">{error}</p>
+        </div>
+      )}
       {loading ? (
-        <p className="text-gray-500 text-sm">불러오는 중...</p>
+        <div className="px-4 py-8 text-center admin-content-panel rounded-lg">
+          <p className="text-sm text-gray-400">불러오는 중...</p>
+        </div>
       ) : (
-        <div className="overflow-x-auto">
+        <div className="overflow-x-auto admin-content-table rounded-xl shadow-sm">
           <table className="w-full text-sm">
             <thead>
-              <tr className="border-b border-gray-800 text-gray-400 text-left">
-                <th className="py-2 pr-4 w-10">#</th>
-                <th className="py-2 pr-4">이름</th>
-                <th className="py-2 pr-4">URL</th>
-                <th className="py-2 pr-4">설명</th>
-                <th className="py-2 pr-4">카테고리</th>
-                <th className="py-2 pr-4">활성</th>
-                <th className="py-2">액션</th>
+              <tr className="border-b border-gray-200 text-gray-600 text-center">
+                <th className="py-3 pr-4 w-10 font-medium">#</th>
+                <th className="py-3 pr-4 font-medium">이름</th>
+                <th className="py-3 pr-4 font-medium">URL</th>
+                <th className="py-3 pr-4 font-medium">설명</th>
+                <th className="py-3 pr-4 font-medium">카테고리</th>
+                <th className="py-3 pr-4 font-medium">활성</th>
+                <th className="py-3 font-medium">액션</th>
               </tr>
             </thead>
-            <tbody>
+            <tbody className="divide-y divide-gray-100">
               {sites.map((site) => (
                 <tr
                   key={site.seq}
-                  className="border-b border-gray-800/50 hover:bg-gray-900/40"
+                  className="hover:bg-gray-50 transition-colors"
                 >
-                  <td className="py-2 pr-4 text-gray-500">{site.seq}</td>
-                  <td className="py-2 pr-4 text-white">{site.name}</td>
-                  <td className="py-2 pr-4">
+                  <td className="py-3 pr-4 text-center text-gray-400">{site.seq}</td>
+                  <td className="py-3 pr-4 text-center text-gray-900 font-medium">{site.name}</td>
+                  <td className="py-3 pr-4">
                     <a
                       href={site.href}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="text-indigo-400 hover:underline truncate max-w-xs block"
+                      className="mx-auto block max-w-xs truncate text-center text-blue-600 hover:text-blue-700 hover:underline"
                     >
                       {site.href}
                     </a>
                   </td>
-                  <td className="py-2 pr-4 text-gray-400">
+                  <td className="py-3 pr-4 text-center text-gray-600">
                     {site.description ?? "-"}
                   </td>
-                  <td className="py-2 pr-4 text-gray-400">
-                    {site.category ?? "-"}
+                  <td className="py-3 pr-4 text-center text-gray-600">
+                    {site.category ? (
+                      <span className="inline-flex items-center justify-center border border-gray-200 bg-gray-100 rounded-full px-2 py-0.5 text-xs text-gray-700">
+                        {site.category}
+                      </span>
+                    ) : (
+                      "-"
+                    )}
                   </td>
-                  <td className="py-2 pr-4">
+                  <td className="py-3 pr-4 text-center">
                     <button
                       onClick={() => handleToggleActive(site)}
-                      className={`text-xs px-2 py-0.5 rounded ${
+                      disabled={isProcessing}
+                      className={`${rowActionBaseClass} min-w-[64px] ${
                         site.is_active
-                          ? "bg-green-900/50 text-green-400"
-                          : "bg-gray-800 text-gray-500"
+                          ? "border-emerald-200 bg-emerald-50 text-emerald-700 hover:bg-emerald-100"
+                          : "border-gray-200 bg-gray-50 text-gray-500 hover:bg-gray-100"
                       }`}
                     >
                       {site.is_active ? "활성" : "비활성"}
                     </button>
                   </td>
-                  <td className="py-2 flex gap-2">
-                    <button
-                      onClick={() => startEdit(site)}
-                      className="text-xs text-indigo-400 hover:text-indigo-300"
-                    >
-                      수정
-                    </button>
-                    <button
-                      onClick={() => handleDelete(site.seq)}
-                      className="text-xs text-red-400 hover:text-red-300"
-                    >
-                      삭제
-                    </button>
+                  <td className="py-3">
+                    <div className="flex justify-center gap-2">
+                      <button
+                        onClick={() => startEdit(site)}
+                        disabled={isProcessing}
+                        className={`${rowActionBaseClass} border-blue-200 bg-blue-50 text-blue-700 hover:bg-blue-100`}
+                      >
+                        수정
+                      </button>
+                      <button
+                        onClick={() => handleDelete(site.seq)}
+                        disabled={isProcessing}
+                        className={`${rowActionBaseClass} border-red-200 bg-red-50 text-red-600 hover:bg-red-100`}
+                      >
+                        삭제
+                      </button>
+                    </div>
                   </td>
                 </tr>
               ))}
             </tbody>
           </table>
+        </div>
+      )}
+
+      {isProcessing && (
+        <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40">
+          <div className="rounded-xl border border-gray-200 bg-white px-6 py-5 text-center shadow-2xl">
+            <p className="text-sm font-semibold text-gray-900">처리중입니다...</p>
+            <p className="mt-1 text-xs text-gray-500">{busyMessage}</p>
+          </div>
         </div>
       )}
     </div>

--- a/client/app/admin/sites/page.tsx
+++ b/client/app/admin/sites/page.tsx
@@ -35,7 +35,7 @@ function SiteCardPreview({ form }: { form: typeof EMPTY_FORM }) {
   })();
 
   return (
-    <div className="relative flex flex-col rounded-xl border border-gray-200 bg-gray-50 p-3 min-h-[80px]">
+    <div className="relative flex flex-col rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] p-3 min-h-[80px]">
       <div className="flex items-start justify-between gap-2 pr-1">
         <div className="flex min-w-0 items-center gap-1.5">
           {iconSrc && (
@@ -48,16 +48,22 @@ function SiteCardPreview({ form }: { form: typeof EMPTY_FORM }) {
               className="shrink-0 rounded-sm"
             />
           )}
-          <span className="truncate font-semibold text-gray-900 text-sm">
-            {form.name || <span className="text-gray-400">이름</span>}
+          <span className="truncate font-semibold text-[color:var(--admin-text)] text-sm">
+            {form.name || (
+              <span className="text-[color:var(--admin-text-subtle)]">
+                이름
+              </span>
+            )}
           </span>
         </div>
-        <span className="shrink-0 rounded-full px-2 py-0.5 text-xs text-gray-600 bg-gray-100 border border-gray-200">
+        <span className="admin-badge admin-badge-neutral">
           {form.category || "카테고리"}
         </span>
       </div>
-      <p className="mt-1.5 text-xs text-gray-600 line-clamp-2">
-        {form.description || <span className="text-gray-400">설명</span>}
+      <p className="mt-1.5 text-xs text-[color:var(--admin-text-muted)] line-clamp-2">
+        {form.description || (
+          <span className="text-[color:var(--admin-text-subtle)]">설명</span>
+        )}
       </p>
     </div>
   );
@@ -345,45 +351,28 @@ export default function AdminSitesPage() {
   }
 
   const isProcessing = busyMessage !== null;
-  const rowActionBaseClass =
-    "inline-flex items-center justify-center rounded-md border px-2.5 py-1 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-45";
   const totalSites = sites.length;
   const activeSites = sites.filter((site) => site.is_active === 1).length;
   const inactiveSites = totalSites - activeSites;
 
   return (
-    <div className="space-y-5 p-4 admin-content-shell rounded-xl">
-      <div className="px-5 py-4 admin-content-panel rounded-lg">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <h1 className="text-xl font-semibold text-gray-900">사이트 관리</h1>
-            <p className="mt-1 text-xs text-gray-500">
-              등록된 사이트 상태를 한 곳에서 관리하고 즉시 반영 여부를 확인합니다.
-            </p>
-          </div>
-          <div className="grid grid-cols-3 gap-2 text-center">
-            <div className="border border-gray-200 bg-gray-50 rounded-lg px-3 py-2">
-              <p className="text-[10px] text-gray-500">전체</p>
-              <p className="text-sm font-semibold text-gray-900">{totalSites}</p>
-            </div>
-            <div className="border border-emerald-200 bg-emerald-50 rounded-lg px-3 py-2">
-              <p className="text-[10px] text-emerald-600">활성</p>
-              <p className="text-sm font-semibold text-emerald-700">{activeSites}</p>
-            </div>
-            <div className="border border-rose-200 bg-rose-50 rounded-lg px-3 py-2">
-              <p className="text-[10px] text-rose-500">비활성</p>
-              <p className="text-sm font-semibold text-rose-600">{inactiveSites}</p>
-            </div>
-          </div>
+    <div>
+      {/* 헤더 */}
+      <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4 mb-6">
+        <div>
+          <h1 className="admin-page-title">사이트 관리</h1>
+          <p className="admin-page-subtitle mt-1">
+            등록된 사이트 상태를 관리하고 즉시 반영 여부를 확인합니다.
+          </p>
         </div>
-        <div className="mt-4 flex flex-wrap gap-2">
+        <div className="flex gap-2">
           <button
             onClick={handlePurge}
             disabled={purging || isProcessing}
-            className="text-sm border border-gray-300 bg-white hover:bg-gray-50 disabled:opacity-50 text-gray-700 px-3 py-2 rounded-lg transition-colors"
+            className="admin-btn admin-btn-secondary"
             title="Redis 사이트 캐시 즉시 삭제"
           >
-            {purging ? "처리 중..." : "새로고침"}
+            {purging ? "처리 중..." : "캐시 새로고침"}
           </button>
           <button
             onClick={() => {
@@ -393,30 +382,50 @@ export default function AdminSitesPage() {
               setFormError("");
             }}
             disabled={isProcessing}
-            className="text-sm border border-blue-600 bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors"
+            className="admin-btn admin-btn-primary"
           >
             + 사이트 추가
           </button>
         </div>
       </div>
 
+      {/* 통계 카드 */}
+      <div className="grid grid-cols-3 gap-4 mb-6">
+        <div className="admin-stat-card">
+          <p className="admin-stat-label">전체 사이트</p>
+          <p className="admin-stat-value mt-1">{totalSites}</p>
+        </div>
+        <div className="admin-stat-card">
+          <p className="admin-stat-label">활성</p>
+          <p className="admin-stat-value mt-1 text-emerald-600">
+            {activeSites}
+          </p>
+        </div>
+        <div className="admin-stat-card">
+          <p className="admin-stat-label">비활성</p>
+          <p className="admin-stat-value mt-1 text-gray-400">
+            {inactiveSites}
+          </p>
+        </div>
+      </div>
+
       {/* 모달 */}
       {showForm && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          className="admin-modal-overlay"
           onClick={(e) => {
             if (!isProcessing && e.target === e.currentTarget) cancelEdit();
           }}
         >
-          <div className="bg-white border border-gray-200 rounded-xl p-6 w-full max-w-2xl shadow-2xl">
-            <div className="flex items-center justify-between mb-4">
-              <h2 className="text-sm font-semibold text-gray-900">
-                {editingId ? `사이트 수정 — #${editingId}` : "새 사이트 추가"}
+          <div className="admin-modal w-full max-w-2xl p-6">
+            <div className="flex items-center justify-between mb-5">
+              <h2 className="text-base font-semibold text-[color:var(--admin-text)]">
+                {editingId ? `사이트 수정 · #${editingId}` : "새 사이트 추가"}
               </h2>
               <button
                 onClick={cancelEdit}
                 disabled={isProcessing}
-                className="text-gray-400 hover:text-gray-600 text-lg leading-none"
+                className="text-[color:var(--admin-text-subtle)] hover:text-[color:var(--admin-text)] text-lg leading-none"
               >
                 ✕
               </button>
@@ -432,9 +441,7 @@ export default function AdminSitesPage() {
                       key={field}
                       className={field === "description" ? "col-span-2" : ""}
                     >
-                      <label className="block text-xs text-gray-600 mb-1 capitalize">
-                        {field}
-                      </label>
+                      <label className="admin-label capitalize">{field}</label>
                       <input
                         type="text"
                         value={form[field]}
@@ -442,7 +449,7 @@ export default function AdminSitesPage() {
                         onChange={(e) =>
                           setForm((p) => ({ ...p, [field]: e.target.value }))
                         }
-                        className="w-full bg-white border border-gray-300 rounded-lg px-3 py-1.5 text-sm text-gray-900 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+                        className="admin-input"
                       />
                     </div>
                   ))}
@@ -454,14 +461,14 @@ export default function AdminSitesPage() {
                   <button
                     onClick={handleSave}
                     disabled={saving || isProcessing}
-                    className="bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white text-sm px-4 py-1.5 rounded-lg transition-colors"
+                    className="admin-btn admin-btn-primary"
                   >
                     {saving ? "저장 중..." : "저장"}
                   </button>
                   <button
                     onClick={cancelEdit}
                     disabled={isProcessing}
-                    className="text-gray-500 hover:text-gray-700 border border-gray-300 bg-white text-sm px-4 py-1.5 rounded-lg transition-colors"
+                    className="admin-btn admin-btn-secondary"
                   >
                     취소
                   </button>
@@ -470,7 +477,9 @@ export default function AdminSitesPage() {
 
               {/* 카드 미리보기 */}
               <div className="w-52 shrink-0">
-                <p className="text-xs text-gray-400 mb-2">미리보기</p>
+                <p className="text-xs text-[color:var(--admin-text-muted)] mb-2 font-medium">
+                  미리보기
+                </p>
                 <SiteCardPreview form={form} />
               </div>
             </div>
@@ -479,101 +488,112 @@ export default function AdminSitesPage() {
       )}
 
       {error && (
-        <div className="border border-red-200 bg-red-50 rounded-lg px-3 py-2">
+        <div className="admin-card mb-4 px-4 py-3 border-red-200 bg-red-50">
           <p className="text-sm text-red-600">{error}</p>
         </div>
       )}
       {loading ? (
-        <div className="px-4 py-8 text-center admin-content-panel rounded-lg">
-          <p className="text-sm text-gray-400">불러오는 중...</p>
+        <div className="admin-card admin-card-padded text-center">
+          <p className="text-sm text-[color:var(--admin-text-muted)]">
+            불러오는 중...
+          </p>
         </div>
       ) : (
-        <div className="overflow-x-auto admin-content-table rounded-xl shadow-sm">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-gray-200 text-gray-600 text-center">
-                <th className="py-3 pr-4 w-10 font-medium">#</th>
-                <th className="py-3 pr-4 font-medium">이름</th>
-                <th className="py-3 pr-4 font-medium">URL</th>
-                <th className="py-3 pr-4 font-medium">설명</th>
-                <th className="py-3 pr-4 font-medium">카테고리</th>
-                <th className="py-3 pr-4 font-medium">활성</th>
-                <th className="py-3 font-medium">액션</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-100">
-              {sites.map((site) => (
-                <tr
-                  key={site.seq}
-                  className="hover:bg-gray-50 transition-colors"
-                >
-                  <td className="py-3 pr-4 text-center text-gray-400">{site.seq}</td>
-                  <td className="py-3 pr-4 text-center text-gray-900 font-medium">{site.name}</td>
-                  <td className="py-3 pr-4">
-                    <a
-                      href={site.href}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="mx-auto block max-w-xs truncate text-center text-blue-600 hover:text-blue-700 hover:underline"
-                    >
-                      {site.href}
-                    </a>
-                  </td>
-                  <td className="py-3 pr-4 text-center text-gray-600">
-                    {site.description ?? "-"}
-                  </td>
-                  <td className="py-3 pr-4 text-center text-gray-600">
-                    {site.category ? (
-                      <span className="inline-flex items-center justify-center border border-gray-200 bg-gray-100 rounded-full px-2 py-0.5 text-xs text-gray-700">
-                        {site.category}
-                      </span>
-                    ) : (
-                      "-"
-                    )}
-                  </td>
-                  <td className="py-3 pr-4 text-center">
-                    <button
-                      onClick={() => handleToggleActive(site)}
-                      disabled={isProcessing}
-                      className={`${rowActionBaseClass} min-w-[64px] ${
-                        site.is_active
-                          ? "border-emerald-200 bg-emerald-50 text-emerald-700 hover:bg-emerald-100"
-                          : "border-gray-200 bg-gray-50 text-gray-500 hover:bg-gray-100"
-                      }`}
-                    >
-                      {site.is_active ? "활성" : "비활성"}
-                    </button>
-                  </td>
-                  <td className="py-3">
-                    <div className="flex justify-center gap-2">
-                      <button
-                        onClick={() => startEdit(site)}
-                        disabled={isProcessing}
-                        className={`${rowActionBaseClass} border-blue-200 bg-blue-50 text-blue-700 hover:bg-blue-100`}
-                      >
-                        수정
-                      </button>
-                      <button
-                        onClick={() => handleDelete(site.seq)}
-                        disabled={isProcessing}
-                        className={`${rowActionBaseClass} border-red-200 bg-red-50 text-red-600 hover:bg-red-100`}
-                      >
-                        삭제
-                      </button>
-                    </div>
-                  </td>
+        <div className="admin-card overflow-hidden">
+          <div className="overflow-x-auto">
+            <table className="admin-table">
+              <thead>
+                <tr>
+                  <th className="w-12 text-center">#</th>
+                  <th>이름</th>
+                  <th>URL</th>
+                  <th>설명</th>
+                  <th>카테고리</th>
+                  <th className="text-center">활성</th>
+                  <th className="text-center">액션</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {sites.map((site) => (
+                  <tr key={site.seq}>
+                    <td className="text-center text-[color:var(--admin-text-subtle)] tabular-nums">
+                      {site.seq}
+                    </td>
+                    <td className="font-medium">{site.name}</td>
+                    <td>
+                      <a
+                        href={site.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="block max-w-xs truncate text-blue-600 hover:text-blue-700 hover:underline"
+                      >
+                        {site.href}
+                      </a>
+                    </td>
+                    <td className="text-[color:var(--admin-text-muted)] max-w-xs truncate">
+                      {site.description ?? "-"}
+                    </td>
+                    <td>
+                      {site.category ? (
+                        <span
+                          className={`admin-badge ${getCategoryTone(site.category)}`}
+                        >
+                          {site.category}
+                        </span>
+                      ) : (
+                        <span className="text-[color:var(--admin-text-subtle)]">
+                          -
+                        </span>
+                      )}
+                    </td>
+                    <td className="text-center">
+                      <button
+                        onClick={() => handleToggleActive(site)}
+                        disabled={isProcessing}
+                        className={`admin-badge ${
+                          site.is_active
+                            ? "admin-badge-success cursor-pointer"
+                            : "admin-badge-neutral cursor-pointer"
+                        }`}
+                      >
+                        {site.is_active ? "활성" : "비활성"}
+                      </button>
+                    </td>
+                    <td>
+                      <div className="flex justify-center gap-2">
+                        <button
+                          onClick={() => startEdit(site)}
+                          disabled={isProcessing}
+                          className="admin-btn admin-btn-sm admin-btn-secondary"
+                        >
+                          수정
+                        </button>
+                        <button
+                          onClick={() => handleDelete(site.seq)}
+                          disabled={isProcessing}
+                          className="admin-btn admin-btn-sm admin-btn-danger"
+                        >
+                          삭제
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </div>
       )}
 
       {isProcessing && (
-        <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40">
-          <div className="rounded-xl border border-gray-200 bg-white px-6 py-5 text-center shadow-2xl">
-            <p className="text-sm font-semibold text-gray-900">처리중입니다...</p>
-            <p className="mt-1 text-xs text-gray-500">{busyMessage}</p>
+        <div className="admin-modal-overlay">
+          <div className="admin-modal px-6 py-5 text-center">
+            <p className="text-sm font-semibold text-[color:var(--admin-text)]">
+              처리중입니다...
+            </p>
+            <p className="mt-1 text-xs text-[color:var(--admin-text-muted)]">
+              {busyMessage}
+            </p>
           </div>
         </div>
       )}

--- a/client/app/admin/youtube/page.tsx
+++ b/client/app/admin/youtube/page.tsx
@@ -1,4 +1,4 @@
-﻿"use client";
+"use client";
 
 import { useEffect, useMemo, useState } from "react";
 import {
@@ -11,7 +11,7 @@ import {
 } from "recharts";
 import type { YoutubeVideo } from "@/types";
 
-// ?�?�?� ?�틸 ?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�
+// ===== 유틸 =====
 
 function parseDurationSec(dur: string): number {
   const parts = dur.split(":").map(Number);
@@ -24,19 +24,19 @@ function formatRelativeDate(iso: string) {
   const diff = Math.floor(
     (Date.now() - new Date(iso).getTime()) / (1000 * 60 * 60 * 24),
   );
-  if (diff === 0) return "?�늘";
-  if (diff === 1) return "?�제";
-  return `${diff}????;
+  if (diff === 0) return "오늘";
+  if (diff === 1) return "어제";
+  return `${diff}일 전`;
 }
 
 function formatViews(n: number) {
-  if (n >= 100_000_000) return `${(n / 100_000_000).toFixed(1)}?�회`;
+  if (n >= 100_000_000) return `${(n / 100_000_000).toFixed(1)}억회`;
   if (n >= 10_000) return `${(n / 10_000).toFixed(1)}만회`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}천회`;
-  return `${n.toLocaleString()}??;
+  return `${n.toLocaleString()}회`;
 }
 
-// ?�?�?� ?�렬 ?�수 ?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�
+// ===== 정렬 =====
 
 type ViewSort = "default" | "views_asc" | "views_desc";
 type DurSort = "default" | "dur_asc" | "dur_desc";
@@ -45,22 +45,22 @@ const VIEW_CYCLE: ViewSort[] = ["default", "views_asc", "views_desc"];
 const DUR_CYCLE: DurSort[] = ["default", "dur_asc", "dur_desc"];
 
 const VIEW_LABEL: Record<ViewSort, string> = {
-  default: "조회??,
-  views_asc: "조회????,
-  views_desc: "조회????,
+  default: "조회수",
+  views_asc: "조회수 ↑",
+  views_desc: "조회수 ↓",
 };
 const DUR_LABEL: Record<DurSort, string> = {
   default: "길이",
-  dur_asc: "길이 ??,
-  dur_desc: "길이 ??,
+  dur_asc: "길이 ↑",
+  dur_desc: "길이 ↓",
 };
 
-// ?�?�?� 그래??컴포?�트 ?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�
+// ===== Bar Chart =====
 
 function BarChart({
   title,
   data,
-  color = "bg-indigo-500",
+  color = "bg-blue-500",
 }: {
   title: string;
   data: { label: string; value: number }[];
@@ -69,20 +69,22 @@ function BarChart({
   const max = Math.max(...data.map((d) => d.value), 1);
   return (
     <div>
-      <p className="text-xs font-medium text-gray-500 mb-2">{title}</p>
-      <div className="space-y-1.5">
+      <p className="text-xs font-semibold text-[color:var(--admin-text-muted)] mb-3 uppercase tracking-wide">
+        {title}
+      </p>
+      <div className="space-y-2">
         {data.map((d) => (
           <div key={d.label} className="flex items-center gap-2">
-            <span className="text-xs text-gray-500 w-16 shrink-0 text-right leading-none">
+            <span className="text-xs text-[color:var(--admin-text-muted)] w-16 shrink-0 text-right leading-none truncate">
               {d.label}
             </span>
-            <div className="flex-1 bg-gray-200 rounded-full h-4 overflow-hidden">
+            <div className="flex-1 bg-gray-100 rounded-full h-2.5 overflow-hidden">
               <div
                 className={`${color} h-full rounded-full transition-all duration-500`}
                 style={{ width: `${(d.value / max) * 100}%` }}
               />
             </div>
-            <span className="text-xs text-gray-500 tabular-nums w-6 text-right">
+            <span className="text-xs text-[color:var(--admin-text)] font-medium tabular-nums w-6 text-right">
               {d.value}
             </span>
           </div>
@@ -92,7 +94,7 @@ function BarChart({
   );
 }
 
-// ?�?�?� 메인 ?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�
+// ===== Main =====
 
 export default function AdminYoutubePage() {
   const [items, setItems] = useState<YoutubeVideo[]>([]);
@@ -210,7 +212,6 @@ export default function AdminYoutubePage() {
     }
   }
 
-  // ?�렬??목록
   const filtered = useMemo(() => {
     const arr = [...items];
     if (viewSort === "views_asc")
@@ -228,22 +229,18 @@ export default function AdminYoutubePage() {
     return arr;
   }, [items, viewSort, durSort]);
 
-  // ?�체 ?�계 (?�터 무�?)
   const stats = useMemo(() => {
     if (items.length === 0) return null;
 
-    // 길이 구간 분포
     const durBuckets = [
-      { label: "~10�?, count: 0 },
-      { label: "10~20�?, count: 0 },
-      { label: "20~30�?, count: 0 },
-      { label: "30�?", count: 0 },
+      { label: "~10분", count: 0 },
+      { label: "10~20분", count: 0 },
+      { label: "20~30분", count: 0 },
+      { label: "30분+", count: 0 },
     ];
-    // 채널�?집계
     const channelMap = new Map<string, number>();
 
     for (const v of items) {
-      // 길이 버킷
       const sec = parseDurationSec(v.duration);
       if (sec < 600) durBuckets[0].count++;
       else if (sec < 1200) durBuckets[1].count++;
@@ -261,166 +258,172 @@ export default function AdminYoutubePage() {
     return { durBuckets, topChannels };
   }, [items]);
 
+  const sortButtonClass = (active: boolean) =>
+    `admin-btn admin-btn-sm ${active ? "admin-btn-primary" : "admin-btn-secondary"}`;
+
   return (
     <div
       className="flex flex-col h-full"
       style={{ maxHeight: "calc(100vh - 64px)" }}
     >
-      {/* ?�?� ?�더 ?�?� */}
-      <div className="flex items-center justify-between mb-3 shrink-0">
-        <div className="flex items-center gap-3">
-          <h1 className="text-xl font-semibold">?�튜�??�기 ?�상</h1>
-          {total !== null && (
-            <span className="text-xs text-gray-500">�?{total}�?/span>
-          )}
+      {/* 헤더 */}
+      <div className="flex items-end justify-between mb-5 shrink-0">
+        <div>
+          <h1 className="admin-page-title">유튜브 인기 영상</h1>
+          <p className="admin-page-subtitle mt-1">
+            {total !== null
+              ? `총 ${total}개의 인기 영상이 캐시되어 있습니다.`
+              : "캐시된 영상 목록을 확인합니다."}
+          </p>
         </div>
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2">
           {purgeResult === "done" && (
-            <span className="text-xs text-green-600">??캐시 ??�� ?�료</span>
+            <span className="text-xs text-emerald-600">✓ 캐시 삭제 완료</span>
           )}
           {purgeResult === "error" && (
-            <span className="text-xs text-red-500">???�류</span>
+            <span className="text-xs text-red-500">✗ 오류</span>
           )}
           {snapshotResult === "done" && (
-            <span className="text-xs text-green-600">???�냅???�???�료</span>
+            <span className="text-xs text-emerald-600">✓ 스냅샷 저장 완료</span>
           )}
           {snapshotResult === "empty" && (
-            <span className="text-xs text-yellow-600">??캐시 ?�음</span>
+            <span className="text-xs text-amber-600">⚠ 캐시 없음</span>
           )}
           {snapshotResult === "error" && (
-            <span className="text-xs text-red-500">???�냅???�류</span>
+            <span className="text-xs text-red-500">✗ 스냅샷 오류</span>
           )}
           <button
             onClick={handleSnapshot}
             disabled={snapshotting}
-            className="text-sm bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white px-3 py-1.5 rounded-lg transition-colors"
-            title="?�재 Redis 캐시???�기 ?�상 조회?��? DB??즉시 ?�냅???�??(UPSERT)"
+            className="admin-btn admin-btn-primary"
+            title="현재 Redis 캐시의 인기 영상 조회수를 DB에 즉시 스냅샷 저장 (UPSERT)"
           >
-            {snapshotting ? "?�??�?.." : "?�냅???�??}
+            {snapshotting ? "저장 중..." : "스냅샷 저장"}
           </button>
           <button
             onClick={handlePurge}
             disabled={purging}
-            className="text-sm border border-gray-300 bg-white hover:bg-gray-50 disabled:opacity-50 text-gray-700 px-3 py-1.5 rounded-lg transition-colors"
+            className="admin-btn admin-btn-secondary"
           >
-            {purging ? "처리 �?.." : "?�로고침"}
+            {purging ? "처리 중..." : "캐시 새로고침"}
           </button>
         </div>
       </div>
 
-      {/* ?�?� ?�렬 �??�?� */}
-      <div className="flex items-center gap-2 mb-3 shrink-0">
-        <span className="text-xs text-gray-500 mr-1">게시?�순</span>
-        <span className="text-xs text-gray-300">|</span>
-        <button
-          onClick={cycleView}
-          className={`text-xs px-2.5 py-1 rounded border transition-colors ${
-            viewSort !== "default"
-              ? "bg-blue-600 border-blue-600 text-white"
-              : "bg-white border-gray-300 text-gray-500 hover:border-gray-400"
-          }`}
-        >
-          {VIEW_LABEL[viewSort]}
-        </button>
-        <button
-          onClick={cycleDur}
-          className={`text-xs px-2.5 py-1 rounded border transition-colors ${
-            durSort !== "default"
-              ? "bg-blue-600 border-blue-600 text-white"
-              : "bg-white border-gray-300 text-gray-500 hover:border-gray-400"
-          }`}
-        >
-          {DUR_LABEL[durSort]}
-        </button>
+      {/* 정렬 바 */}
+      <div className="admin-card admin-card-padded mb-4 shrink-0">
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-[color:var(--admin-text-muted)] mr-2 font-medium">
+            정렬:
+          </span>
+          <button
+            onClick={cycleView}
+            className={sortButtonClass(viewSort !== "default")}
+          >
+            {VIEW_LABEL[viewSort]}
+          </button>
+          <button
+            onClick={cycleDur}
+            className={sortButtonClass(durSort !== "default")}
+          >
+            {DUR_LABEL[durSort]}
+          </button>
+          <span className="text-xs text-[color:var(--admin-text-subtle)] ml-auto">
+            게시일 기준 정렬 (기본)
+          </span>
+        </div>
       </div>
 
-      {/* ?�?� 본문: 목록 + ?�계 ?�?� */}
+      {/* 본문: 목록 + 통계 */}
       <div className="flex flex-1 gap-5 min-h-0">
-        {/* ?�쪽: ?�상 목록 */}
-        <div className="flex flex-col flex-1 min-w-0 min-h-0">
-          <div className="flex-1 overflow-y-auto pr-0.5">
+        {/* 좌측: 영상 목록 */}
+        <div className="admin-card flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden">
+          <div className="flex-1 overflow-y-auto">
             {loading ? (
-              <div className="text-sm text-gray-400 py-8 text-center">
-                불러?�는 �?..
+              <div className="text-sm text-[color:var(--admin-text-muted)] py-12 text-center">
+                불러오는 중...
               </div>
             ) : filtered.length === 0 ? (
-              <div className="text-sm text-gray-400 py-8 text-center">
-                ?�당?�는 ?�상???�습?�다.
+              <div className="text-sm text-[color:var(--admin-text-muted)] py-12 text-center">
+                해당하는 영상이 없습니다.
               </div>
             ) : (
-              filtered.map((v, i) => (
-                <a
-                  key={v.videoId}
-                  href={`https://www.youtube.com/watch?v=${v.videoId}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className={`flex items-center gap-3 px-3 py-2 hover:bg-gray-50 transition-colors rounded-lg ${i % 2 === 0 ? "bg-gray-50" : "bg-white"}`}
-                >
-                  <div className="w-24 shrink-0 aspect-video bg-gray-200 rounded overflow-hidden">
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img
-                      src={v.thumbnailUrl}
-                      alt={v.title}
-                      className="w-full h-full object-cover"
-                    />
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm text-gray-900 leading-snug line-clamp-2 break-keep">
-                      {v.title}
-                    </p>
-                    <div className="flex items-center mt-1">
-                      <span className="text-xs text-blue-600 w-28 shrink-0 truncate">
-                        {v.channelTitle}
-                      </span>
-                      <span className="text-xs text-gray-400 w-14 shrink-0 tabular-nums">
-                        {formatRelativeDate(v.publishedAt)}
-                      </span>
-                      <span className="text-xs text-gray-500 w-16 shrink-0 tabular-nums">
-                        {formatViews(v.viewCount)}
-                      </span>
-                      <span className="text-xs text-gray-400 w-10 shrink-0 tabular-nums">
-                        {v.duration}
-                      </span>
-                    </div>
-                  </div>
-                </a>
-              ))
+              <ul className="divide-y divide-[color:var(--admin-border)]">
+                {filtered.map((v) => (
+                  <li key={v.videoId}>
+                    <a
+                      href={`https://www.youtube.com/watch?v=${v.videoId}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center gap-3 px-4 py-3 hover:bg-[color:var(--admin-surface-muted)] transition-colors"
+                    >
+                      <div className="w-28 shrink-0 aspect-video bg-gray-100 rounded-md overflow-hidden">
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img
+                          src={v.thumbnailUrl}
+                          alt={v.title}
+                          className="w-full h-full object-cover"
+                        />
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm text-[color:var(--admin-text)] font-medium leading-snug line-clamp-2 break-keep">
+                          {v.title}
+                        </p>
+                        <div className="flex items-center gap-3 mt-2 text-xs">
+                          <span className="text-blue-600 truncate max-w-[140px]">
+                            {v.channelTitle}
+                          </span>
+                          <span className="text-[color:var(--admin-text-subtle)]">
+                            {formatRelativeDate(v.publishedAt)}
+                          </span>
+                          <span className="text-[color:var(--admin-text-muted)] tabular-nums">
+                            {formatViews(v.viewCount)}
+                          </span>
+                          <span className="text-[color:var(--admin-text-subtle)] tabular-nums">
+                            {v.duration}
+                          </span>
+                        </div>
+                      </div>
+                    </a>
+                  </li>
+                ))}
+              </ul>
             )}
           </div>
         </div>
 
-        {/* ?�른�? ?�계 그래??*/}
-        <div className="w-72 shrink-0 flex flex-col gap-5 overflow-y-auto">
+        {/* 우측: 통계 */}
+        <div className="w-80 shrink-0 flex flex-col gap-4 overflow-y-auto">
           {loading ? (
-            <div className="text-xs text-gray-400 text-center pt-8">
-              로딩 �?..
+            <div className="admin-card admin-card-padded text-xs text-[color:var(--admin-text-muted)] text-center">
+              로딩 중...
             </div>
           ) : (
             <>
-              {/* ?�짜�??�균 조회??차트 */}
-              <div>
-                <p className="text-xs font-medium text-gray-500 mb-2">
-                  ?�짜�??�균 조회??
+              {/* 평균 조회수 차트 */}
+              <div className="admin-card admin-card-padded">
+                <p className="text-xs font-semibold text-[color:var(--admin-text-muted)] mb-3 uppercase tracking-wide">
+                  날짜별 평균 조회수
                 </p>
-                <div className="flex flex-wrap gap-1 mb-3">
+                <div className="flex flex-wrap gap-1.5 mb-3">
                   {(
                     [
-                      { label: "1??, days: 1 },
-                      { label: "3??, days: 3 },
-                      { label: "7??, days: 7 },
-                      { label: "30??, days: 30 },
-                      { label: "90??, days: 90 },
-                      { label: "150??, days: 150 },
-                      { label: "1??, days: 365 },
+                      { label: "1일", days: 1 },
+                      { label: "3일", days: 3 },
+                      { label: "7일", days: 7 },
+                      { label: "30일", days: 30 },
+                      { label: "90일", days: 90 },
+                      { label: "150일", days: 150 },
+                      { label: "1년", days: 365 },
                     ] as const
                   ).map(({ label, days }) => (
                     <button
                       key={days}
                       onClick={() => setRangeDay(days)}
-                      className={`text-xs px-2 py-0.5 rounded border transition-colors ${
+                      className={`text-xs px-2.5 py-1 rounded-md border transition-colors ${
                         rangeDay === days
                           ? "bg-blue-600 border-blue-600 text-white"
-                          : "bg-white border-gray-300 text-gray-500 hover:border-gray-400"
+                          : "bg-white border-[color:var(--admin-border)] text-[color:var(--admin-text-muted)] hover:border-[color:var(--admin-border-strong)]"
                       }`}
                     >
                       {label}
@@ -428,15 +431,15 @@ export default function AdminYoutubePage() {
                   ))}
                 </div>
                 {historyLoading ? (
-                  <p className="text-xs text-gray-400 text-center py-6">
-                    로딩 �?..
+                  <p className="text-xs text-[color:var(--admin-text-subtle)] text-center py-6">
+                    로딩 중...
                   </p>
                 ) : historyData.length === 0 ? (
-                  <p className="text-xs text-gray-400 text-center py-6">
-                    ?�냅???�이???�음 (갱신 ???�임)
+                  <p className="text-xs text-[color:var(--admin-text-subtle)] text-center py-6">
+                    스냅샷 데이터 없음 (갱신 후 시점)
                   </p>
                 ) : (
-                  <ResponsiveContainer width="100%" height={150}>
+                  <ResponsiveContainer width="100%" height={140}>
                     <AreaChart
                       data={historyData}
                       margin={{ top: 4, right: 4, bottom: 0, left: 0 }}
@@ -451,19 +454,19 @@ export default function AdminYoutubePage() {
                         >
                           <stop
                             offset="5%"
-                            stopColor="#6366f1"
-                            stopOpacity={0.4}
+                            stopColor="#2563eb"
+                            stopOpacity={0.3}
                           />
                           <stop
                             offset="95%"
-                            stopColor="#6366f1"
+                            stopColor="#2563eb"
                             stopOpacity={0}
                           />
                         </linearGradient>
                       </defs>
                       <XAxis
                         dataKey="date"
-                        tick={{ fill: "#6b7280", fontSize: 10 }}
+                        tick={{ fill: "#9ca3af", fontSize: 10 }}
                         axisLine={false}
                         tickLine={false}
                         interval="preserveStartEnd"
@@ -473,9 +476,11 @@ export default function AdminYoutubePage() {
                         content={({ active, payload, label }) => {
                           if (!active || !payload?.length) return null;
                           return (
-                            <div className="bg-white border border-gray-200 shadow rounded-lg px-2 py-1 text-xs">
-                              <p className="text-gray-500">{label}</p>
-                              <p className="text-blue-600">
+                            <div className="bg-white border border-[color:var(--admin-border)] shadow-md rounded-md px-2.5 py-1.5 text-xs">
+                              <p className="text-[color:var(--admin-text-muted)]">
+                                {label}
+                              </p>
+                              <p className="text-blue-600 font-semibold">
                                 {formatViews(payload[0]?.value as number)}
                               </p>
                             </div>
@@ -485,11 +490,11 @@ export default function AdminYoutubePage() {
                       <Area
                         type="monotone"
                         dataKey="avg"
-                        stroke="#6366f1"
+                        stroke="#2563eb"
                         strokeWidth={2}
                         fill="url(#viewGrad)"
                         dot={false}
-                        activeDot={{ r: 3, fill: "#6366f1" }}
+                        activeDot={{ r: 3, fill: "#2563eb" }}
                       />
                     </AreaChart>
                   </ResponsiveContainer>
@@ -498,25 +503,29 @@ export default function AdminYoutubePage() {
 
               {stats && (
                 <>
-                  <BarChart
-                    title="길이 분포"
-                    data={stats.durBuckets.map((b) => ({
-                      label: b.label,
-                      value: b.count,
-                    }))}
-                    color="bg-teal-500"
-                  />
-                  <BarChart
-                    title="채널�?(?�위 6)"
-                    data={stats.topChannels.map((c) => ({
-                      label:
-                        c.label.length > 8
-                          ? c.label.slice(0, 7) + "??
-                          : c.label,
-                      value: c.value,
-                    }))}
-                    color="bg-violet-500"
-                  />
+                  <div className="admin-card admin-card-padded">
+                    <BarChart
+                      title="길이 분포"
+                      data={stats.durBuckets.map((b) => ({
+                        label: b.label,
+                        value: b.count,
+                      }))}
+                      color="bg-teal-500"
+                    />
+                  </div>
+                  <div className="admin-card admin-card-padded">
+                    <BarChart
+                      title="채널별 (상위 6)"
+                      data={stats.topChannels.map((c) => ({
+                        label:
+                          c.label.length > 8
+                            ? c.label.slice(0, 7) + "…"
+                            : c.label,
+                        value: c.value,
+                      }))}
+                      color="bg-violet-500"
+                    />
+                  </div>
                 </>
               )}
             </>

--- a/client/app/admin/youtube/page.tsx
+++ b/client/app/admin/youtube/page.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import { useEffect, useMemo, useState } from "react";
 import {
@@ -11,7 +11,7 @@ import {
 } from "recharts";
 import type { YoutubeVideo } from "@/types";
 
-// ─── 유틸 ─────────────────────────────────────────────────────────────────────
+// ?�?�?� ?�틸 ?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�
 
 function parseDurationSec(dur: string): number {
   const parts = dur.split(":").map(Number);
@@ -24,19 +24,19 @@ function formatRelativeDate(iso: string) {
   const diff = Math.floor(
     (Date.now() - new Date(iso).getTime()) / (1000 * 60 * 60 * 24),
   );
-  if (diff === 0) return "오늘";
-  if (diff === 1) return "어제";
-  return `${diff}일 전`;
+  if (diff === 0) return "?�늘";
+  if (diff === 1) return "?�제";
+  return `${diff}????;
 }
 
 function formatViews(n: number) {
-  if (n >= 100_000_000) return `${(n / 100_000_000).toFixed(1)}억회`;
+  if (n >= 100_000_000) return `${(n / 100_000_000).toFixed(1)}?�회`;
   if (n >= 10_000) return `${(n / 10_000).toFixed(1)}만회`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}천회`;
-  return `${n.toLocaleString()}회`;
+  return `${n.toLocaleString()}??;
 }
 
-// ─── 정렬 상수 ────────────────────────────────────────────────────────────────
+// ?�?�?� ?�렬 ?�수 ?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�
 
 type ViewSort = "default" | "views_asc" | "views_desc";
 type DurSort = "default" | "dur_asc" | "dur_desc";
@@ -45,17 +45,17 @@ const VIEW_CYCLE: ViewSort[] = ["default", "views_asc", "views_desc"];
 const DUR_CYCLE: DurSort[] = ["default", "dur_asc", "dur_desc"];
 
 const VIEW_LABEL: Record<ViewSort, string> = {
-  default: "조회수",
-  views_asc: "조회수 ↑",
-  views_desc: "조회수 ↓",
+  default: "조회??,
+  views_asc: "조회????,
+  views_desc: "조회????,
 };
 const DUR_LABEL: Record<DurSort, string> = {
   default: "길이",
-  dur_asc: "길이 ↑",
-  dur_desc: "길이 ↓",
+  dur_asc: "길이 ??,
+  dur_desc: "길이 ??,
 };
 
-// ─── 그래프 컴포넌트 ──────────────────────────────────────────────────────────
+// ?�?�?� 그래??컴포?�트 ?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�
 
 function BarChart({
   title,
@@ -69,20 +69,20 @@ function BarChart({
   const max = Math.max(...data.map((d) => d.value), 1);
   return (
     <div>
-      <p className="text-xs font-medium text-gray-400 mb-2">{title}</p>
+      <p className="text-xs font-medium text-gray-500 mb-2">{title}</p>
       <div className="space-y-1.5">
         {data.map((d) => (
           <div key={d.label} className="flex items-center gap-2">
             <span className="text-xs text-gray-500 w-16 shrink-0 text-right leading-none">
               {d.label}
             </span>
-            <div className="flex-1 bg-gray-800 rounded-full h-4 overflow-hidden">
+            <div className="flex-1 bg-gray-200 rounded-full h-4 overflow-hidden">
               <div
                 className={`${color} h-full rounded-full transition-all duration-500`}
                 style={{ width: `${(d.value / max) * 100}%` }}
               />
             </div>
-            <span className="text-xs text-gray-400 tabular-nums w-6 text-right">
+            <span className="text-xs text-gray-500 tabular-nums w-6 text-right">
               {d.value}
             </span>
           </div>
@@ -92,7 +92,7 @@ function BarChart({
   );
 }
 
-// ─── 메인 ─────────────────────────────────────────────────────────────────────
+// ?�?�?� 메인 ?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�?�
 
 export default function AdminYoutubePage() {
   const [items, setItems] = useState<YoutubeVideo[]>([]);
@@ -210,7 +210,7 @@ export default function AdminYoutubePage() {
     }
   }
 
-  // 정렬된 목록
+  // ?�렬??목록
   const filtered = useMemo(() => {
     const arr = [...items];
     if (viewSort === "views_asc")
@@ -228,18 +228,18 @@ export default function AdminYoutubePage() {
     return arr;
   }, [items, viewSort, durSort]);
 
-  // 전체 통계 (필터 무관)
+  // ?�체 ?�계 (?�터 무�?)
   const stats = useMemo(() => {
     if (items.length === 0) return null;
 
     // 길이 구간 분포
     const durBuckets = [
-      { label: "~10분", count: 0 },
-      { label: "10~20분", count: 0 },
-      { label: "20~30분", count: 0 },
-      { label: "30분+", count: 0 },
+      { label: "~10�?, count: 0 },
+      { label: "10~20�?, count: 0 },
+      { label: "20~30�?, count: 0 },
+      { label: "30�?", count: 0 },
     ];
-    // 채널별 집계
+    // 채널�?집계
     const channelMap = new Map<string, number>();
 
     for (const v of items) {
@@ -266,58 +266,58 @@ export default function AdminYoutubePage() {
       className="flex flex-col h-full"
       style={{ maxHeight: "calc(100vh - 64px)" }}
     >
-      {/* ── 헤더 ── */}
+      {/* ?�?� ?�더 ?�?� */}
       <div className="flex items-center justify-between mb-3 shrink-0">
         <div className="flex items-center gap-3">
-          <h1 className="text-xl font-semibold">유튜브 인기 영상</h1>
+          <h1 className="text-xl font-semibold">?�튜�??�기 ?�상</h1>
           {total !== null && (
-            <span className="text-xs text-gray-500">총 {total}개</span>
+            <span className="text-xs text-gray-500">�?{total}�?/span>
           )}
         </div>
         <div className="flex items-center gap-3">
           {purgeResult === "done" && (
-            <span className="text-xs text-green-400">✓ 캐시 삭제 완료</span>
+            <span className="text-xs text-green-600">??캐시 ??�� ?�료</span>
           )}
           {purgeResult === "error" && (
-            <span className="text-xs text-red-400">✗ 오류</span>
+            <span className="text-xs text-red-500">???�류</span>
           )}
           {snapshotResult === "done" && (
-            <span className="text-xs text-green-400">✓ 스냅샷 저장 완료</span>
+            <span className="text-xs text-green-600">???�냅???�???�료</span>
           )}
           {snapshotResult === "empty" && (
-            <span className="text-xs text-yellow-400">⚠ 캐시 없음</span>
+            <span className="text-xs text-yellow-600">??캐시 ?�음</span>
           )}
           {snapshotResult === "error" && (
-            <span className="text-xs text-red-400">✗ 스냅샷 오류</span>
+            <span className="text-xs text-red-500">???�냅???�류</span>
           )}
           <button
             onClick={handleSnapshot}
             disabled={snapshotting}
-            className="text-sm bg-indigo-700 hover:bg-indigo-600 disabled:opacity-50 text-white px-3 py-1.5 rounded transition-colors"
-            title="현재 Redis 캐시의 인기 영상 조회수를 DB에 즉시 스냅샷 저장 (UPSERT)"
+            className="text-sm bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white px-3 py-1.5 rounded-lg transition-colors"
+            title="?�재 Redis 캐시???�기 ?�상 조회?��? DB??즉시 ?�냅???�??(UPSERT)"
           >
-            {snapshotting ? "저장 중..." : "스냅샷 저장"}
+            {snapshotting ? "?�??�?.." : "?�냅???�??}
           </button>
           <button
             onClick={handlePurge}
             disabled={purging}
-            className="text-sm bg-gray-700 hover:bg-gray-600 disabled:opacity-50 text-gray-300 px-3 py-1.5 rounded transition-colors"
+            className="text-sm border border-gray-300 bg-white hover:bg-gray-50 disabled:opacity-50 text-gray-700 px-3 py-1.5 rounded-lg transition-colors"
           >
-            {purging ? "처리 중..." : "새로고침"}
+            {purging ? "처리 �?.." : "?�로고침"}
           </button>
         </div>
       </div>
 
-      {/* ── 정렬 바 ── */}
+      {/* ?�?� ?�렬 �??�?� */}
       <div className="flex items-center gap-2 mb-3 shrink-0">
-        <span className="text-xs text-gray-500 mr-1">게시일순</span>
-        <span className="text-xs text-gray-700">|</span>
+        <span className="text-xs text-gray-500 mr-1">게시?�순</span>
+        <span className="text-xs text-gray-300">|</span>
         <button
           onClick={cycleView}
           className={`text-xs px-2.5 py-1 rounded border transition-colors ${
             viewSort !== "default"
-              ? "bg-indigo-600 border-indigo-600 text-white"
-              : "bg-transparent border-gray-700 text-gray-400 hover:border-gray-500"
+              ? "bg-blue-600 border-blue-600 text-white"
+              : "bg-white border-gray-300 text-gray-500 hover:border-gray-400"
           }`}
         >
           {VIEW_LABEL[viewSort]}
@@ -326,26 +326,26 @@ export default function AdminYoutubePage() {
           onClick={cycleDur}
           className={`text-xs px-2.5 py-1 rounded border transition-colors ${
             durSort !== "default"
-              ? "bg-indigo-600 border-indigo-600 text-white"
-              : "bg-transparent border-gray-700 text-gray-400 hover:border-gray-500"
+              ? "bg-blue-600 border-blue-600 text-white"
+              : "bg-white border-gray-300 text-gray-500 hover:border-gray-400"
           }`}
         >
           {DUR_LABEL[durSort]}
         </button>
       </div>
 
-      {/* ── 본문: 목록 + 통계 ── */}
+      {/* ?�?� 본문: 목록 + ?�계 ?�?� */}
       <div className="flex flex-1 gap-5 min-h-0">
-        {/* 왼쪽: 영상 목록 */}
+        {/* ?�쪽: ?�상 목록 */}
         <div className="flex flex-col flex-1 min-w-0 min-h-0">
           <div className="flex-1 overflow-y-auto pr-0.5">
             {loading ? (
-              <div className="text-sm text-gray-500 py-8 text-center">
-                불러오는 중...
+              <div className="text-sm text-gray-400 py-8 text-center">
+                불러?�는 �?..
               </div>
             ) : filtered.length === 0 ? (
-              <div className="text-sm text-gray-500 py-8 text-center">
-                해당하는 영상이 없습니다.
+              <div className="text-sm text-gray-400 py-8 text-center">
+                ?�당?�는 ?�상???�습?�다.
               </div>
             ) : (
               filtered.map((v, i) => (
@@ -354,9 +354,9 @@ export default function AdminYoutubePage() {
                   href={`https://www.youtube.com/watch?v=${v.videoId}`}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className={`flex items-center gap-3 px-3 py-2 hover:bg-gray-800/70 transition-colors rounded ${i % 2 === 0 ? "bg-gray-900/50" : ""}`}
+                  className={`flex items-center gap-3 px-3 py-2 hover:bg-gray-50 transition-colors rounded-lg ${i % 2 === 0 ? "bg-gray-50" : "bg-white"}`}
                 >
-                  <div className="w-24 shrink-0 aspect-video bg-gray-800 rounded overflow-hidden">
+                  <div className="w-24 shrink-0 aspect-video bg-gray-200 rounded overflow-hidden">
                     {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img
                       src={v.thumbnailUrl}
@@ -365,20 +365,20 @@ export default function AdminYoutubePage() {
                     />
                   </div>
                   <div className="flex-1 min-w-0">
-                    <p className="text-sm text-white leading-snug line-clamp-2 break-keep">
+                    <p className="text-sm text-gray-900 leading-snug line-clamp-2 break-keep">
                       {v.title}
                     </p>
                     <div className="flex items-center mt-1">
-                      <span className="text-xs text-indigo-400 w-28 shrink-0 truncate">
+                      <span className="text-xs text-blue-600 w-28 shrink-0 truncate">
                         {v.channelTitle}
                       </span>
-                      <span className="text-xs text-gray-500 w-14 shrink-0 tabular-nums">
+                      <span className="text-xs text-gray-400 w-14 shrink-0 tabular-nums">
                         {formatRelativeDate(v.publishedAt)}
                       </span>
-                      <span className="text-xs text-gray-400 w-16 shrink-0 tabular-nums">
+                      <span className="text-xs text-gray-500 w-16 shrink-0 tabular-nums">
                         {formatViews(v.viewCount)}
                       </span>
-                      <span className="text-xs text-gray-500 w-10 shrink-0 tabular-nums">
+                      <span className="text-xs text-gray-400 w-10 shrink-0 tabular-nums">
                         {v.duration}
                       </span>
                     </div>
@@ -389,29 +389,29 @@ export default function AdminYoutubePage() {
           </div>
         </div>
 
-        {/* 오른쪽: 통계 그래프 */}
+        {/* ?�른�? ?�계 그래??*/}
         <div className="w-72 shrink-0 flex flex-col gap-5 overflow-y-auto">
           {loading ? (
-            <div className="text-xs text-gray-600 text-center pt-8">
-              로딩 중...
+            <div className="text-xs text-gray-400 text-center pt-8">
+              로딩 �?..
             </div>
           ) : (
             <>
-              {/* 날짜별 평균 조회수 차트 */}
+              {/* ?�짜�??�균 조회??차트 */}
               <div>
-                <p className="text-xs font-medium text-gray-400 mb-2">
-                  날짜별 평균 조회수
+                <p className="text-xs font-medium text-gray-500 mb-2">
+                  ?�짜�??�균 조회??
                 </p>
                 <div className="flex flex-wrap gap-1 mb-3">
                   {(
                     [
-                      { label: "1일", days: 1 },
-                      { label: "3일", days: 3 },
-                      { label: "7일", days: 7 },
-                      { label: "30일", days: 30 },
-                      { label: "90일", days: 90 },
-                      { label: "150일", days: 150 },
-                      { label: "1년", days: 365 },
+                      { label: "1??, days: 1 },
+                      { label: "3??, days: 3 },
+                      { label: "7??, days: 7 },
+                      { label: "30??, days: 30 },
+                      { label: "90??, days: 90 },
+                      { label: "150??, days: 150 },
+                      { label: "1??, days: 365 },
                     ] as const
                   ).map(({ label, days }) => (
                     <button
@@ -419,8 +419,8 @@ export default function AdminYoutubePage() {
                       onClick={() => setRangeDay(days)}
                       className={`text-xs px-2 py-0.5 rounded border transition-colors ${
                         rangeDay === days
-                          ? "bg-indigo-600 border-indigo-600 text-white"
-                          : "bg-transparent border-gray-700 text-gray-500 hover:border-gray-500"
+                          ? "bg-blue-600 border-blue-600 text-white"
+                          : "bg-white border-gray-300 text-gray-500 hover:border-gray-400"
                       }`}
                     >
                       {label}
@@ -428,12 +428,12 @@ export default function AdminYoutubePage() {
                   ))}
                 </div>
                 {historyLoading ? (
-                  <p className="text-xs text-gray-600 text-center py-6">
-                    로딩 중...
+                  <p className="text-xs text-gray-400 text-center py-6">
+                    로딩 �?..
                   </p>
                 ) : historyData.length === 0 ? (
-                  <p className="text-xs text-gray-600 text-center py-6">
-                    스냅샷 데이터 없음 (갱신 후 쌓임)
+                  <p className="text-xs text-gray-400 text-center py-6">
+                    ?�냅???�이???�음 (갱신 ???�임)
                   </p>
                 ) : (
                   <ResponsiveContainer width="100%" height={150}>
@@ -473,9 +473,9 @@ export default function AdminYoutubePage() {
                         content={({ active, payload, label }) => {
                           if (!active || !payload?.length) return null;
                           return (
-                            <div className="bg-gray-900 border border-gray-700 rounded px-2 py-1 text-xs">
-                              <p className="text-gray-400">{label}</p>
-                              <p className="text-indigo-400">
+                            <div className="bg-white border border-gray-200 shadow rounded-lg px-2 py-1 text-xs">
+                              <p className="text-gray-500">{label}</p>
+                              <p className="text-blue-600">
                                 {formatViews(payload[0]?.value as number)}
                               </p>
                             </div>
@@ -507,11 +507,11 @@ export default function AdminYoutubePage() {
                     color="bg-teal-500"
                   />
                   <BarChart
-                    title="채널별 (상위 6)"
+                    title="채널�?(?�위 6)"
                     data={stats.topChannels.map((c) => ({
                       label:
                         c.label.length > 8
-                          ? c.label.slice(0, 7) + "…"
+                          ? c.label.slice(0, 7) + "??
                           : c.label,
                       value: c.value,
                     }))}

--- a/client/app/globals.css
+++ b/client/app/globals.css
@@ -76,22 +76,306 @@ body {
   animation: youtube-card-drop-in 0.36s ease-out both;
 }
 
-.admin-content-shell {
-  border: 1px solid #e5e7eb;
-  background: #ffffff;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+/* =========================================================
+   Admin Design System (CleanPay-inspired light theme)
+   ========================================================= */
+:root {
+  --admin-bg: #f5f7fb;
+  --admin-surface: #ffffff;
+  --admin-surface-muted: #f9fafb;
+  --admin-border: #e5e7eb;
+  --admin-border-strong: #d1d5db;
+  --admin-text: #111827;
+  --admin-text-muted: #6b7280;
+  --admin-text-subtle: #9ca3af;
+  --admin-primary: #2563eb;
+  --admin-primary-hover: #1d4ed8;
+  --admin-primary-soft: #eff6ff;
+  --admin-success: #10b981;
+  --admin-success-soft: #ecfdf5;
+  --admin-warning: #f59e0b;
+  --admin-warning-soft: #fffbeb;
+  --admin-danger: #ef4444;
+  --admin-danger-soft: #fef2f2;
+  --admin-sidebar-bg: #111827;
+  --admin-sidebar-bg-active: #1f2937;
+  --admin-sidebar-border: #1f2937;
+  --admin-sidebar-text: #d1d5db;
+  --admin-sidebar-text-muted: #6b7280;
+  --admin-shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.04);
+  --admin-shadow-md: 0 4px 16px rgba(15, 23, 42, 0.06);
+  --admin-shadow-lg: 0 20px 40px rgba(15, 23, 42, 0.12);
+  --admin-radius-sm: 8px;
+  --admin-radius: 12px;
+  --admin-radius-lg: 16px;
 }
 
-.admin-content-panel {
-  border: 1px solid #e5e7eb;
-  background: #ffffff;
+/* Layout */
+.admin-shell {
+  background: var(--admin-bg);
+  color: var(--admin-text);
+}
+.admin-sidebar {
+  background: var(--admin-sidebar-bg);
+  border-right: 1px solid var(--admin-sidebar-border);
+}
+.admin-sidebar-brand {
+  color: #ffffff;
+  letter-spacing: -0.01em;
+}
+.admin-sidebar-link {
+  color: var(--admin-sidebar-text);
+  transition:
+    background 0.15s,
+    color 0.15s;
+}
+.admin-sidebar-link:hover {
+  background: rgba(255, 255, 255, 0.04);
+  color: #ffffff;
+}
+.admin-sidebar-link.is-active {
+  background: var(--admin-primary);
+  color: #ffffff;
+  font-weight: 600;
+}
+.admin-sidebar-logout {
+  color: var(--admin-sidebar-text-muted);
+  transition: color 0.15s;
+}
+.admin-sidebar-logout:hover {
+  color: #ffffff;
 }
 
-.admin-content-table {
-  border: 1px solid #e5e7eb;
-  background: #ffffff;
+/* Page heading */
+.admin-page-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--admin-text);
+  letter-spacing: -0.02em;
+}
+.admin-page-subtitle {
+  font-size: 0.875rem;
+  color: var(--admin-text-muted);
 }
 
-.admin-content-table thead tr {
-  background: #f9fafb;
+/* Surfaces */
+.admin-card {
+  background: var(--admin-surface);
+  border: 1px solid var(--admin-border);
+  border-radius: var(--admin-radius);
+  box-shadow: var(--admin-shadow-sm);
+}
+.admin-card-padded {
+  padding: 1.25rem 1.5rem;
+}
+.admin-stat-card {
+  background: var(--admin-surface);
+  border: 1px solid var(--admin-border);
+  border-radius: var(--admin-radius);
+  padding: 1rem 1.25rem;
+  box-shadow: var(--admin-shadow-sm);
+}
+.admin-stat-label {
+  font-size: 0.75rem;
+  color: var(--admin-text-muted);
+  font-weight: 500;
+}
+.admin-stat-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--admin-text);
+  letter-spacing: -0.02em;
+}
+
+/* Buttons */
+.admin-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  height: 36px;
+  padding: 0 0.875rem;
+  border-radius: var(--admin-radius-sm);
+  font-size: 0.875rem;
+  font-weight: 500;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    color 0.15s,
+    box-shadow 0.15s;
+}
+.admin-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.admin-btn-primary {
+  background: var(--admin-primary);
+  color: #ffffff;
+}
+.admin-btn-primary:hover:not(:disabled) {
+  background: var(--admin-primary-hover);
+}
+.admin-btn-secondary {
+  background: var(--admin-surface);
+  color: var(--admin-text);
+  border-color: var(--admin-border);
+}
+.admin-btn-secondary:hover:not(:disabled) {
+  background: var(--admin-surface-muted);
+  border-color: var(--admin-border-strong);
+}
+.admin-btn-danger {
+  background: var(--admin-danger-soft);
+  color: var(--admin-danger);
+  border-color: #fecaca;
+}
+.admin-btn-danger:hover:not(:disabled) {
+  background: #fee2e2;
+}
+.admin-btn-danger-solid {
+  background: var(--admin-danger);
+  color: #ffffff;
+}
+.admin-btn-danger-solid:hover:not(:disabled) {
+  background: #dc2626;
+}
+.admin-btn-sm {
+  height: 30px;
+  padding: 0 0.625rem;
+  font-size: 0.75rem;
+  border-radius: 6px;
+}
+
+/* Inputs */
+.admin-input,
+.admin-select {
+  width: 100%;
+  height: 36px;
+  padding: 0 0.75rem;
+  background: var(--admin-surface);
+  border: 1px solid var(--admin-border);
+  border-radius: var(--admin-radius-sm);
+  font-size: 0.875rem;
+  color: var(--admin-text);
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
+}
+.admin-input::placeholder {
+  color: var(--admin-text-subtle);
+}
+.admin-input:focus,
+.admin-select:focus {
+  outline: none;
+  border-color: var(--admin-primary);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12);
+}
+.admin-textarea {
+  width: 100%;
+  padding: 0.625rem 0.75rem;
+  background: var(--admin-surface);
+  border: 1px solid var(--admin-border);
+  border-radius: var(--admin-radius-sm);
+  font-size: 0.875rem;
+  color: var(--admin-text);
+  resize: vertical;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
+}
+.admin-textarea:focus {
+  outline: none;
+  border-color: var(--admin-primary);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12);
+}
+.admin-label {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--admin-text-muted);
+  margin-bottom: 0.375rem;
+}
+
+/* Table */
+.admin-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 0.875rem;
+}
+.admin-table thead th {
+  position: sticky;
+  top: 0;
+  background: var(--admin-surface-muted);
+  color: var(--admin-text-muted);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  text-align: left;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--admin-border);
+}
+.admin-table tbody td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid #f1f5f9;
+  color: var(--admin-text);
+  vertical-align: middle;
+}
+.admin-table tbody tr:hover td {
+  background: var(--admin-surface-muted);
+}
+.admin-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+/* Badges */
+.admin-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.125rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+}
+.admin-badge-success {
+  background: var(--admin-success-soft);
+  color: #047857;
+  border-color: #a7f3d0;
+}
+.admin-badge-neutral {
+  background: #f3f4f6;
+  color: #4b5563;
+  border-color: #e5e7eb;
+}
+.admin-badge-info {
+  background: var(--admin-primary-soft);
+  color: #1d4ed8;
+  border-color: #bfdbfe;
+}
+.admin-badge-warning {
+  background: var(--admin-warning-soft);
+  color: #b45309;
+  border-color: #fde68a;
+}
+
+/* Modal */
+.admin-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(17, 24, 39, 0.5);
+  backdrop-filter: blur(2px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+.admin-modal {
+  background: var(--admin-surface);
+  border-radius: var(--admin-radius-lg);
+  box-shadow: var(--admin-shadow-lg);
+  border: 1px solid var(--admin-border);
 }

--- a/client/app/globals.css
+++ b/client/app/globals.css
@@ -148,14 +148,26 @@ body {
 
 /* Page heading */
 .admin-page-title {
-  font-size: 1.5rem;
-  font-weight: 700;
+  font-size: 1.75rem;
+  font-weight: 800;
   color: var(--admin-text);
-  letter-spacing: -0.02em;
+  letter-spacing: -0.025em;
+  line-height: 1.2;
 }
 .admin-page-subtitle {
   font-size: 0.875rem;
   color: var(--admin-text-muted);
+}
+.admin-breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8125rem;
+  color: var(--admin-text-muted);
+  margin-bottom: 0.5rem;
+}
+.admin-breadcrumb-sep {
+  color: var(--admin-text-subtle);
 }
 
 /* Surfaces */
@@ -247,6 +259,42 @@ body {
   font-size: 0.75rem;
   border-radius: 6px;
 }
+.admin-btn-detail {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  height: 28px;
+  padding: 0 0.625rem;
+  background: var(--admin-primary-soft);
+  color: var(--admin-primary);
+  border: 1px solid #bfdbfe;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.admin-btn-detail:hover:not(:disabled) {
+  background: #dbeafe;
+}
+.admin-pagination-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  color: var(--admin-text-muted);
+  font-size: 0.8125rem;
+  cursor: pointer;
+  background: transparent;
+  border: none;
+  padding: 0.5rem 0.75rem;
+}
+.admin-pagination-link:hover:not(:disabled) {
+  color: var(--admin-text);
+}
+.admin-pagination-link:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
 
 /* Inputs */
 .admin-input,
@@ -308,14 +356,12 @@ body {
 .admin-table thead th {
   position: sticky;
   top: 0;
-  background: var(--admin-surface-muted);
+  background: var(--admin-surface);
   color: var(--admin-text-muted);
-  font-size: 0.75rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
+  font-size: 0.8125rem;
+  font-weight: 500;
   text-align: left;
-  padding: 0.75rem 1rem;
+  padding: 0.875rem 1rem;
   border-bottom: 1px solid var(--admin-border);
 }
 .admin-table tbody td {
@@ -331,35 +377,38 @@ body {
   border-bottom: none;
 }
 
-/* Badges */
+/* Badges — CleanPay style: outlined (transparent bg, colored border + text) */
 .admin-badge {
   display: inline-flex;
   align-items: center;
-  padding: 0.125rem 0.5rem;
-  border-radius: 999px;
-  font-size: 0.6875rem;
-  font-weight: 600;
+  justify-content: center;
+  min-width: 44px;
+  padding: 0.1875rem 0.5rem;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  background: #ffffff;
   border: 1px solid transparent;
 }
 .admin-badge-success {
-  background: var(--admin-success-soft);
-  color: #047857;
-  border-color: #a7f3d0;
+  color: #10b981;
+  border-color: #6ee7b7;
 }
 .admin-badge-neutral {
-  background: #f3f4f6;
-  color: #4b5563;
-  border-color: #e5e7eb;
+  color: #6b7280;
+  border-color: #d1d5db;
 }
 .admin-badge-info {
-  background: var(--admin-primary-soft);
-  color: #1d4ed8;
-  border-color: #bfdbfe;
+  color: #2563eb;
+  border-color: #93c5fd;
 }
 .admin-badge-warning {
-  background: var(--admin-warning-soft);
-  color: #b45309;
-  border-color: #fde68a;
+  color: #f59e0b;
+  border-color: #fcd34d;
+}
+.admin-badge-danger {
+  color: #ef4444;
+  border-color: #fca5a5;
 }
 
 /* Modal */

--- a/client/app/globals.css
+++ b/client/app/globals.css
@@ -75,3 +75,23 @@ body {
 .youtube-card-enter {
   animation: youtube-card-drop-in 0.36s ease-out both;
 }
+
+.admin-content-shell {
+  border: 1px solid #e5e7eb;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+}
+
+.admin-content-panel {
+  border: 1px solid #e5e7eb;
+  background: #ffffff;
+}
+
+.admin-content-table {
+  border: 1px solid #e5e7eb;
+  background: #ffffff;
+}
+
+.admin-content-table thead tr {
+  background: #f9fafb;
+}

--- a/server/src/admin/admin-characters.controller.ts
+++ b/server/src/admin/admin-characters.controller.ts
@@ -39,7 +39,7 @@ export class AdminCharactersController {
     @Query('classDetail') classDetailFilter = '',
   ) {
     const limit = Math.min(Math.max(parseInt(pageSize, 10) || 50, 1), 200);
-    const offset = (Math.max(parseInt(page, 10) || 1, 1) - 1) * limit;
+    const pageNum = Math.max(parseInt(page, 10) || 1, 1);
 
     const conditions: string[] = [];
     const params: (string | number)[] = [];
@@ -56,42 +56,30 @@ export class AdminCharactersController {
     const where =
       conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
 
-    const [countRows] = await this.pool.execute<CountRow[]>(
-      `SELECT COUNT(*) AS total
-       FROM loa_users u
-       LEFT JOIN loa_class c ON u.class = c.idx
-       ${where}`,
-      params,
-    );
-    const total = countRows[0]?.total ?? 0;
+    const selectColumns = `
+      u.name,
+      u.server,
+      u.level,
+      u.combat_power    AS combatPower,
+      c.class_detail    AS classDetail,
+      c.class_engraving AS classEngraving,
+      u.stat_crit       AS statCrit,
+      u.stat_spec       AS statSpec,
+      u.stat_swift      AS statSwift,
+      u.thesix,
+      ag_sun.core       AS coreSun,
+      ag_moon.core      AS coreMoon,
+      ag_star.core      AS coreStar
+    `;
+    const fromJoin = `
+      FROM loa_users u
+      LEFT JOIN loa_class    c       ON u.class      = c.idx
+      LEFT JOIN loa_ark_grid ag_sun  ON u.core_sun   = ag_sun.seq
+      LEFT JOIN loa_ark_grid ag_moon ON u.core_moon  = ag_moon.seq
+      LEFT JOIN loa_ark_grid ag_star ON u.core_star  = ag_star.seq
+    `;
 
-    const [rows] = await this.pool.execute<CharacterRow[]>(
-      `SELECT
-         u.name,
-         u.server,
-         u.level,
-         u.combat_power    AS combatPower,
-         c.class_detail    AS classDetail,
-         c.class_engraving AS classEngraving,
-         u.stat_crit       AS statCrit,
-         u.stat_spec       AS statSpec,
-         u.stat_swift      AS statSwift,
-         u.thesix,
-         ag_sun.core       AS coreSun,
-         ag_moon.core      AS coreMoon,
-         ag_star.core      AS coreStar
-       FROM loa_users u
-       LEFT JOIN loa_class    c       ON u.class      = c.idx
-       LEFT JOIN loa_ark_grid ag_sun  ON u.core_sun   = ag_sun.seq
-       LEFT JOIN loa_ark_grid ag_moon ON u.core_moon  = ag_moon.seq
-       LEFT JOIN loa_ark_grid ag_star ON u.core_star  = ag_star.seq
-       ${where}
-       ORDER BY u.level DESC
-       LIMIT ? OFFSET ?`,
-      [...params, limit, offset],
-    );
-
-    let items = rows.map((r) => ({
+    const mapRow = (r: CharacterRow) => ({
       name: r.name,
       server: r.server,
       level: r.level,
@@ -106,13 +94,47 @@ export class AdminCharactersController {
       coreSun: r.coreSun ?? null,
       coreMoon: r.coreMoon ?? null,
       coreStar: r.coreStar ?? null,
-    }));
+    });
 
-    // statBuild 필터는 JS에서 적용 (classifyStatBuild 결과 기반)
+    // statBuild 필터가 있는 경우: SQL에서 직접 필터 불가하므로
+    // 검색/직업 조건에 매칭되는 전체 행을 가져와 메모리에서 분류 후 페이징.
     if (statBuildFilter) {
-      items = items.filter((i) => i.statBuild === statBuildFilter);
+      const [rows] = await this.pool.execute<CharacterRow[]>(
+        `SELECT ${selectColumns}
+         ${fromJoin}
+         ${where}
+         ORDER BY u.level DESC`,
+        params,
+      );
+      const classified = rows
+        .map(mapRow)
+        .filter((i) => i.statBuild === statBuildFilter);
+      const total = classified.length;
+      const offset = (pageNum - 1) * limit;
+      const items = classified.slice(offset, offset + limit);
+      return { total, page: pageNum, pageSize: limit, items };
     }
 
-    return { total, page: parseInt(page, 10) || 1, pageSize: limit, items };
+    // 일반 경로: SQL 페이징
+    const offset = (pageNum - 1) * limit;
+    const [countRows] = await this.pool.execute<CountRow[]>(
+      `SELECT COUNT(*) AS total
+       FROM loa_users u
+       LEFT JOIN loa_class c ON u.class = c.idx
+       ${where}`,
+      params,
+    );
+    const total = countRows[0]?.total ?? 0;
+
+    const [rows] = await this.pool.execute<CharacterRow[]>(
+      `SELECT ${selectColumns}
+       ${fromJoin}
+       ${where}
+       ORDER BY u.level DESC
+       LIMIT ? OFFSET ?`,
+      [...params, limit, offset],
+    );
+    const items = rows.map(mapRow);
+    return { total, page: pageNum, pageSize: limit, items };
   }
 }


### PR DESCRIPTION
## Summary

관리자 페이지 전체 UI를 디자인 토큰 기반으로 재구축하고, 캐릭터 목록의 빌드 필터 버그를 수정합니다.

## UI rebuild (CleanPay-inspired light theme)

- `globals.css`에 admin 디자인 토큰(CSS variables) + 재사용 클래스 도입
  - `.admin-shell`, `.admin-sidebar`, `.admin-card`, `.admin-btn-*`, `.admin-input`, `.admin-select`, `.admin-textarea`, `.admin-label`, `.admin-table`, `.admin-badge-*`, `.admin-modal-*` 등
- 사이드바: 다크 네이비 + 파란 active 상태
- 본문: 라이트 그레이 배경, 흰 카드 + 미세 그림자
- 배지: outlined 스타일 (transparent bg + colored border/text)
- 테이블 헤더: plain 회색 텍스트 (한글에 맞게 uppercase tracking 제거)
- 페이지 타이틀: 1.75rem / weight 800
- 적용 대상: `layout.tsx`, `sites`, `characters`, `cache`, `youtube`, `login` 페이지

## Bug fix: statBuild 필터 페이지네이션

- 문제: `특치` 같은 빌드 선택 시 결과가 8개로 줄어드는 현상
- 원인: SQL이 20개 페이지를 먼저 가져온 뒤 JS에서 `statBuild` 필터를 적용. `statBuild`는 DB 컬럼이 아니라 `classifyStatBuild()`로 계산되는 값이라, 페이지 안의 일부만 남는 구조였음.
- 수정: `statBuild` 필터가 있을 때는 `search`/`classDetail` 조건이 적용된 전체 행을 가져와 메모리에서 분류→필터→페이징. `total`도 분류 후 개수로 계산.
- 필터가 없는 일반 경로는 기존 SQL `LIMIT/OFFSET` 유지.

## Commits

- 032cc4e style(admin): apply light theme to cache, characters, sites, youtube pages
- b2decd5 style(admin): apply light theme to login page
- 74647f0 style(admin): rebuild admin UI with new design system
- f63ef06 style(admin): match CleanPay reference more closely
- 57f44bf fix(admin/characters): apply statBuild filter before pagination