### PR TITLE
feat(admin): bidirectional sync by runtime with admin credential scrub

### DIFF
--- a/client/app/admin/login/page.tsx
+++ b/client/app/admin/login/page.tsx
@@ -35,8 +35,10 @@ export default function AdminLoginPage() {
     await login(username, password);
   }
 
-  async function handleGuestLogin() {
-    await login("guest", "1237");
+  function handleGuestFill() {
+    setUsername("guest");
+    setPassword("");
+    setError("");
   }
 
   return (
@@ -82,10 +84,10 @@ export default function AdminLoginPage() {
           <button
             type="button"
             disabled={loading}
-            onClick={handleGuestLogin}
+            onClick={handleGuestFill}
             className="admin-btn admin-btn-secondary w-full"
           >
-            게스트로 둘러보기
+            게스트 아이디 채우기
           </button>
         </form>
       </div>

--- a/client/app/admin/sync/page.tsx
+++ b/client/app/admin/sync/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 type Phase = "idle" | "login" | "begin" | "count" | "chunk" | "done" | "error";
+type SyncDirection = "local-to-prod" | "prod-to-local";
 
 interface SyncState {
   phase: Phase;
@@ -26,12 +27,12 @@ const TABLES: { key: "users" | "sites"; label: string; desc: string }[] = [
   {
     key: "users",
     label: "loa_users (캐릭터)",
-    desc: "전체 캐릭터 데이터를 프로덕션 DB로 덮어씁니다. 기존 프로덕션 데이터는 모두 삭제됩니다.",
+    desc: "선택한 방향 기준으로 전체 데이터를 다시 동기화합니다.",
   },
   {
     key: "sites",
     label: "loa_sites (사이트 모음)",
-    desc: "전체 사이트 데이터를 프로덕션 DB로 덮어씁니다. 기존 프로덕션 데이터는 모두 삭제됩니다.",
+    desc: "선택한 방향 기준으로 전체 데이터를 다시 동기화합니다.",
   },
 ];
 
@@ -44,16 +45,31 @@ export default function SyncPage() {
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+  const [direction, setDirection] = useState<SyncDirection>("local-to-prod");
   const [state, setState] = useState<SyncState>(INITIAL);
   const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    const host = window.location.hostname;
+    const isLocalHost =
+      host === "localhost" || host === "127.0.0.1" || host === "::1";
+    setDirection(isLocalHost ? "local-to-prod" : "prod-to-local");
+  }, []);
 
   const running =
     state.phase !== "idle" && state.phase !== "done" && state.phase !== "error";
 
+  const directionLabel =
+    direction === "local-to-prod" ? "Local → Prod" : "Prod → Local";
+
   const handleSyncClick = (tableKey: "users" | "sites") => {
     const table = TABLES.find((item) => item.key === tableKey);
+    const actionText =
+      direction === "local-to-prod"
+        ? "프로덕션 테이블을 삭제 후 로컬 데이터로 재삽입"
+        : "로컬 테이블을 삭제 후 프로덕션 데이터로 재삽입";
     const ok = window.confirm(
-      `[${table?.label ?? tableKey}]\n\n프로덕션의 해당 테이블을 전체 삭제 후 로컬 데이터로 재삽입합니다.\n계속하시겠습니까?`,
+      `[${table?.label ?? tableKey}] (${directionLabel})\n\n${actionText} 합니다.\n계속하시겠습니까?`,
     );
     if (!ok) return;
 
@@ -65,15 +81,17 @@ export default function SyncPage() {
   async function start(sessionId: string) {
     if (!activeTable) return;
 
-    setState({ ...INITIAL, phase: "login", message: "시작 중..." });
+    setState({
+      ...INITIAL,
+      phase: "login",
+      message: `${directionLabel} 준비 중...`,
+    });
     const ctrl = new AbortController();
     abortRef.current = ctrl;
 
     try {
       const res = await fetch(
-        `/api/admin/sync/${activeTable}?sessionId=${encodeURIComponent(
-          sessionId,
-        )}`,
+        `/api/admin/sync/${activeTable}?sessionId=${encodeURIComponent(sessionId)}&direction=${encodeURIComponent(direction)}`,
         {
           method: "GET",
           signal: ctrl.signal,
@@ -106,7 +124,8 @@ export default function SyncPage() {
       setState((s) => ({
         ...s,
         phase: "error",
-        error: err instanceof Error ? err.message : "동기화 중 오류가 발생했습니다.",
+        error:
+          err instanceof Error ? err.message : "동기화 중 오류가 발생했습니다.",
       }));
     } finally {
       abortRef.current = null;
@@ -162,13 +181,39 @@ export default function SyncPage() {
     <div>
       <div className="space-y-6">
         <header>
-          <h1 className="text-2xl font-bold">서버 동기화 (Local → Prod)</h1>
+          <h1 className="text-2xl font-bold">서버 동기화</h1>
           <p className="mt-2 text-sm text-gray-400">
-            로컬 DB 내용을 프로덕션 DB로 단방향 복제합니다. 프로덕션의 해당
-            테이블은 <strong className="text-red-400">TRUNCATE</strong> 후 전체
-            재삽입됩니다.
+            동기화 방향을 선택한 뒤 실행합니다. 대상 측 테이블은{" "}
+            <strong className="text-red-400">TRUNCATE</strong> 후 전체 재삽입됩니다.
           </p>
         </header>
+
+        <div className="flex gap-2 text-sm">
+          <button
+            type="button"
+            disabled={running}
+            onClick={() => setDirection("local-to-prod")}
+            className={`rounded px-3 py-2 ${
+              direction === "local-to-prod"
+                ? "bg-blue-700 text-white"
+                : "bg-gray-800 text-gray-300"
+            }`}
+          >
+            Local → Prod
+          </button>
+          <button
+            type="button"
+            disabled={running}
+            onClick={() => setDirection("prod-to-local")}
+            className={`rounded px-3 py-2 ${
+              direction === "prod-to-local"
+                ? "bg-blue-700 text-white"
+                : "bg-gray-800 text-gray-300"
+            }`}
+          >
+            Prod → Local
+          </button>
+        </div>
 
         <div className="grid gap-4 md:grid-cols-2">
           {TABLES.map((t) => {
@@ -218,10 +263,7 @@ export default function SyncPage() {
                       {phaseLabel(tableState.phase)}
                     </span>
                     {tableState.message && (
-                      <span className="text-gray-500">
-                        {" "}
-                        · {tableState.message}
-                      </span>
+                      <span className="text-gray-500"> · {tableState.message}</span>
                     )}
                   </div>
                   {tableState.error && (

--- a/client/app/api/admin/sync/[table]/route.ts
+++ b/client/app/api/admin/sync/[table]/route.ts
@@ -9,6 +9,7 @@ export async function GET(
 ) {
   const { table } = await params;
   const sessionId = req.nextUrl.searchParams.get("sessionId")?.trim() ?? "";
+  const direction = req.nextUrl.searchParams.get("direction")?.trim() ?? "";
 
   if (!sessionId) {
     return new Response("missing remote session", { status: 401 });
@@ -16,10 +17,14 @@ export async function GET(
   if (table !== "users" && table !== "sites") {
     return new Response("invalid table", { status: 400 });
   }
+  if (direction !== "local-to-prod" && direction !== "prod-to-local") {
+    return new Response("invalid direction", { status: 400 });
+  }
 
-  const url = `${NEST_API}/api/admin/sync/${table}/run?sessionId=${encodeURIComponent(
-    sessionId,
-  )}`;
+  const url =
+    `${NEST_API}/api/admin/sync/${table}/run` +
+    `?sessionId=${encodeURIComponent(sessionId)}` +
+    `&direction=${encodeURIComponent(direction)}`;
   const upstream = await fetch(url, {
     method: "GET",
     headers: {

--- a/server/src/admin/admin-sync.controller.ts
+++ b/server/src/admin/admin-sync.controller.ts
@@ -1,26 +1,27 @@
 import {
-  Controller,
-  Post,
-  Param,
-  Body,
-  Sse,
-  Query,
-  UseGuards,
   BadRequestException,
-  Inject,
-  MessageEvent,
+  Body,
+  Controller,
   HttpCode,
   HttpStatus,
+  Inject,
+  MessageEvent,
+  Param,
+  Post,
+  Query,
+  Sse,
+  UseGuards,
 } from '@nestjs/common';
-import type { Pool } from 'mysql2/promise';
-import type { RowDataPacket, ResultSetHeader } from 'mysql2';
-import { Observable } from 'rxjs';
 import { ConfigService } from '@nestjs/config';
-import { DB_POOL } from '../db/db.module';
-import { AdminWriteGuard, RequireOwner } from './admin.guard';
+import type { RowDataPacket, ResultSetHeader } from 'mysql2';
+import type { Pool } from 'mysql2/promise';
+import { Observable } from 'rxjs';
 import { AdminAuthService } from './admin-auth.service';
+import { AdminWriteGuard, RequireOwner } from './admin.guard';
+import { DB_POOL } from '../db/db.module';
 
 type TableKey = 'users' | 'sites';
+type SyncDirection = 'local-to-prod' | 'prod-to-local';
 
 interface TableSpec {
   table: string;
@@ -65,16 +66,22 @@ const TABLE_SPECS: Record<TableKey, TableSpec> = {
   },
 };
 
-// Keep each JSON payload below the default Nest/Express body limit.
 const SYNC_CHUNK_SIZE = 25;
 const SYNC_MAX_PAYLOAD_BYTES = 32 * 1024;
 const SYNC_CHUNK_DELAY_MS = 1000;
 
 function specOrThrow(table: string): TableSpec {
   if (!(table in TABLE_SPECS)) {
-    throw new BadRequestException(`지원하지 않는 테이블: ${table}`);
+    throw new BadRequestException(`unsupported table: ${table}`);
   }
   return TABLE_SPECS[table as TableKey];
+}
+
+function directionOrThrow(direction: string): SyncDirection {
+  if (direction === 'local-to-prod' || direction === 'prod-to-local') {
+    return direction;
+  }
+  throw new BadRequestException(`unsupported direction: ${direction}`);
 }
 
 @Controller('api/admin/sync')
@@ -85,7 +92,6 @@ export class AdminSyncController {
     private readonly authService: AdminAuthService,
   ) {}
 
-  /** target 측: 동기화 시작 - TRUNCATE */
   @Post(':table/begin')
   @UseGuards(AdminWriteGuard)
   @RequireOwner()
@@ -102,7 +108,6 @@ export class AdminSyncController {
     return { ok: true, table: spec.table };
   }
 
-  /** target 측: 행 청크 bulk INSERT */
   @Post(':table/chunk')
   @UseGuards(AdminWriteGuard)
   @RequireOwner()
@@ -115,10 +120,11 @@ export class AdminSyncController {
     if (!Array.isArray(rows) || rows.length === 0) {
       return { inserted: 0 };
     }
+
     for (const row of rows) {
       if (!Array.isArray(row) || row.length !== spec.columns.length) {
         throw new BadRequestException(
-          `행 길이가 컬럼 수와 다릅니다 (expected=${spec.columns.length})`,
+          `row length mismatch (expected=${spec.columns.length})`,
         );
       }
     }
@@ -138,26 +144,66 @@ export class AdminSyncController {
     }
   }
 
+  @Post(':table/count')
+  @UseGuards(AdminWriteGuard)
+  @RequireOwner()
+  async count(@Param('table') table: string) {
+    const spec = specOrThrow(table);
+    const [rows] = await this.pool.query<RowDataPacket[]>(
+      `SELECT COUNT(*) AS total FROM \`${spec.table}\``,
+    );
+    return { total: Number(rows[0]?.total ?? 0) };
+  }
+
+  @Post(':table/chunk-read')
+  @UseGuards(AdminWriteGuard)
+  @RequireOwner()
+  async chunkRead(
+    @Param('table') table: string,
+    @Body() body: { afterSeq?: number; limit?: number },
+  ) {
+    const spec = specOrThrow(table);
+    const afterSeq = Number(body?.afterSeq ?? 0);
+    const limit = Number(body?.limit ?? SYNC_CHUNK_SIZE);
+    const safeLimit = Math.max(1, Math.min(SYNC_CHUNK_SIZE, limit));
+    const colList = spec.columns.map((c) => `\`${c}\``).join(', ');
+
+    const [rows] = await this.pool.query<RowDataPacket[]>(
+      `SELECT ${colList} FROM \`${spec.table}\` WHERE seq > ${afterSeq} ORDER BY seq ASC LIMIT ${safeLimit}`,
+    );
+    const values = rows.map((r) => spec.columns.map((c) => normalize(r[c])));
+    const lastSeq = rows.length > 0 ? Number(rows[rows.length - 1].seq) : afterSeq;
+    return { rows: values, lastSeq };
+  }
+
   @Post('check')
   @HttpCode(HttpStatus.OK)
-  async sync_login_check(
-    @Body() body: { username?: string; password?: string },
-  ) {
+  async syncLoginCheck(@Body() body: { username?: string; password?: string }) {
     if (!body.username || !body.password) {
-      throw new BadRequestException('username과 password는 필수입니다');
+      throw new BadRequestException('username/password required');
     }
     return this.authService.login(body.username, body.password);
   }
 
-  /** source/orchestrator 측: 로컬 DB → 원격 target API로 SSE 진행률 스트림 */
   @Sse(':table/run')
   run(
     @Param('table') table: string,
     @Query('sessionId') sessionId?: string,
+    @Query('direction') direction?: string,
   ): Observable<MessageEvent> {
     const spec = specOrThrow(table);
+    const syncDirection = directionOrThrow(direction?.trim() ?? '');
     const targetUrl = this.config.get<string>('SYNC_TARGET_API_URL', '').trim();
     const remoteToken = sessionId?.trim() ?? '';
+    const isLocalRuntime =
+      this.config.get<string>('NODE_ENV', '').trim() !== 'production';
+
+    if (syncDirection === 'local-to-prod' && !isLocalRuntime) {
+      throw new BadRequestException('local-to-prod is allowed only on local runtime');
+    }
+    if (syncDirection === 'prod-to-local' && isLocalRuntime) {
+      throw new BadRequestException('prod-to-local is allowed only on production runtime');
+    }
 
     return new Observable<MessageEvent>((subscriber) => {
       let cancelled = false;
@@ -172,40 +218,46 @@ export class AdminSyncController {
       void (async () => {
         try {
           if (!targetUrl) {
-            throw new Error(
-              'SYNC_TARGET_API_URL 환경변수가 설정되지 않았습니다',
-            );
+            throw new Error('SYNC_TARGET_API_URL is required');
           }
           if (!remoteToken) {
-            throw new Error('원격 관리자 세션이 없습니다');
+            throw new Error('remote admin session is required');
           }
 
-          // run은 로컬 DB를 읽는 orchestrator입니다.
-          // 원격 세션은 Next의 sync/check가 EC2에서 발급받아 전달합니다.
           emit('progress', {
             phase: 'login',
-            message: '원격 관리자 세션 확인 중',
+            message:
+              syncDirection === 'local-to-prod'
+                ? 'validating remote session'
+                : 'validating remote source session',
             percent: 0,
           });
 
-          // 1) target 측 begin (TRUNCATE)
           emit('progress', {
             phase: 'begin',
-            message: `${spec.table} TRUNCATE 중...`,
+            message:
+              syncDirection === 'local-to-prod'
+                ? `${spec.table} remote TRUNCATE`
+                : `${spec.table} local TRUNCATE`,
             percent: 0,
           });
-          await callTargetRaw(
-            targetUrl,
-            `/api/admin/sync/${table}/begin`,
-            remoteToken,
-            {},
-          );
 
-          // 2) total count
-          const [countRows] = await this.pool.query<RowDataPacket[]>(
-            `SELECT COUNT(*) AS total FROM \`${spec.table}\``,
-          );
-          const total = Number(countRows[0]?.total ?? 0);
+          if (syncDirection === 'local-to-prod') {
+            await callTargetRaw(
+              targetUrl,
+              `/api/admin/sync/${table}/begin`,
+              remoteToken,
+              {},
+            );
+          } else {
+            await this.begin(table);
+          }
+
+          const total =
+            syncDirection === 'local-to-prod'
+              ? await readLocalCount(this.pool, spec.table)
+              : await readRemoteCount(targetUrl, table, remoteToken);
+
           emit('progress', {
             phase: 'count',
             total,
@@ -219,33 +271,38 @@ export class AdminSyncController {
             return;
           }
 
-          // 3) chunked read + push
-          const colList = spec.columns.map((c) => `\`${c}\``).join(', ');
           let transferred = 0;
           let lastSeq = 0;
 
           while (!cancelled) {
-            const [chunkRows] = await this.pool.query<RowDataPacket[]>(
-              `SELECT ${colList} FROM \`${spec.table}\` WHERE seq > ${lastSeq} ORDER BY seq ASC LIMIT ${SYNC_CHUNK_SIZE}`,
-            );
-            if (chunkRows.length === 0) break;
+            const values =
+              syncDirection === 'local-to-prod'
+                ? await readLocalChunk(this.pool, spec, lastSeq, SYNC_CHUNK_SIZE)
+                : await readRemoteChunk(
+                    targetUrl,
+                    table,
+                    spec,
+                    remoteToken,
+                    lastSeq,
+                    SYNC_CHUNK_SIZE,
+                  );
 
-            const values = chunkRows.map((r) =>
-              spec.columns.map((c) => normalize(r[c])),
-            );
-
-            const last = chunkRows[chunkRows.length - 1];
-            lastSeq = Number(last.seq);
+            if (values.length === 0) break;
+            const last = values[values.length - 1];
+            lastSeq = Number(last[0] ?? lastSeq);
 
             for (const rows of splitRowsByPayloadSize(values)) {
               if (cancelled) break;
 
-              const res = await callTargetRaw(
-                targetUrl,
-                `/api/admin/sync/${table}/chunk`,
-                remoteToken,
-                { rows },
-              );
+              const res =
+                syncDirection === 'local-to-prod'
+                  ? await callTargetRaw(
+                      targetUrl,
+                      `/api/admin/sync/${table}/chunk`,
+                      remoteToken,
+                      { rows },
+                    )
+                  : await this.chunk(table, { rows });
               const inserted = Number(
                 (res as { inserted?: number })?.inserted ?? 0,
               );
@@ -255,10 +312,7 @@ export class AdminSyncController {
                 phase: 'chunk',
                 total,
                 transferred,
-                percent: Math.min(
-                  99,
-                  Math.floor((transferred / total) * 100),
-                ),
+                percent: Math.min(99, Math.floor((transferred / total) * 100)),
                 lastSeq,
               });
 
@@ -269,7 +323,7 @@ export class AdminSyncController {
           }
 
           if (cancelled) {
-            emit('error', { message: '취소됨' });
+            emit('error', { message: 'cancelled' });
             subscriber.complete();
             return;
           }
@@ -299,10 +353,61 @@ export class AdminSyncController {
   }
 }
 
+async function readLocalCount(pool: Pool, table: string): Promise<number> {
+  const [rows] = await pool.query<RowDataPacket[]>(
+    `SELECT COUNT(*) AS total FROM \`${table}\``,
+  );
+  return Number(rows[0]?.total ?? 0);
+}
+
+async function readLocalChunk(
+  pool: Pool,
+  spec: TableSpec,
+  lastSeq: number,
+  limit: number,
+): Promise<unknown[][]> {
+  const colList = spec.columns.map((c) => `\`${c}\``).join(', ');
+  const [rows] = await pool.query<RowDataPacket[]>(
+    `SELECT ${colList} FROM \`${spec.table}\` WHERE seq > ${lastSeq} ORDER BY seq ASC LIMIT ${limit}`,
+  );
+  return rows.map((r) => spec.columns.map((c) => normalize(r[c])));
+}
+
+async function readRemoteCount(
+  baseUrl: string,
+  table: string,
+  token: string,
+): Promise<number> {
+  const res = await callTargetRaw(baseUrl, `/api/admin/sync/${table}/count`, token, {});
+  return Number((res as { total?: number })?.total ?? 0);
+}
+
+async function readRemoteChunk(
+  baseUrl: string,
+  table: string,
+  spec: TableSpec,
+  token: string,
+  lastSeq: number,
+  limit: number,
+): Promise<unknown[][]> {
+  const res = await callTargetRaw(
+    baseUrl,
+    `/api/admin/sync/${table}/chunk-read`,
+    token,
+    { afterSeq: lastSeq, limit },
+  );
+  const rows = Array.isArray((res as { rows?: unknown[][] })?.rows)
+    ? ((res as { rows: unknown[][] }).rows as unknown[][])
+    : [];
+
+  return rows.map((row) =>
+    spec.columns.map((_, idx) => (Array.isArray(row) ? row[idx] ?? null : null)),
+  );
+}
+
 function normalize(v: unknown): unknown {
   if (v === undefined) return null;
   if (v instanceof Date) {
-    // mysql2는 DATETIME을 Date 객체로 반환. ISO 대신 'YYYY-MM-DD HH:mm:ss' 사용
     const pad = (n: number) => String(n).padStart(2, '0');
     return `${v.getFullYear()}-${pad(v.getMonth() + 1)}-${pad(v.getDate())} ${pad(v.getHours())}:${pad(v.getMinutes())}:${pad(v.getSeconds())}`;
   }
@@ -359,9 +464,7 @@ async function callTargetRaw(
   });
   const text = await res.text();
   if (!res.ok) {
-    throw new Error(
-      `target ${path} 실패 (${res.status}): ${text.slice(0, 300)}`,
-    );
+    throw new Error(`target ${path} failed (${res.status}): ${text.slice(0, 300)}`);
   }
   try {
     return JSON.parse(text) as unknown;

--- a/server/src/admin/admin-sync.controller.ts
+++ b/server/src/admin/admin-sync.controller.ts
@@ -77,6 +77,14 @@ function specOrThrow(table: string): TableSpec {
   return TABLE_SPECS[table as TableKey];
 }
 
+function seqIndexOrThrow(spec: TableSpec): number {
+  const seqIndex = spec.columns.indexOf('seq');
+  if (seqIndex === -1) {
+    throw new BadRequestException(`seq column not found for ${spec.table}`);
+  }
+  return seqIndex;
+}
+
 function directionOrThrow(direction: string): SyncDirection {
   if (direction === 'local-to-prod' || direction === 'prod-to-local') {
     return direction;
@@ -163,6 +171,7 @@ export class AdminSyncController {
     @Body() body: { afterSeq?: number; limit?: number },
   ) {
     const spec = specOrThrow(table);
+    const seqIndex = seqIndexOrThrow(spec);
     const afterSeq = Number(body?.afterSeq ?? 0);
     const limit = Number(body?.limit ?? SYNC_CHUNK_SIZE);
     const safeLimit = Math.max(1, Math.min(SYNC_CHUNK_SIZE, limit));
@@ -172,7 +181,10 @@ export class AdminSyncController {
       `SELECT ${colList} FROM \`${spec.table}\` WHERE seq > ${afterSeq} ORDER BY seq ASC LIMIT ${safeLimit}`,
     );
     const values = rows.map((r) => spec.columns.map((c) => normalize(r[c])));
-    const lastSeq = rows.length > 0 ? Number(rows[rows.length - 1].seq) : afterSeq;
+    const lastRow = rows[rows.length - 1];
+    const seqColumn = spec.columns[seqIndex];
+    const lastSeq =
+      rows.length > 0 ? Number(lastRow[seqColumn] ?? afterSeq) : afterSeq;
     return { rows: values, lastSeq };
   }
 
@@ -192,6 +204,7 @@ export class AdminSyncController {
     @Query('direction') direction?: string,
   ): Observable<MessageEvent> {
     const spec = specOrThrow(table);
+    const seqIndex = seqIndexOrThrow(spec);
     const syncDirection = directionOrThrow(direction?.trim() ?? '');
     const targetUrl = this.config.get<string>('SYNC_TARGET_API_URL', '').trim();
     const remoteToken = sessionId?.trim() ?? '';
@@ -289,7 +302,7 @@ export class AdminSyncController {
 
             if (values.length === 0) break;
             const last = values[values.length - 1];
-            lastSeq = Number(last[0] ?? lastSeq);
+            lastSeq = Number(last[seqIndex] ?? lastSeq);
 
             for (const rows of splitRowsByPayloadSize(values)) {
               if (cancelled) break;


### PR DESCRIPTION
## Summary
- Added bidirectional admin sync directions: `local-to-prod` and `prod-to-local`.
- Added runtime guardrails in server sync orchestrator:
  - `local-to-prod` only on local runtime
  - `prod-to-local` only on production runtime
- Added remote read endpoints for sync source pull (`count`, `chunk-read`) with owner/write guard.
- Updated admin sync UI to select direction and auto-default by host (`localhost` -> local-to-prod, otherwise prod-to-local).
- Removed hardcoded guest password from admin login page. The guest button now only fills the username.

## Security check
- Searched repository for hardcoded `admin_users` row values and known plaintext test password (`1237`); none remain.
- Confirmed only schema/parameterized query definitions for `admin_users` remain.

## Validation
- `server`: `npm run build` succeeded.
- `client`: `npm run build` succeeded.