### PR TITLE
fix/admin → main: backfill compat fix + workflow/docs cleanup

### DIFF
--- a/server/scripts/backfill-stat-build.ts
+++ b/server/scripts/backfill-stat-build.ts
@@ -40,12 +40,15 @@ async function main() {
   let processed = 0;
 
   while (true) {
-    const [rows] = await pool.execute<(Row & mysql.RowDataPacket)[]>(
+    // Use pool.query (not execute) for the LIMIT placeholder because some
+    // MySQL/MariaDB versions reject integer parameters in prepared LIMIT clauses
+    // ("Incorrect arguments to mysqld_stmt_execute"). BATCH is a hardcoded
+    // integer constant so inlining it is safe.
+    const [rows] = await pool.query<(Row & mysql.RowDataPacket)[]>(
       `SELECT seq, stat_crit, stat_spec, stat_swift
          FROM loa_users
         WHERE stat_build IS NULL OR stat_build = ''
-        LIMIT ?`,
-      [BATCH],
+        LIMIT ${BATCH}`,
     );
     if (rows.length === 0) break;
 


### PR DESCRIPTION
## Summary

`fix/admin` 누적분을 `main`에 반영. 가장 큰 변경은 백필 스크립트 호환성 수정이며, 나머지는 워크플로/문서 정비.

## 주요 변경

### 코드 수정

- **server/scripts/backfill-stat-build.ts** (PR #73)
  - 프로덕션 MariaDB에서 `pool.execute(... LIMIT ?, [BATCH])` 가 `Incorrect arguments to mysqld_stmt_execute` 에러로 거부됨
  - `pool.query()` + `LIMIT ${BATCH}` 인라인으로 변경 (BATCH 는 하드코딩 상수, SQL injection 위험 없음)

### 워크플로/문서 정비

- `.github/pull_request_template.md` 추가
- `.github/workflows/`: `drawio-export.yml` 제거, `pr-ci.yml`/`pr-check.yml`/`server-e2e.yml`/`main-post-merge.yml` 정리
- `AGENTS.md`, `README.md`, `.gitignore` 정비
- `client/vercel.json`, `docs/architecture.drawio` 제거

## 프로덕션 마이그레이션 상태

- ALTER TABLE 마이그레이션: 완료 (stat_build VARCHAR(10) + idx_stat_build)
- 백필: 29,583행 100% 완료
- 분포: 신치 6580 / 특치 6392 / 신특 5158 / 미설정 4802 / 치신 3537 / 특신 1364 / 치특신 1283 / 치특 467

## 머지 후 영향

- 프로덕션 NestJS는 이미 stat_build 컬럼을 활용 중 (PR #70에서 머지됨)
- 클라이언트 홈 ISR 정책은 이미 PR #72로 main에 반영됨
- 본 PR은 추가 배포 액션 불필요 (백필 스크립트 변경은 일회성 운영 스크립트)
