### PR TITLE
perf(home): restore ISR caching for public home page

### DIFF
--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -4,15 +4,17 @@ import SiteList from "@/components/sites/SiteList";
 import YoutubeSection from "@/components/youtube/YoutubeSection";
 import type { Site, StatBuildTab } from "@/types";
 
-// Always fetch fresh data so normal refresh reflects latest crawler/admin changes.
+// Sites use ISR with on-demand revalidation triggered by admin mutations
+// (see client/app/api/admin/sites/**). Stat builds are refreshed periodically
+// by the crawler, so a short revalidate window is sufficient.
 const API = process.env.NEST_API_URL ?? "http://localhost:3001";
 
 export default async function Home() {
   const [sites, statBuilds] = await Promise.all([
-    fetch(`${API}/api/sites`, { cache: "no-store" })
+    fetch(`${API}/api/sites`, { next: { revalidate: 3600 } })
       .then<Site[]>((r) => r.json())
       .catch(() => [] as Site[]),
-    fetch(`${API}/api/characters/stat-builds`, { cache: "no-store" })
+    fetch(`${API}/api/characters/stat-builds`, { next: { revalidate: 300 } })
       .then<StatBuildTab[]>((r) => r.json())
       .catch(() => [] as StatBuildTab[]),
   ]);


### PR DESCRIPTION
## Summary

공개 홈(/) 접속 지연 회귀 수정. cache: 'no-store' → ISR 복원.

## Why

이전 커밋(901abac)에서 어드민/크롤러 최신 데이터 반영을 위해 cache: 'no-store'로 변경했으나, 일반 방문자도 매 요청마다 NestJS API + DB를 거치게 되어 daloa.kr 로드 시간이 길어지는 회귀가 발생.

## What

client/app/page.tsx:

- `/api/sites`: `cache: 'no-store'` → `next: { revalidate: 3600 }`
  - 어드민 mutation 라우트(`client/app/api/admin/sites/**`)에서 이미 `revalidatePath('/')` 호출 중이므로, 어드민 추가/수정/삭제 시 **즉시 무효화**됨.
- `/api/characters/stat-builds`: `cache: 'no-store'` → `next: { revalidate: 300 }`
  - 크롤러가 주기적으로 갱신하므로 5분 ISR로 충분.

## Effect

- 일반 방문: 정적 캐시 응답 → 속도 복귀
- 어드민에서 사이트 변경 → 공개 홈 새로고침 시 즉시 반영
- 빌드 통계: 최대 5분 지연으로 자동 갱신