### PR TITLE
Fix/admin

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -30,6 +30,16 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 
+    location /api/admin/sync/ {
+        proxy_pass         http://nest:3001;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_read_timeout 60s;
+    }
+
     location / {
         limit_req zone=api_per_ip burst=30 nodelay;
         proxy_pass         http://nest:3001;

--- a/server/src/admin/admin-sync.controller.ts
+++ b/server/src/admin/admin-sync.controller.ts
@@ -68,6 +68,7 @@ const TABLE_SPECS: Record<TableKey, TableSpec> = {
 // Keep each JSON payload below the default Nest/Express body limit.
 const SYNC_CHUNK_SIZE = 100;
 const SYNC_MAX_PAYLOAD_BYTES = 75 * 1024;
+const SYNC_CHUNK_DELAY_MS = 50;
 
 function specOrThrow(table: string): TableSpec {
   if (!(table in TABLE_SPECS)) {
@@ -260,6 +261,8 @@ export class AdminSyncController {
                 ),
                 lastSeq,
               });
+
+              await sleep(SYNC_CHUNK_DELAY_MS);
             }
 
             if (cancelled) break;
@@ -332,6 +335,10 @@ function splitRowsByPayloadSize(rows: unknown[][]): unknown[][][] {
 
 function payloadSize(body: unknown): number {
   return Buffer.byteLength(JSON.stringify(body), 'utf8');
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 async function callTargetRaw(


### PR DESCRIPTION
변경 내용:

#nginx/default.conf
- /api/admin/sync/ 전용 location 추가
- 이 경로는 limit_req 없이 Nest로 프록시합니다.
- 일반 API 경로 /는 기존 rate limit 유지합니다.

#server/src/admin/admin-sync.controller.ts
- chunk 전송마다 50ms 지연을 추가했습니다.
- Nginx 예외가 있어도 EC2/Nest/MySQL에 요청이 너무 빡빡하게 몰리지 않도록 완충합니다.