### PR TITLE
fix: make deploy key path repo-relative

### DIFF
--- a/context/INDEX.md
+++ b/context/INDEX.md
@@ -63,7 +63,7 @@ cd server && npm run test:e2e  # E2E (docker-compose up -d 선행)
 ### EC2 SSH 접속
 
 ```powershell
-ssh -i "C:\Users\tjdtn\Desktop\내가생각하는미래\개발\로아사이트 모음\daloa-key.pem" ubuntu@3.39.239.9
+ssh -i "C:\Users\tjdtn\Desktop\ingit\daloa\daloa-key.pem" ubuntu@3.39.239.9
 ```
 
 - PEM 키 위치: 프로젝트 루트 `daloa-key.pem`

--- a/context/deployment.md
+++ b/context/deployment.md
@@ -8,14 +8,14 @@
 
 - AWS EC2 ?몄뒪?댁뒪 (Ubuntu)
 - Docker + Docker Compose ?ㅼ튂??
-- SSH ???뚯씪: `daloa-key.pem` (寃쎈줈: `C:\Users\tjdtn\Desktop\?닿??앷컖?섎뒗誘몃옒\媛쒕컻\濡쒖븘?ъ씠??紐⑥쓬\daloa-key.pem`)
+- SSH ???뚯씪: `daloa-key.pem` (寃쎈줈: `C:\Users\tjdtn\Desktop\ingit\daloa\daloa-key.pem`)
 - EC2 IP: `3.39.239.9`
 - Let's Encrypt SSL ?몄쬆??諛쒓툒 ?꾨즺 (`api.daloa.kr`)
 
 ### 1-1. SSH ?묒냽
 
 ```powershell
-ssh -i "C:\\Users\\tjdtn\\Desktop\\내가생각하는미래\\개발\\로아사이트 모음\\daloa-key.pem" ubuntu@3.39.239.9
+ssh -i "C:\\Users\\tjdtn\\Desktop\\ingit\\daloa\\daloa-key.pem" ubuntu@3.39.239.9
 ```
 
 ### 1-2. 肄붾뱶 ?낅뜲?댄듃 + 鍮뚮뱶 + ?ъ떆??
@@ -39,7 +39,7 @@ docker compose up -d --build nest
 ### 1-3. ?먯빱留⑤뱶 諛고룷 (濡쒖뺄?먯꽌)
 
 ```powershell
-ssh -i "C:\\Users\\tjdtn\\Desktop\\내가생각하는미래\\개발\\로아사이트 모음\\daloa-key.pem" -o StrictHostKeyChecking=no ubuntu@3.39.239.9 "cd daloa && git pull && cd server && npm run build 2>&1 | tail -3 && cd .. && docker compose up -d --build nest 2>&1 | tail -3"
+ssh -i "C:\\Users\\tjdtn\\Desktop\\ingit\\daloa\\daloa-key.pem" -o StrictHostKeyChecking=no ubuntu@3.39.239.9 "cd daloa && git pull && cd server && npm run build 2>&1 | tail -3 && cd .. && docker compose up -d --build nest 2>&1 | tail -3"
 ```
 
 ### 1-4. ?꾩껜 ?쒕퉬???ъ떆??(MySQL, Redis, Nginx ?ы븿)
@@ -67,7 +67,7 @@ cd daloa && docker compose up -d --build nest
 
 ```powershell
 # ?? EC2 ?꾩슜 ??鍮꾨?踰덊샇媛 ?ы븿??EC2 .env瑜?濡쒖뺄?먯꽌 ??뼱?곗? ?딅룄濡?二쇱쓽
-scp -i "C:\\Users\\tjdtn\\Desktop\\내가생각하는미래\\개발\\로아사이트 모음\\daloa-key.pem" .env ubuntu@3.39.239.9:/home/ubuntu/daloa/.env
+scp -i "C:\\Users\\tjdtn\\Desktop\\ingit\\daloa\\daloa-key.pem" .env ubuntu@3.39.239.9:/home/ubuntu/daloa/.env
 ```
 
 ### 1-5. 濡쒓렇 ?뺤씤
