### PR TITLE
fix(어드민): 게스트 권한의 쓰기 작업 차단

### DIFF
--- a/client/app/admin/cache/page.tsx
+++ b/client/app/admin/cache/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { buildGuestNotice, useAdminRole } from "@/lib/admin-role";
 
 const CACHE_KEYS = [
   { key: "sites", label: "사이트 목록", desc: "sites:all" },
@@ -14,8 +15,18 @@ export default function AdminCachePage() {
   const [status, setStatus] = useState<StatusMap>({});
   const [allLoading, setAllLoading] = useState(false);
   const [allResult, setAllResult] = useState("");
+  const [accessNotice, setAccessNotice] = useState("");
+  const role = useAdminRole();
+  const isGuest = role === "guest";
+
+  function requireMaster(action: string) {
+    if (!isGuest) return true;
+    setAccessNotice(buildGuestNotice(action));
+    return false;
+  }
 
   async function purgeOne(key: string) {
+    if (!requireMaster("캐시 개별 새로고침")) return;
     setStatus((p) => ({ ...p, [key]: "loading" }));
     const res = await fetch("/api/admin/cache", {
       method: "POST",
@@ -27,6 +38,7 @@ export default function AdminCachePage() {
   }
 
   async function purgeAll() {
+    if (!requireMaster("전체 캐시 새로고침")) return;
     setAllLoading(true);
     setAllResult("");
     const res = await fetch("/api/admin/cache", { method: "DELETE" });
@@ -53,6 +65,11 @@ export default function AdminCachePage() {
         <p className="admin-page-subtitle">
           캐시를 삭제하면 다음 요청 시 DB에서 새로 조회합니다.
         </p>
+        {accessNotice && (
+          <pre className="mt-3 whitespace-pre-wrap rounded border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+            {accessNotice}
+          </pre>
+        )}
       </div>
 
       <div className="admin-card admin-card-padded space-y-3 mb-6">

--- a/client/app/admin/characters/page.tsx
+++ b/client/app/admin/characters/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { buildGuestNotice, useAdminRole } from "@/lib/admin-role";
 
 interface Character {
   name: string;
@@ -43,6 +44,9 @@ export default function AdminCharactersPage() {
   const [result, setResult] = useState<ListResult | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const [accessNotice, setAccessNotice] = useState("");
+  const role = useAdminRole();
+  const isGuest = role === "guest";
 
   const [search, setSearch] = useState("");
   const [statBuild, setStatBuild] = useState("");
@@ -84,7 +88,14 @@ export default function AdminCharactersPage() {
 
   const [purging, setPurging] = useState(false);
 
+  function requireMaster(action: string) {
+    if (!isGuest) return true;
+    setAccessNotice(buildGuestNotice(action));
+    return false;
+  }
+
   async function handlePurge() {
+    if (!requireMaster("캐릭터 캐시 새로고침")) return;
     setPurging(true);
     try {
       await fetch("/api/admin/cache", {
@@ -113,6 +124,11 @@ export default function AdminCharactersPage() {
             총 {result?.total.toLocaleString() ?? "-"}명의 캐릭터가 등록되어
             있습니다.
           </p>
+          {accessNotice && (
+            <pre className="mt-3 whitespace-pre-wrap rounded border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+              {accessNotice}
+            </pre>
+          )}
         </div>
         <button
           onClick={handlePurge}

--- a/client/app/admin/login/page.test.tsx
+++ b/client/app/admin/login/page.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AdminLoginPage from "./page";
 
 describe("AdminLoginPage", () => {
@@ -16,6 +16,7 @@ describe("AdminLoginPage", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it("로그인 성공 시 window.location.replace로 /admin/sites 이동", async () => {
@@ -35,8 +36,6 @@ describe("AdminLoginPage", () => {
     await waitFor(() => {
       expect(replaceSpy).toHaveBeenCalledWith("/admin/sites");
     });
-
-    vi.unstubAllGlobals();
   });
 
   it("로그인 실패 시 에러 메시지 표시", async () => {
@@ -59,23 +58,19 @@ describe("AdminLoginPage", () => {
     await waitFor(() => {
       expect(screen.getByText("인증 실패")).toBeTruthy();
     });
-
-    vi.unstubAllGlobals();
   });
 
-  it("게스트 로그인 성공 시 window.location.replace로 /admin/sites 이동", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+  it("게스트 아이디 채우기 버튼 클릭 시 아이디만 guest로 채워짐", async () => {
+    render(<AdminLoginPage />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "게스트 아이디 채우기" }),
     );
 
-    render(<AdminLoginPage />);
-    await userEvent.click(screen.getByRole("button", { name: /게스트/ }));
-
-    await waitFor(() => {
-      expect(replaceSpy).toHaveBeenCalledWith("/admin/sites");
-    });
-
-    vi.unstubAllGlobals();
+    expect(screen.getByRole("textbox")).toHaveValue("guest");
+    const passwordInput = document.querySelector<HTMLInputElement>(
+      'input[type="password"]',
+    )!;
+    expect(passwordInput).toHaveValue("");
   });
 });

--- a/client/app/admin/sites/page.tsx
+++ b/client/app/admin/sites/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { buildGuestNotice, useAdminRole } from "@/lib/admin-role";
 
 interface Site {
   seq: number;
@@ -93,7 +94,10 @@ export default function AdminSitesPage() {
   const [sites, setSites] = useState<Site[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const [accessNotice, setAccessNotice] = useState("");
   const [busyMessage, setBusyMessage] = useState<string | null>(null);
+  const role = useAdminRole();
+  const isGuest = role === "guest";
 
   // 추가/수정 폼
   const [showForm, setShowForm] = useState(false);
@@ -101,6 +105,12 @@ export default function AdminSitesPage() {
   const [editingId, setEditingId] = useState<number | null>(null);
   const [saving, setSaving] = useState(false);
   const [formError, setFormError] = useState("");
+
+  function requireMaster(action: string) {
+    if (!isGuest) return true;
+    setAccessNotice(buildGuestNotice(action));
+    return false;
+  }
 
   const load = useCallback(
     async (options?: { withSpinner?: boolean }): Promise<Site[] | null> => {
@@ -136,6 +146,7 @@ export default function AdminSitesPage() {
   }, [load]);
 
   function startEdit(site: Site) {
+    if (!requireMaster("사이트 수정")) return;
     setShowForm(true);
     setEditingId(site.seq);
     setForm({
@@ -206,6 +217,7 @@ export default function AdminSitesPage() {
   }
 
   async function handleSave() {
+    if (!requireMaster("사이트 추가/수정")) return;
     if (!form.name || !form.href) {
       setFormError("이름과 URL은 필수입니다");
       return;
@@ -299,6 +311,7 @@ export default function AdminSitesPage() {
   }
 
   async function handleToggleActive(site: Site) {
+    if (!requireMaster("사이트 활성 상태 변경")) return;
     const nextActive = site.is_active === 0;
 
     await runWithBusyMessage("활성 상태 반영 확인 중입니다...", async () => {
@@ -326,6 +339,7 @@ export default function AdminSitesPage() {
   }
 
   async function handleDelete(seq: number) {
+    if (!requireMaster("사이트 삭제")) return;
     if (!confirm("정말 삭제하시겠습니까?")) return;
 
     await runWithBusyMessage("삭제 반영 확인 중입니다...", async () => {
@@ -349,6 +363,7 @@ export default function AdminSitesPage() {
   const [purging, setPurging] = useState(false);
 
   async function handlePurge() {
+    if (!requireMaster("사이트 캐시 새로고침")) return;
     setPurging(true);
     await purgeSitesCache();
     setPurging(false);
@@ -369,6 +384,11 @@ export default function AdminSitesPage() {
           <p className="admin-page-subtitle mt-1">
             등록된 사이트 상태를 관리하고 즉시 반영 여부를 확인합니다.
           </p>
+          {accessNotice && (
+            <pre className="mt-3 whitespace-pre-wrap rounded border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+              {accessNotice}
+            </pre>
+          )}
         </div>
         <div className="flex gap-2">
           <button
@@ -381,6 +401,7 @@ export default function AdminSitesPage() {
           </button>
           <button
             onClick={() => {
+              if (!requireMaster("사이트 추가")) return;
               setShowForm(true);
               setEditingId(null);
               setForm(EMPTY_FORM);

--- a/client/app/admin/sync/page.tsx
+++ b/client/app/admin/sync/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { buildGuestNotice, useAdminRole } from "@/lib/admin-role";
 
 type Phase = "idle" | "login" | "begin" | "count" | "chunk" | "done" | "error";
 type SyncDirection = "local-to-prod" | "prod-to-local";
@@ -46,8 +47,11 @@ export default function SyncPage() {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [direction, setDirection] = useState<SyncDirection>("local-to-prod");
+  const [accessNotice, setAccessNotice] = useState("");
   const [state, setState] = useState<SyncState>(INITIAL);
   const abortRef = useRef<AbortController | null>(null);
+  const role = useAdminRole();
+  const isGuest = role === "guest";
 
   useEffect(() => {
     const host = window.location.hostname;
@@ -62,7 +66,14 @@ export default function SyncPage() {
   const directionLabel =
     direction === "local-to-prod" ? "Local → Prod" : "Prod → Local";
 
+  function requireMaster(action: string) {
+    if (!isGuest) return true;
+    setAccessNotice(buildGuestNotice(action));
+    return false;
+  }
+
   const handleSyncClick = (tableKey: "users" | "sites") => {
+    if (!requireMaster("DB 동기화")) return;
     const table = TABLES.find((item) => item.key === tableKey);
     const actionText =
       direction === "local-to-prod"
@@ -186,6 +197,11 @@ export default function SyncPage() {
             동기화 방향을 선택한 뒤 실행합니다. 대상 측 테이블은{" "}
             <strong className="text-red-400">TRUNCATE</strong> 후 전체 재삽입됩니다.
           </p>
+          {accessNotice && (
+            <pre className="mt-3 whitespace-pre-wrap rounded border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+              {accessNotice}
+            </pre>
+          )}
         </header>
 
         <div className="flex gap-2 text-sm">

--- a/client/app/admin/youtube/page.tsx
+++ b/client/app/admin/youtube/page.tsx
@@ -10,6 +10,7 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import type { YoutubeVideo } from "@/types";
+import { buildGuestNotice, useAdminRole } from "@/lib/admin-role";
 
 // ===== 유틸 =====
 
@@ -111,6 +112,15 @@ export default function AdminYoutubePage() {
     { date: string; avg: number }[]
   >([]);
   const [historyLoading, setHistoryLoading] = useState(false);
+  const [accessNotice, setAccessNotice] = useState("");
+  const role = useAdminRole();
+  const isGuest = role === "guest";
+
+  function requireMaster(action: string) {
+    if (!isGuest) return true;
+    setAccessNotice(buildGuestNotice(action));
+    return false;
+  }
 
   function cycleView() {
     setViewSort(
@@ -174,6 +184,7 @@ export default function AdminYoutubePage() {
   }, [rangeDay]);
 
   async function handlePurge() {
+    if (!requireMaster("유튜브 캐시 새로고침")) return;
     setPurging(true);
     setPurgeResult("idle");
     const res = await fetch("/api/admin/cache", {
@@ -192,6 +203,7 @@ export default function AdminYoutubePage() {
   >("idle");
 
   async function handleSnapshot() {
+    if (!requireMaster("유튜브 스냅샷 저장")) return;
     setSnapshotting(true);
     setSnapshotResult("idle");
     try {
@@ -275,6 +287,11 @@ export default function AdminYoutubePage() {
               ? `총 ${total}개의 인기 영상이 캐시되어 있습니다.`
               : "캐시된 영상 목록을 확인합니다."}
           </p>
+          {accessNotice && (
+            <pre className="mt-3 whitespace-pre-wrap rounded border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+              {accessNotice}
+            </pre>
+          )}
         </div>
         <div className="flex items-center gap-2">
           {purgeResult === "done" && (

--- a/client/app/api/admin/auth/login/route.ts
+++ b/client/app/api/admin/auth/login/route.ts
@@ -19,18 +19,26 @@ export async function POST(req: Request) {
 
   if (!upstream.ok) {
     return NextResponse.json(
-      { message: data.message ?? "인증 실패" },
+      { message: data.message ?? "인증에 실패했습니다." },
       { status: upstream.status },
     );
   }
 
   const res = NextResponse.json({ role: data.role });
-  res.cookies.set("admin_token", data.sessionId ?? "", {
-    httpOnly: true,
+  const cookieBase = {
     secure: process.env.NODE_ENV === "production",
-    sameSite: "lax",
+    sameSite: "lax" as const,
     path: "/",
-    maxAge: 60 * 60 * 8, // 8시간
+    maxAge: 60 * 60 * 8,
+  };
+
+  res.cookies.set("admin_token", data.sessionId ?? "", {
+    ...cookieBase,
+    httpOnly: true,
+  });
+  res.cookies.set("admin_role", data.role ?? "", {
+    ...cookieBase,
+    httpOnly: false,
   });
   return res;
 }

--- a/client/app/api/admin/auth/logout/route.ts
+++ b/client/app/api/admin/auth/logout/route.ts
@@ -22,5 +22,12 @@ export async function POST() {
     path: "/",
     maxAge: 0,
   });
+  res.cookies.set("admin_role", "", {
+    httpOnly: false,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: 0,
+  });
   return res;
 }

--- a/client/app/api/admin/sync/[table]/route.ts
+++ b/client/app/api/admin/sync/[table]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from "next/server";
+import { cookies } from "next/headers";
 const NEST_API = process.env.NEST_API_URL ?? "http://localhost:3001";
 
 export const dynamic = "force-dynamic";
@@ -10,6 +11,8 @@ export async function GET(
   const { table } = await params;
   const sessionId = req.nextUrl.searchParams.get("sessionId")?.trim() ?? "";
   const direction = req.nextUrl.searchParams.get("direction")?.trim() ?? "";
+  const store = await cookies();
+  const localSession = store.get("admin_token")?.value ?? "";
 
   if (!sessionId) {
     return new Response("missing remote session", { status: 401 });
@@ -29,6 +32,7 @@ export async function GET(
     method: "GET",
     headers: {
       accept: "text/event-stream",
+      ...(localSession ? { "x-admin-session": localSession } : {}),
     },
     signal: req.signal,
   });

--- a/client/lib/admin-role.ts
+++ b/client/lib/admin-role.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export type AdminRole = "master" | "guest" | null;
+
+export function readAdminRole(): AdminRole {
+  if (typeof document === "undefined") return null;
+  const match = document.cookie.match(
+    /(?:^|;\s*)admin_role=([^;]+)/,
+  );
+  if (!match) return null;
+  const value = decodeURIComponent(match[1]);
+  return value === "master" || value === "guest" ? value : null;
+}
+
+export function useAdminRole(): AdminRole {
+  const [role, setRole] = useState<AdminRole>(null);
+
+  useEffect(() => {
+    setRole(readAdminRole());
+  }, []);
+
+  return role;
+}
+
+export function buildGuestNotice(action: string): string {
+  return [
+    `게스트 계정은 ${action}을 할 수 없습니다.`,
+    "흐름: 로그인된 세션 확인 -> role 검사 -> 작업 차단",
+  ].join("\n");
+}

--- a/server/src/admin/admin-sync.controller.ts
+++ b/server/src/admin/admin-sync.controller.ts
@@ -198,6 +198,8 @@ export class AdminSyncController {
   }
 
   @Sse(':table/run')
+  @UseGuards(AdminWriteGuard)
+  @RequireOwner()
   run(
     @Param('table') table: string,
     @Query('sessionId') sessionId?: string,


### PR DESCRIPTION
## 요약
- 게스트 계정은 사이트 추가/수정, 캐시 새로고침, 유튜브 스냅샷 저장, DB 동기화를 실행할 수 없도록 막았습니다.
- 화면에서는 차단 이유와 간단한 흐름 안내를 보여주고, 서버에서는 마스터 권한만 통과하도록 다시 검증합니다.