### PR TITLE
fix(backfill): use pool.query for LIMIT placeholder to avoid mysqld_stmt_execute error

### DIFF
--- a/server/scripts/backfill-stat-build.ts
+++ b/server/scripts/backfill-stat-build.ts
@@ -40,12 +40,15 @@ async function main() {
   let processed = 0;
 
   while (true) {
-    const [rows] = await pool.execute<(Row & mysql.RowDataPacket)[]>(
+    // Use pool.query (not execute) for the LIMIT placeholder because some
+    // MySQL/MariaDB versions reject integer parameters in prepared LIMIT clauses
+    // ("Incorrect arguments to mysqld_stmt_execute"). BATCH is a hardcoded
+    // integer constant so inlining it is safe.
+    const [rows] = await pool.query<(Row & mysql.RowDataPacket)[]>(
       `SELECT seq, stat_crit, stat_spec, stat_swift
          FROM loa_users
         WHERE stat_build IS NULL OR stat_build = ''
-        LIMIT ?`,
-      [BATCH],
+        LIMIT ${BATCH}`,
     );
     if (rows.length === 0) break;
 


### PR DESCRIPTION
## Summary

프로덕션 EC2 백필 실행 중 발생한 `Incorrect arguments to mysqld_stmt_execute` (errno 1210) 에러 수정.

## Background

로컬 MariaDB 10.6 환경에서는 `pool.execute(... LIMIT ?, [BATCH])` 가 정상 동작해 백필이 성공했지만, 프로덕션 MariaDB 환경에서는 동일 쿼리가 prepared statement의 정수 placeholder를 거부함.

## Fix

`pool.execute()` → `pool.query()` 로 변경하고 `LIMIT ?` 의 placeholder를 `LIMIT \` 로 인라인. `BATCH` 는 코드에 하드코딩된 상수(1000)이므로 SQL injection 위험 없음.

## Production status

- ALTER TABLE 마이그레이션: 적용 완료 (stat_build VARCHAR(10) + idx_stat_build)
- 백필: 수정된 스크립트로 29,583행 100% 완료
- 분포: 신치 6580 / 특치 6392 / 신특 5158 / 미설정 4802 / 치신 3537 / 특신 1364 / 치특신 1283 / 치특 467