@@ -310,14 +310,14 @@ scp -i "daloa-key.pem" scripts/dump.sql ubuntu@3.39.239.9:~/daloa/scripts/
 
 ```powershell
 # 1. 濡쒖뺄?먯꽌 SQL ?뚯씪 ?묒꽦 ??EC2濡??꾩넚
-scp -i "C:\\Users\\tjdtn\\Desktop\\내가생각하는미래\\개발\\로아사이트 모음\\daloa-key.pem" fix.sql ubuntu@3.39.239.9:/tmp/fix.sql
+scp -i "C:\\Users\\tjdtn\\Desktop\\ingit\\daloa\\daloa-key.pem" fix.sql ubuntu@3.39.239.9:/tmp/fix.sql
 
 # 2. EC2 MySQL 而⑦뀒?대꼫?먯꽌 ?ㅽ뻾
-ssh -i "C:\\Users\\tjdtn\\Desktop\\내가생각하는미래\\개발\\로아사이트 모음\\daloa-key.pem" -o StrictHostKeyChecking=no ubuntu@3.39.239.9 \
+ssh -i "C:\\Users\\tjdtn\\Desktop\\ingit\\daloa\\daloa-key.pem" -o StrictHostKeyChecking=no ubuntu@3.39.239.9 \
   "docker exec -i daloa-mysql mysql -udaloa -p1234 --default-character-set=utf8mb4 lost_ark < /tmp/fix.sql"
 
 # 3. 愿??Redis 罹먯떆 ??젣 (?? sites)
-ssh -i "C:\\Users\\tjdtn\\Desktop\\내가생각하는미래\\개발\\로아사이트 모음\\daloa-key.pem" -o StrictHostKeyChecking=no ubuntu@3.39.239.9 \
+ssh -i "C:\\Users\\tjdtn\\Desktop\\ingit\\daloa\\daloa-key.pem" -o StrictHostKeyChecking=no ubuntu@3.39.239.9 \
   "docker exec daloa-redis redis-cli -a Redis9999! DEL sites:all"
 ```
 

--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -3,11 +3,21 @@
 # 효과: git pull → dist 삭제 → npm run build → Nest/Nginx 재생성 → Redis 캐시 플러시
 
 param(
-    [string]$KeyPath = "C:\Users\tjdtn\Desktop\내가생각하는미래\개발\로아사이트 모음\daloa-key.pem",
-    [string]$Host    = "ubuntu@3.39.239.9",
-    [switch]$FlushRedis,    # -FlushRedis 시 Redis 캐시 전체 삭제
-    [switch]$Full           # -Full 시 MySQL/Redis/Nginx 포함 전체 재시작
+    [string]$KeyPath = "",
+    [string]$SshHost = "ubuntu@3.39.239.9",
+    [switch]$FlushRedis,
+    [switch]$Full
 )
+
+$Root = Split-Path -Parent $PSScriptRoot
+if (-not $KeyPath) {
+    $KeyPath = Join-Path $Root "daloa-key.pem"
+}
+
+if (-not (Test-Path -LiteralPath $KeyPath)) {
+    Write-Host "[deploy] SSH key not found: $KeyPath"
+    exit 1
+}
 
 Write-Host ""
 Write-Host "========================================"
@@ -40,7 +50,7 @@ $remoteCmd = $commands -join " && "
 Write-Host "[deploy] SSH 접속 + 배포 시작..."
 Write-Host ""
 
-ssh -i $KeyPath -o StrictHostKeyChecking=no $Host $remoteCmd
+ssh -i "$KeyPath" -o StrictHostKeyChecking=no $SshHost $remoteCmd
 
 $exitCode = $LASTEXITCODE
 


### PR DESCRIPTION
## Summary
- Replace stale local SSH key path examples with the current repository path.
- Make `scripts/deploy.ps1` default to the repo-root `daloa-key.pem` instead of a user-specific absolute path.
- Rename the deploy host parameter to `SshHost` and add a key existence check before SSH.

## Validation
- Parsed `scripts/deploy.ps1` with the PowerShell parser.
- Checked staged diff with `git diff --cached --check`.
- Confirmed old local path strings are no longer present.