### PR TITLE
feat(admin): loa_users/loa_sites 로컬→프로덕션 단방향 동기화

### DIFF
--- a/client/app/admin/layout.tsx
+++ b/client/app/admin/layout.tsx
@@ -7,6 +7,7 @@ const NAV = [
   { href: "/admin/sites", label: "사이트 관리" },
   { href: "/admin/characters", label: "캐릭터 목록" },
   { href: "/admin/youtube", label: "유튜브" },
+  { href: "/admin/sync", label: "DB 동기화" },
 ];
 
 export default function AdminLayout({

--- a/client/app/admin/sync/page.tsx
+++ b/client/app/admin/sync/page.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import { useRef, useState } from "react";
+
+type Phase = "idle" | "login" | "begin" | "count" | "chunk" | "done" | "error";
+
+interface SyncState {
+  phase: Phase;
+  total: number;
+  transferred: number;
+  percent: number;
+  message: string;
+  error: string;
+}
+
+const INITIAL: SyncState = {
+  phase: "idle",
+  total: 0,
+  transferred: 0,
+  percent: 0,
+  message: "",
+  error: "",
+};
+
+const TABLES: { key: "users" | "sites"; label: string; desc: string }[] = [
+  {
+    key: "users",
+    label: "loa_users (캐릭터)",
+    desc: "전체 캐릭터 데이터를 프로덕션 DB로 덮어씁니다. 기존 프로덕션 데이터는 모두 삭제됩니다.",
+  },
+  {
+    key: "sites",
+    label: "loa_sites (사이트 모음)",
+    desc: "전체 사이트 데이터를 프로덕션 DB로 덮어씁니다. 기존 프로덕션 데이터는 모두 삭제됩니다.",
+  },
+];
+
+export default function SyncPage() {
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="text-2xl font-bold">서버 동기화 (Local → Prod)</h1>
+        <p className="mt-2 text-sm text-gray-400">
+          로컬 DB 내용을 프로덕션 DB로 단방향 복제합니다. 프로덕션의 해당
+          테이블은 <strong className="text-red-400">TRUNCATE</strong> 후 전체
+          재삽입됩니다.
+        </p>
+      </header>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {TABLES.map((t) => (
+          <SyncCard key={t.key} table={t.key} label={t.label} desc={t.desc} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SyncCard({
+  table,
+  label,
+  desc,
+}: {
+  table: "users" | "sites";
+  label: string;
+  desc: string;
+}) {
+  const [state, setState] = useState<SyncState>(INITIAL);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const running =
+    state.phase !== "idle" &&
+    state.phase !== "done" &&
+    state.phase !== "error";
+
+  async function start() {
+    const ok = window.confirm(
+      `[${label}]\n\n프로덕션의 해당 테이블을 전체 삭제 후 로컬 데이터로 재삽입합니다.\n계속하시겠습니까?`,
+    );
+    if (!ok) return;
+
+    setState({ ...INITIAL, phase: "login", message: "시작 중..." });
+    const ctrl = new AbortController();
+    abortRef.current = ctrl;
+
+    try {
+      const res = await fetch(`/api/admin/sync/${table}`, {
+        method: "GET",
+        signal: ctrl.signal,
+        headers: { accept: "text/event-stream" },
+      });
+      if (!res.ok || !res.body) {
+        const txt = await res.text().catch(() => "");
+        throw new Error(`연결 실패 (${res.status}): ${txt}`);
+      }
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buf = "";
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+
+        let idx: number;
+        while ((idx = buf.indexOf("\n\n")) !== -1) {
+          const raw = buf.slice(0, idx);
+          buf = buf.slice(idx + 2);
+          handleEvent(raw, setState);
+        }
+      }
+    } catch (err) {
+      if ((err as Error).name === "AbortError") return;
+      setState((s) => ({
+        ...s,
+        phase: "error",
+        error: (err as Error).message,
+      }));
+    } finally {
+      abortRef.current = null;
+    }
+  }
+
+  function cancel() {
+    abortRef.current?.abort();
+    setState((s) => ({ ...s, phase: "error", error: "사용자가 취소함" }));
+  }
+
+  return (
+    <section className="rounded-xl border border-gray-700 bg-gray-900 p-5">
+      <h2 className="text-lg font-semibold">{label}</h2>
+      <p className="mt-1 text-xs text-gray-400">{desc}</p>
+
+      <div className="mt-4 space-y-2">
+        <div className="flex justify-between text-xs text-gray-300">
+          <span>
+            진행:{" "}
+            <strong>
+              {state.transferred.toLocaleString()} /{" "}
+              {state.total.toLocaleString()}
+            </strong>
+          </span>
+          <span>{state.percent}%</span>
+        </div>
+        <div className="h-2 w-full overflow-hidden rounded bg-gray-700">
+          <div
+            className={`h-full transition-all ${
+              state.phase === "error"
+                ? "bg-red-500"
+                : state.phase === "done"
+                  ? "bg-green-500"
+                  : "bg-blue-500"
+            }`}
+            style={{ width: `${state.percent}%` }}
+          />
+        </div>
+        <div className="text-xs">
+          상태:{" "}
+          <span
+            className={
+              state.phase === "error"
+                ? "text-red-400"
+                : state.phase === "done"
+                  ? "text-green-400"
+                  : "text-gray-300"
+            }
+          >
+            {phaseLabel(state.phase)}
+          </span>
+          {state.message && (
+            <span className="text-gray-500"> · {state.message}</span>
+          )}
+        </div>
+        {state.error && (
+          <pre className="whitespace-pre-wrap rounded bg-red-950/40 p-2 text-xs text-red-300">
+            {state.error}
+          </pre>
+        )}
+      </div>
+
+      <div className="mt-4 flex gap-2">
+        <button
+          type="button"
+          onClick={start}
+          disabled={running}
+          className="rounded bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-gray-700"
+        >
+          {running ? "동기화 중..." : "서버와 동기화"}
+        </button>
+        {running && (
+          <button
+            type="button"
+            onClick={cancel}
+            className="rounded border border-gray-600 px-4 py-2 text-sm text-gray-300 hover:bg-gray-800"
+          >
+            취소
+          </button>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function phaseLabel(p: Phase): string {
+  switch (p) {
+    case "idle":
+      return "대기";
+    case "login":
+      return "원격 로그인";
+    case "begin":
+      return "TRUNCATE";
+    case "count":
+      return "카운트 조회";
+    case "chunk":
+      return "전송 중";
+    case "done":
+      return "완료";
+    case "error":
+      return "오류";
+  }
+}
+
+function handleEvent(
+  raw: string,
+  setState: React.Dispatch<React.SetStateAction<SyncState>>,
+) {
+  // SSE block: 'event: progress\ndata: {...}' 또는 'data: {...}'
+  const lines = raw.split("\n");
+  let evt = "message";
+  let dataStr = "";
+  for (const line of lines) {
+    if (line.startsWith("event:")) evt = line.slice(6).trim();
+    else if (line.startsWith("data:")) dataStr += line.slice(5).trim();
+  }
+  if (!dataStr) return;
+
+  let data: Record<string, unknown>;
+  try {
+    data = JSON.parse(dataStr) as Record<string, unknown>;
+  } catch {
+    return;
+  }
+
+  setState((s) => {
+    const next = { ...s };
+    if (evt === "progress") {
+      if (typeof data.phase === "string") next.phase = data.phase as Phase;
+      if (typeof data.total === "number") next.total = data.total;
+      if (typeof data.transferred === "number")
+        next.transferred = data.transferred;
+      if (typeof data.percent === "number") next.percent = data.percent;
+      if (typeof data.message === "string") next.message = data.message;
+    } else if (evt === "done") {
+      next.phase = "done";
+      next.percent = 100;
+      if (typeof data.total === "number") next.total = data.total;
+      if (typeof data.transferred === "number")
+        next.transferred = data.transferred;
+      next.message = "동기화 완료";
+    } else if (evt === "error") {
+      next.phase = "error";
+      next.error = (data.message as string) ?? "알 수 없는 오류";
+    }
+    return next;
+  });
+}

--- a/client/app/api/admin/sync/[table]/route.ts
+++ b/client/app/api/admin/sync/[table]/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest } from "next/server";
+import { cookies } from "next/headers";
+
+const NEST_API = process.env.NEST_API_URL ?? "http://localhost:3001";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ table: string }> },
+) {
+  const { table } = await params;
+  const store = await cookies();
+  const token = store.get("admin_token")?.value ?? "";
+
+  if (!token) {
+    return new Response("unauthorized", { status: 401 });
+  }
+  if (table !== "users" && table !== "sites") {
+    return new Response("invalid table", { status: 400 });
+  }
+
+  const url = `${NEST_API}/api/admin/sync/${table}/run`;
+  const upstream = await fetch(url, {
+    method: "GET",
+    headers: {
+      "x-admin-session": token,
+      accept: "text/event-stream",
+    },
+    signal: req.signal,
+  });
+
+  if (!upstream.ok || !upstream.body) {
+    const text = await upstream.text().catch(() => "");
+    return new Response(text || "upstream error", { status: upstream.status });
+  }
+
+  return new Response(upstream.body, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/server/src/admin/admin-sync.controller.ts
+++ b/server/src/admin/admin-sync.controller.ts
@@ -1,0 +1,314 @@
+import {
+  Controller,
+  Post,
+  Param,
+  Body,
+  Sse,
+  Query,
+  UseGuards,
+  BadRequestException,
+  Inject,
+  MessageEvent,
+} from '@nestjs/common';
+import type { Pool } from 'mysql2/promise';
+import type { RowDataPacket, ResultSetHeader } from 'mysql2';
+import { Observable } from 'rxjs';
+import { ConfigService } from '@nestjs/config';
+import { DB_POOL } from '../db/db.module';
+import { AdminGuard, AdminWriteGuard, RequireOwner } from './admin.guard';
+
+type TableKey = 'users' | 'sites';
+
+interface TableSpec {
+  table: string;
+  columns: readonly string[];
+}
+
+const TABLE_SPECS: Record<TableKey, TableSpec> = {
+  users: {
+    table: 'loa_users',
+    columns: [
+      'seq',
+      'server',
+      'level',
+      'combat_power',
+      'class',
+      'thesix',
+      'name',
+      'expedition_key',
+      'core_sun',
+      'core_moon',
+      'core_star',
+      'stat_crit',
+      'stat_spec',
+      'stat_swift',
+      'stat_build',
+    ],
+  },
+  sites: {
+    table: 'loa_sites',
+    columns: [
+      'seq',
+      'name',
+      'href',
+      'category',
+      'description',
+      'icon',
+      'is_active',
+      'last_title',
+      'last_status',
+      'checked_at',
+    ],
+  },
+};
+
+const CHUNK_SIZE = 1000;
+
+function specOrThrow(table: string): TableSpec {
+  if (!(table in TABLE_SPECS)) {
+    throw new BadRequestException(`지원하지 않는 테이블: ${table}`);
+  }
+  return TABLE_SPECS[table as TableKey];
+}
+
+@Controller('api/admin/sync')
+@UseGuards(AdminGuard)
+export class AdminSyncController {
+  constructor(
+    @Inject(DB_POOL) private readonly pool: Pool,
+    private readonly config: ConfigService,
+  ) {}
+
+  /** target 측: 동기화 시작 - TRUNCATE */
+  @Post(':table/begin')
+  @UseGuards(AdminWriteGuard)
+  @RequireOwner()
+  async begin(@Param('table') table: string) {
+    const spec = specOrThrow(table);
+    const conn = await this.pool.getConnection();
+    try {
+      await conn.query('SET FOREIGN_KEY_CHECKS=0');
+      await conn.query(`TRUNCATE TABLE \`${spec.table}\``);
+      await conn.query('SET FOREIGN_KEY_CHECKS=1');
+    } finally {
+      conn.release();
+    }
+    return { ok: true, table: spec.table };
+  }
+
+  /** target 측: 행 청크 bulk INSERT */
+  @Post(':table/chunk')
+  @UseGuards(AdminWriteGuard)
+  @RequireOwner()
+  async chunk(
+    @Param('table') table: string,
+    @Body() body: { rows?: unknown[][] },
+  ) {
+    const spec = specOrThrow(table);
+    const rows = body?.rows;
+    if (!Array.isArray(rows) || rows.length === 0) {
+      return { inserted: 0 };
+    }
+    for (const row of rows) {
+      if (!Array.isArray(row) || row.length !== spec.columns.length) {
+        throw new BadRequestException(
+          `행 길이가 컬럼 수와 다릅니다 (expected=${spec.columns.length})`,
+        );
+      }
+    }
+
+    const colList = spec.columns.map((c) => `\`${c}\``).join(', ');
+    const conn = await this.pool.getConnection();
+    try {
+      await conn.query('SET FOREIGN_KEY_CHECKS=0');
+      const [result] = await conn.query<ResultSetHeader>(
+        `INSERT INTO \`${spec.table}\` (${colList}) VALUES ?`,
+        [rows],
+      );
+      await conn.query('SET FOREIGN_KEY_CHECKS=1');
+      return { inserted: result.affectedRows };
+    } finally {
+      conn.release();
+    }
+  }
+
+  /** source/orchestrator 측: 로컬 DB → 원격 target API로 SSE 진행률 스트림 */
+  @Sse(':table/run')
+  @RequireOwner()
+  run(
+    @Param('table') table: string,
+    @Query('sessionId') sessionId?: string,
+  ): Observable<MessageEvent> {
+    const spec = specOrThrow(table);
+    const targetUrl = this.config.get<string>('SYNC_TARGET_API_URL', '').trim();
+    const targetPassword = this.config
+      .get<string>('SYNC_TARGET_ADMIN_PASSWORD', '')
+      .trim();
+
+    return new Observable<MessageEvent>((subscriber) => {
+      let cancelled = false;
+
+      const emit = (
+        type: 'progress' | 'done' | 'error',
+        data: Record<string, unknown>,
+      ) => {
+        subscriber.next({ type, data: JSON.stringify(data) });
+      };
+
+      void (async () => {
+        try {
+          if (!targetUrl || !targetPassword) {
+            throw new Error(
+              'SYNC_TARGET_API_URL / SYNC_TARGET_ADMIN_PASSWORD 환경변수가 설정되지 않았습니다',
+            );
+          }
+          if (sessionId && sessionId !== '') {
+            // session id is already validated by guard; we keep param for future use
+          }
+
+          // 0) target에 master 계정으로 로그인하여 sessionId 획득
+          emit('progress', {
+            phase: 'login',
+            message: '원격 서버 로그인 중...',
+            percent: 0,
+          });
+          const loginRes = (await callTargetRaw(
+            targetUrl,
+            '/api/admin/auth/login',
+            '',
+            { username: 'master', password: targetPassword },
+          )) as { sessionId?: string };
+          const remoteToken = loginRes?.sessionId ?? '';
+          if (!remoteToken) {
+            throw new Error('원격 로그인 실패: sessionId 없음');
+          }
+
+          // 1) target 측 begin (TRUNCATE)
+          emit('progress', {
+            phase: 'begin',
+            message: `${spec.table} TRUNCATE 중...`,
+            percent: 0,
+          });
+          await callTargetRaw(
+            targetUrl,
+            `/api/admin/sync/${table}/begin`,
+            remoteToken,
+            {},
+          );
+
+          // 2) total count
+          const [countRows] = await this.pool.query<RowDataPacket[]>(
+            `SELECT COUNT(*) AS total FROM \`${spec.table}\``,
+          );
+          const total = Number(countRows[0]?.total ?? 0);
+          emit('progress', {
+            phase: 'count',
+            total,
+            transferred: 0,
+            percent: total === 0 ? 100 : 0,
+          });
+
+          if (total === 0) {
+            emit('done', { total: 0, transferred: 0 });
+            subscriber.complete();
+            return;
+          }
+
+          // 3) chunked read + push
+          const colList = spec.columns.map((c) => `\`${c}\``).join(', ');
+          let transferred = 0;
+          let lastSeq = 0;
+
+          while (!cancelled) {
+            const [chunkRows] = await this.pool.query<RowDataPacket[]>(
+              `SELECT ${colList} FROM \`${spec.table}\` WHERE seq > ${lastSeq} ORDER BY seq ASC LIMIT ${CHUNK_SIZE}`,
+            );
+            if (chunkRows.length === 0) break;
+
+            const values = chunkRows.map((r) =>
+              spec.columns.map((c) => normalize(r[c])),
+            );
+
+            const last = chunkRows[chunkRows.length - 1];
+            lastSeq = Number(last.seq);
+
+            const res = await callTargetRaw(
+              targetUrl,
+              `/api/admin/sync/${table}/chunk`,
+              remoteToken,
+              { rows: values },
+            );
+            const inserted = Number(
+              (res as { inserted?: number })?.inserted ?? 0,
+            );
+            transferred += inserted;
+
+            emit('progress', {
+              phase: 'chunk',
+              total,
+              transferred,
+              percent: Math.min(99, Math.floor((transferred / total) * 100)),
+              lastSeq,
+            });
+          }
+
+          if (cancelled) {
+            emit('error', { message: '취소됨' });
+            subscriber.complete();
+            return;
+          }
+
+          emit('done', { total, transferred, percent: 100 });
+          subscriber.complete();
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          emit('error', { message: msg });
+          subscriber.complete();
+        }
+      })();
+
+      return () => {
+        cancelled = true;
+      };
+    });
+  }
+}
+
+function normalize(v: unknown): unknown {
+  if (v === undefined) return null;
+  if (v instanceof Date) {
+    // mysql2는 DATETIME을 Date 객체로 반환. ISO 대신 'YYYY-MM-DD HH:mm:ss' 사용
+    const pad = (n: number) => String(n).padStart(2, '0');
+    return `${v.getFullYear()}-${pad(v.getMonth() + 1)}-${pad(v.getDate())} ${pad(v.getHours())}:${pad(v.getMinutes())}:${pad(v.getSeconds())}`;
+  }
+  return v;
+}
+
+async function callTargetRaw(
+  baseUrl: string,
+  path: string,
+  token: string,
+  body: unknown,
+): Promise<unknown> {
+  const url = baseUrl.replace(/\/$/, '') + path;
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (token) headers['x-admin-session'] = token;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(
+      `target ${path} 실패 (${res.status}): ${text.slice(0, 300)}`,
+    );
+  }
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return {};
+  }
+}

--- a/server/src/admin/admin.module.ts
+++ b/server/src/admin/admin.module.ts
@@ -4,6 +4,7 @@ import { AdminAuthController } from './admin-auth.controller';
 import { AdminSitesController } from './admin-sites.controller';
 import { AdminCacheController } from './admin-cache.controller';
 import { AdminCharactersController } from './admin-characters.controller';
+import { AdminSyncController } from './admin-sync.controller';
 import { AdminGuard, AdminWriteGuard } from './admin.guard';
 import { StreamersModule } from '../streamers/streamers.module';
 
@@ -14,6 +15,7 @@ import { StreamersModule } from '../streamers/streamers.module';
     AdminSitesController,
     AdminCacheController,
     AdminCharactersController,
+    AdminSyncController,
   ],
   providers: [AdminAuthService, AdminGuard, AdminWriteGuard],
   exports: [AdminAuthService],


### PR DESCRIPTION
## 요약

로컬 어드민에서 버튼 한 번으로 `loa_users` / `loa_sites` 테이블을 프로덕션 DB로 복제하는 단방향 동기화 기능 추가.

## 변경사항

### NestJS (`server/src/admin/admin-sync.controller.ts`)
- `POST /api/admin/sync/:table/begin` — target: TRUNCATE (FK_CHECKS=0)
- `POST /api/admin/sync/:table/chunk` — target: 1000행 bulk INSERT (FK_CHECKS=0)
- `GET  /api/admin/sync/:table/run` (SSE) — source/orchestrator: 원격 로그인 → begin → 청크 전송 → 진행률 push
- 모두 owner 전용 (`@RequireOwner()`)

### Next.js
- `/admin/sync` 페이지: 테이블별 카드 + 진행률 바 + 취소 버튼
- `/api/admin/sync/[table]` 라우트: SSE 패스스루 프록시
- 어드민 사이드바에 `DB 동기화` 메뉴 추가

## 환경변수 (server/.env)
`
# 로컬 -> 원격(target) NestJS
SYNC_TARGET_API_URL=https://api.daloa.kr
SYNC_TARGET_ADMIN_PASSWORD=<원격 master 계정 비밀번호>
`

## 사전 마이그레이션
프로덕션 `loa_users`에 `combat_power DECIMAL(10,2)` 컬럼 추가 완료 (이미 적용됨).

## 보안
- owner 전용 가드
- TRUNCATE 전 확인 다이얼로그
- 원격 호출은 master 계정 비밀번호로 `/api/admin/auth/login` 후 일회용 sessionId 사용