### PR TITLE
fix(클라이언트): 어드민 로그인 테스트를 게스트 아이디 채우기 동작에 맞춤

### DIFF
--- a/client/app/admin/login/page.test.tsx
+++ b/client/app/admin/login/page.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AdminLoginPage from "./page";
 
 describe("AdminLoginPage", () => {
@@ -16,6 +16,7 @@ describe("AdminLoginPage", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it("로그인 성공 시 window.location.replace로 /admin/sites 이동", async () => {
@@ -35,8 +36,6 @@ describe("AdminLoginPage", () => {
     await waitFor(() => {
       expect(replaceSpy).toHaveBeenCalledWith("/admin/sites");
     });
-
-    vi.unstubAllGlobals();
   });
 
   it("로그인 실패 시 에러 메시지 표시", async () => {
@@ -59,23 +58,19 @@ describe("AdminLoginPage", () => {
     await waitFor(() => {
       expect(screen.getByText("인증 실패")).toBeTruthy();
     });
-
-    vi.unstubAllGlobals();
   });
 
-  it("게스트 로그인 성공 시 window.location.replace로 /admin/sites 이동", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+  it("게스트 아이디 채우기 버튼 클릭 시 아이디만 guest로 채워짐", async () => {
+    render(<AdminLoginPage />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "게스트 아이디 채우기" }),
     );
 
-    render(<AdminLoginPage />);
-    await userEvent.click(screen.getByRole("button", { name: /게스트/ }));
-
-    await waitFor(() => {
-      expect(replaceSpy).toHaveBeenCalledWith("/admin/sites");
-    });
-
-    vi.unstubAllGlobals();
+    expect(screen.getByRole("textbox")).toHaveValue("guest");
+    const passwordInput = document.querySelector<HTMLInputElement>(
+      'input[type="password"]',
+    )!;
+    expect(passwordInput).toHaveValue("");
   });
 });


### PR DESCRIPTION
## 요약
- 게스트 버튼이 더 이상 즉시 로그인하지 않고 아이디만 채우는 새 동작에 맞춰 테스트를 수정했습니다.
- 로그인 성공/실패 테스트는 그대로 유지했고, 게스트 버튼 테스트는 아이디와 비밀번호 입력 상태를 검증하도록 바꿨습니다.