### PR TITLE
fix(docs): use raw.githubusercontent URL for architecture SVG link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@
 
 시스템 흐름:
 
-<a href="docs/architecture.svg?raw=true" target="_blank" rel="noopener">
+<a href="https://raw.githubusercontent.com/haihire/daloa/main/docs/architecture.svg" target="_blank" rel="noopener">
   <img src="docs/architecture.svg" alt="아키텍처 다이어그램" width="100%" />
 </a>
 
-원본 크기로 보기: [docs/architecture.svg](docs/architecture.svg?raw=true)
+원본 크기로 보기: [docs/architecture.svg](https://raw.githubusercontent.com/haihire/daloa/main/docs/architecture.svg)
 
 1. 사용자는 프론트엔드(Next.js)에서 페이지를 요청
 2. 프론트엔드는 서버 렌더링/클라이언트 요청으로 API를 호출


### PR DESCRIPTION
README \uc544\ud0a4\ud14d\ucc98 \ub2e4\uc774\uc5b4\uadf8\ub7a8 \ud074\ub9ad \uc2dc `blob/...?raw=true` URL\uc774 GitHub UI \uc5d0\uc11c `Error loading page` \uc5d0\ub7ec\ub97c \ub0b4\ub294 \ubb38\uc81c\ub97c, `raw.githubusercontent.com/<owner>/<repo>/main/docs/architecture.svg` \uc9c1\uc811 URL\ub85c \uad50\uccb4\ud574 \ud574\uacb0\ud55c\ub2e4.