### PR TITLE
fix(ci): unshallow checkout for drawio-export workflow

### DIFF
--- a/.github/workflows/drawio-export.yml
+++ b/.github/workflows/drawio-export.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "docs/architecture.drawio"
+  workflow_dispatch:
 
 jobs:
   export:
@@ -13,6 +14,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Export architecture.drawio → SVG
         uses: rlespinasse/drawio-export-action@v2


### PR DESCRIPTION
﻿## 목적
GitHub README의 아키텍처 다이어그램이 표시되지 않는 문제를 해결한다. 원인은 `Export Draw.io to SVG` 워크플로가 shallow checkout으로 인해 실패하여 `docs/architecture.svg`가 생성·커밋되지 않은 것이다.

## 변경점
- `.github/workflows/drawio-export.yml`
  - `actions/checkout@v4`에 `fetch-depth: 0`을 추가해 `rlespinasse/drawio-export-action@v2`가 요구하는 전체 git 히스토리를 확보
  - `workflow_dispatch` 트리거 추가하여 머지 이후 수동 실행으로 SVG를 즉시 생성 가능하도록 함

## 영향범위
- 수정 파일 목록
  - `.github/workflows/drawio-export.yml`
- 영향받는 영역
  - GitHub Actions: drawio → SVG 자동 export 파이프라인
  - 문서: 머지 후 워크플로 수동 실행 시 `docs/architecture.svg`가 자동 생성되어 README의 아키텍처 다이어그램 이미지가 정상 렌더링됨
