### PR TITLE
Fix/admin

### DIFF
--- a/client/app/admin/cache/page.tsx
+++ b/client/app/admin/cache/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { buildGuestNotice, useAdminRole } from "@/lib/admin-role";
 
 const CACHE_KEYS = [
   { key: "sites", label: "사이트 목록", desc: "sites:all" },
@@ -14,8 +15,18 @@ export default function AdminCachePage() {
   const [status, setStatus] = useState<StatusMap>({});
   const [allLoading, setAllLoading] = useState(false);
   const [allResult, setAllResult] = useState("");
+  const [accessNotice, setAccessNotice] = useState("");
+  const role = useAdminRole();
+  const isGuest = role === "guest";
+
+  function requireMaster(action: string) {
+    if (!isGuest) return true;
+    setAccessNotice(buildGuestNotice(action));
+    return false;
+  }
 
   async function purgeOne(key: string) {
+    if (!requireMaster("캐시 개별 새로고침")) return;
     setStatus((p) => ({ ...p, [key]: "loading" }));
     const res = await fetch("/api/admin/cache", {
       method: "POST",
@@ -27,6 +38,7 @@ export default function AdminCachePage() {
   }
 
   async function purgeAll() {
+    if (!requireMaster("전체 캐시 새로고침")) return;
     setAllLoading(true);
     setAllResult("");
     const res = await fetch("/api/admin/cache", { method: "DELETE" });
@@ -53,6 +65,11 @@ export default function AdminCachePage() {
         <p className="admin-page-subtitle">
           캐시를 삭제하면 다음 요청 시 DB에서 새로 조회합니다.
         </p>
+        {accessNotice && (
+          <pre className="mt-3 whitespace-pre-wrap rounded border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+            {accessNotice}
+          </pre>
+        )}
       </div>
 
       <div className="admin-card admin-card-padded space-y-3 mb-6">

--- a/client/app/admin/characters/page.tsx
+++ b/client/app/admin/characters/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { buildGuestNotice, useAdminRole } from "@/lib/admin-role";
 
 interface Character {
   name: string;
@@ -43,6 +44,9 @@ export default function AdminCharactersPage() {
   const [result, setResult] = useState<ListResult | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const [accessNotice, setAccessNotice] = useState("");
+  const role = useAdminRole();
+  const isGuest = role === "guest";
 
   const [search, setSearch] = useState("");
   const [statBuild, setStatBuild] = useState("");
@@ -84,7 +88,14 @@ export default function AdminCharactersPage() {
 
   const [purging, setPurging] = useState(false);
 
+  function requireMaster(action: string) {
+    if (!isGuest) return true;
+    setAccessNotice(buildGuestNotice(action));
+    return false;
+  }
+
   async function handlePurge() {
+    if (!requireMaster("캐릭터 캐시 새로고침")) return;
     setPurging(true);
     try {
       await fetch("/api/admin/cache", {
@@ -113,6 +124,11 @@ export default function AdminCharactersPage() {
             총 {result?.total.toLocaleString() ?? "-"}명의 캐릭터가 등록되어
             있습니다.
           </p>
+          {accessNotice && (
+            <pre className="mt-3 whitespace-pre-wrap rounded border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+              {accessNotice}
+            </pre>
+          )}
         </div>
         <button
           onClick={handlePurge}

--- a/client/app/admin/login/page.test.tsx
+++ b/client/app/admin/login/page.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AdminLoginPage from "./page";
 
 describe("AdminLoginPage", () => {
@@ -16,6 +16,7 @@ describe("AdminLoginPage", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it("로그인 성공 시 window.location.replace로 /admin/sites 이동", async () => {
@@ -35,8 +36,6 @@ describe("AdminLoginPage", () => {
     await waitFor(() => {
       expect(replaceSpy).toHaveBeenCalledWith("/admin/sites");
     });
-
-    vi.unstubAllGlobals();
   });
 
   it("로그인 실패 시 에러 메시지 표시", async () => {
@@ -59,23 +58,19 @@ describe("AdminLoginPage", () => {
     await waitFor(() => {
       expect(screen.getByText("인증 실패")).toBeTruthy();
     });
-
-    vi.unstubAllGlobals();
   });
 
-  it("게스트 로그인 성공 시 window.location.replace로 /admin/sites 이동", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+  it("게스트 아이디 채우기 버튼 클릭 시 아이디만 guest로 채워짐", async () => {
+    render(<AdminLoginPage />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "게스트 아이디 채우기" }),
     );
 
-    render(<AdminLoginPage />);
-    await userEvent.click(screen.getByRole("button", { name: /게스트/ }));
-
-    await waitFor(() => {
-      expect(replaceSpy).toHaveBeenCalledWith("/admin/sites");
-    });
-
-    vi.unstubAllGlobals();
+    expect(screen.getByRole("textbox")).toHaveValue("guest");
+    const passwordInput = document.querySelector<HTMLInputElement>(
+      'input[type="password"]',
+    )!;
+    expect(passwordInput).toHaveValue("");
   });
 });

--- a/client/app/admin/login/page.tsx
+++ b/client/app/admin/login/page.tsx
@@ -35,8 +35,10 @@ export default function AdminLoginPage() {
     await login(username, password);
   }
 
-  async function handleGuestLogin() {
-    await login("guest", "1237");
+  function handleGuestFill() {
+    setUsername("guest");
+    setPassword("");
+    setError("");
   }
 
   return (
@@ -82,10 +84,10 @@ export default function AdminLoginPage() {
           <button
             type="button"
             disabled={loading}
-            onClick={handleGuestLogin}
+            onClick={handleGuestFill}
             className="admin-btn admin-btn-secondary w-full"
           >
-            게스트로 둘러보기
+            게스트 아이디 채우기
           </button>
         </form>
       </div>

--- a/client/app/admin/sites/page.tsx
+++ b/client/app/admin/sites/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { buildGuestNotice, useAdminRole } from "@/lib/admin-role";
 
 interface Site {
   seq: number;
@@ -93,7 +94,10 @@ export default function AdminSitesPage() {
   const [sites, setSites] = useState<Site[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const [accessNotice, setAccessNotice] = useState("");
   const [busyMessage, setBusyMessage] = useState<string | null>(null);
+  const role = useAdminRole();
+  const isGuest = role === "guest";
 
   // 추가/수정 폼
   const [showForm, setShowForm] = useState(false);
@@ -101,6 +105,12 @@ export default function AdminSitesPage() {
   const [editingId, setEditingId] = useState<number | null>(null);
   const [saving, setSaving] = useState(false);
   const [formError, setFormError] = useState("");
+
+  function requireMaster(action: string) {
+    if (!isGuest) return true;
+    setAccessNotice(buildGuestNotice(action));
+    return false;
+  }
 
   const load = useCallback(
     async (options?: { withSpinner?: boolean }): Promise<Site[] | null> => {
@@ -136,6 +146,7 @@ export default function AdminSitesPage() {
   }, [load]);
 
   function startEdit(site: Site) {
+    if (!requireMaster("사이트 수정")) return;
     setShowForm(true);
     setEditingId(site.seq);
     setForm({
@@ -206,6 +217,7 @@ export default function AdminSitesPage() {
   }
 
   async function handleSave() {
+    if (!requireMaster("사이트 추가/수정")) return;
     if (!form.name || !form.href) {
       setFormError("이름과 URL은 필수입니다");
       return;
@@ -299,6 +311,7 @@ export default function AdminSitesPage() {
   }
 
   async function handleToggleActive(site: Site) {
+    if (!requireMaster("사이트 활성 상태 변경")) return;
     const nextActive = site.is_active === 0;
 
     await runWithBusyMessage("활성 상태 반영 확인 중입니다...", async () => {
@@ -326,6 +339,7 @@ export default function AdminSitesPage() {
   }
 
   async function handleDelete(seq: number) {
+    if (!requireMaster("사이트 삭제")) return;
     if (!confirm("정말 삭제하시겠습니까?")) return;
 
     await runWithBusyMessage("삭제 반영 확인 중입니다...", async () => {
@@ -349,6 +363,7 @@ export default function AdminSitesPage() {
   const [purging, setPurging] = useState(false);
 
   async function handlePurge() {
+    if (!requireMaster("사이트 캐시 새로고침")) return;
     setPurging(true);
     await purgeSitesCache();
     setPurging(false);
@@ -369,6 +384,11 @@ export default function AdminSitesPage() {
           <p className="admin-page-subtitle mt-1">
             등록된 사이트 상태를 관리하고 즉시 반영 여부를 확인합니다.
           </p>
+          {accessNotice && (
+            <pre className="mt-3 whitespace-pre-wrap rounded border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+              {accessNotice}
+            </pre>
+          )}
         </div>
         <div className="flex gap-2">
           <button
@@ -381,6 +401,7 @@ export default function AdminSitesPage() {
           </button>
           <button
             onClick={() => {
+              if (!requireMaster("사이트 추가")) return;
               setShowForm(true);
               setEditingId(null);
               setForm(EMPTY_FORM);

--- a/client/app/admin/sync/page.tsx
+++ b/client/app/admin/sync/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 type Phase = "idle" | "login" | "begin" | "count" | "chunk" | "done" | "error";
+type SyncDirection = "local-to-prod" | "prod-to-local";
 
 interface SyncState {
   phase: Phase;
@@ -26,12 +27,12 @@ const TABLES: { key: "users" | "sites"; label: string; desc: string }[] = [
   {
     key: "users",
     label: "loa_users (캐릭터)",
-    desc: "전체 캐릭터 데이터를 프로덕션 DB로 덮어씁니다. 기존 프로덕션 데이터는 모두 삭제됩니다.",
+    desc: "선택한 방향 기준으로 전체 데이터를 다시 동기화합니다.",
   },
   {
     key: "sites",
     label: "loa_sites (사이트 모음)",
-    desc: "전체 사이트 데이터를 프로덕션 DB로 덮어씁니다. 기존 프로덕션 데이터는 모두 삭제됩니다.",
+    desc: "선택한 방향 기준으로 전체 데이터를 다시 동기화합니다.",
   },
 ];
 
@@ -44,16 +45,31 @@ export default function SyncPage() {
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+  const [direction, setDirection] = useState<SyncDirection>("local-to-prod");
   const [state, setState] = useState<SyncState>(INITIAL);
   const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    const host = window.location.hostname;
+    const isLocalHost =
+      host === "localhost" || host === "127.0.0.1" || host === "::1";
+    setDirection(isLocalHost ? "local-to-prod" : "prod-to-local");
+  }, []);
 
   const running =
     state.phase !== "idle" && state.phase !== "done" && state.phase !== "error";
 
+  const directionLabel =
+    direction === "local-to-prod" ? "Local → Prod" : "Prod → Local";
+
   const handleSyncClick = (tableKey: "users" | "sites") => {
     const table = TABLES.find((item) => item.key === tableKey);
+    const actionText =
+      direction === "local-to-prod"
+        ? "프로덕션 테이블을 삭제 후 로컬 데이터로 재삽입"
+        : "로컬 테이블을 삭제 후 프로덕션 데이터로 재삽입";
     const ok = window.confirm(
-      `[${table?.label ?? tableKey}]\n\n프로덕션의 해당 테이블을 전체 삭제 후 로컬 데이터로 재삽입합니다.\n계속하시겠습니까?`,
+      `[${table?.label ?? tableKey}] (${directionLabel})\n\n${actionText} 합니다.\n계속하시겠습니까?`,
     );
     if (!ok) return;
 
@@ -65,15 +81,17 @@ export default function SyncPage() {
   async function start(sessionId: string) {
     if (!activeTable) return;
 
-    setState({ ...INITIAL, phase: "login", message: "시작 중..." });
+    setState({
+      ...INITIAL,
+      phase: "login",
+      message: `${directionLabel} 준비 중...`,
+    });
     const ctrl = new AbortController();
     abortRef.current = ctrl;
 
     try {
       const res = await fetch(
-        `/api/admin/sync/${activeTable}?sessionId=${encodeURIComponent(
-          sessionId,
-        )}`,
+        `/api/admin/sync/${activeTable}?sessionId=${encodeURIComponent(sessionId)}&direction=${encodeURIComponent(direction)}`,
         {
           method: "GET",
           signal: ctrl.signal,
@@ -106,7 +124,8 @@ export default function SyncPage() {
       setState((s) => ({
         ...s,
         phase: "error",
-        error: err instanceof Error ? err.message : "동기화 중 오류가 발생했습니다.",
+        error:
+          err instanceof Error ? err.message : "동기화 중 오류가 발생했습니다.",
       }));
     } finally {
       abortRef.current = null;
@@ -162,13 +181,39 @@ export default function SyncPage() {
     <div>
       <div className="space-y-6">
         <header>
-          <h1 className="text-2xl font-bold">서버 동기화 (Local → Prod)</h1>
+          <h1 className="text-2xl font-bold">서버 동기화</h1>
           <p className="mt-2 text-sm text-gray-400">
-            로컬 DB 내용을 프로덕션 DB로 단방향 복제합니다. 프로덕션의 해당
-            테이블은 <strong className="text-red-400">TRUNCATE</strong> 후 전체
-            재삽입됩니다.
+            동기화 방향을 선택한 뒤 실행합니다. 대상 측 테이블은{" "}
+            <strong className="text-red-400">TRUNCATE</strong> 후 전체 재삽입됩니다.
           </p>
         </header>
+
+        <div className="flex gap-2 text-sm">
+          <button
+            type="button"
+            disabled={running}
+            onClick={() => setDirection("local-to-prod")}
+            className={`rounded px-3 py-2 ${
+              direction === "local-to-prod"
+                ? "bg-blue-700 text-white"
+                : "bg-gray-800 text-gray-300"
+            }`}
+          >
+            Local → Prod
+          </button>
+          <button
+            type="button"
+            disabled={running}
+            onClick={() => setDirection("prod-to-local")}
+            className={`rounded px-3 py-2 ${
+              direction === "prod-to-local"
+                ? "bg-blue-700 text-white"
+                : "bg-gray-800 text-gray-300"
+            }`}
+          >
+            Prod → Local
+          </button>
+        </div>
 
         <div className="grid gap-4 md:grid-cols-2">
           {TABLES.map((t) => {
@@ -218,10 +263,7 @@ export default function SyncPage() {
                       {phaseLabel(tableState.phase)}
                     </span>
                     {tableState.message && (
-                      <span className="text-gray-500">
-                        {" "}
-                        · {tableState.message}
-                      </span>
+                      <span className="text-gray-500"> · {tableState.message}</span>
                     )}
                   </div>
                   {tableState.error && (

--- a/client/app/admin/sync/page.tsx
+++ b/client/app/admin/sync/page.tsx
@@ -39,9 +39,7 @@ const TABLES: { key: "users" | "sites"; label: string; desc: string }[] = [
 
 export default function SyncPage() {
   const [showForm, setShowForm] = useState(false);
-  const [activeTable, setActiveTable] = useState<"users" | "sites" | null>(
-    null,
-  );
+  const [activeTable, setActiveTable] = useState<"users" | "sites" | null>(null);
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
@@ -64,7 +62,7 @@ export default function SyncPage() {
     state.phase !== "idle" && state.phase !== "done" && state.phase !== "error";
 
   const directionLabel =
-    direction === "local-to-prod" ? "Local → Prod" : "Prod → Local";
+    direction === "local-to-prod" ? "프로덕션으로 동기화" : "로컬과 동기화";
 
   function requireMaster(action: string) {
     if (!isGuest) return true;
@@ -77,10 +75,10 @@ export default function SyncPage() {
     const table = TABLES.find((item) => item.key === tableKey);
     const actionText =
       direction === "local-to-prod"
-        ? "프로덕션 테이블을 삭제 후 로컬 데이터로 재삽입"
-        : "로컬 테이블을 삭제 후 프로덕션 데이터로 재삽입";
+        ? "프로덕션 테이블을 비우고 로컬 데이터를 복사합니다."
+        : "로컬 테이블을 비우고 프로덕션 데이터를 복사합니다.";
     const ok = window.confirm(
-      `[${table?.label ?? tableKey}] (${directionLabel})\n\n${actionText} 합니다.\n계속하시겠습니까?`,
+      `[${table?.label ?? tableKey}] (${directionLabel})\n\n${actionText}\n계속하시겠습니까?`,
     );
     if (!ok) return;
 
@@ -136,7 +134,9 @@ export default function SyncPage() {
         ...s,
         phase: "error",
         error:
-          err instanceof Error ? err.message : "동기화 중 오류가 발생했습니다.",
+          err instanceof Error
+            ? err.message
+            : "동기화 중 오류가 발생했습니다.",
       }));
     } finally {
       abortRef.current = null;
@@ -145,7 +145,7 @@ export default function SyncPage() {
 
   function cancel() {
     abortRef.current?.abort();
-    setState((s) => ({ ...s, phase: "error", error: "사용자가 취소함" }));
+    setState((s) => ({ ...s, phase: "error", error: "사용자가 취소했습니다." }));
   }
 
   async function syncCheck(u: string, p: string) {
@@ -176,7 +176,9 @@ export default function SyncPage() {
       await start(data.sessionId);
     } catch (err) {
       setError(
-        err instanceof Error ? err.message : "원격 관리자 인증 중 오류가 발생했습니다.",
+        err instanceof Error
+          ? err.message
+          : "원격 관리자 인증 중 오류가 발생했습니다.",
       );
     } finally {
       setLoading(false);
@@ -194,8 +196,8 @@ export default function SyncPage() {
         <header>
           <h1 className="text-2xl font-bold">서버 동기화</h1>
           <p className="mt-2 text-sm text-gray-400">
-            동기화 방향을 선택한 뒤 실행합니다. 대상 측 테이블은{" "}
-            <strong className="text-red-400">TRUNCATE</strong> 후 전체 재삽입됩니다.
+            동기화 방향을 선택한 뒤 실행합니다. 대상 테이블은{" "}
+            <strong className="text-red-400">TRUNCATE</strong> 후 전체 복사됩니다.
           </p>
           {accessNotice && (
             <pre className="mt-3 whitespace-pre-wrap rounded border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
@@ -215,7 +217,7 @@ export default function SyncPage() {
                 : "bg-gray-800 text-gray-300"
             }`}
           >
-            Local → Prod
+            프로덕션으로 동기화
           </button>
           <button
             type="button"
@@ -227,7 +229,7 @@ export default function SyncPage() {
                 : "bg-gray-800 text-gray-300"
             }`}
           >
-            Prod → Local
+            로컬과 동기화
           </button>
         </div>
 
@@ -239,7 +241,7 @@ export default function SyncPage() {
                 className="rounded-xl border border-gray-700 bg-gray-900 p-5"
                 key={t.key}
               >
-                <h2 className="text-lg font-semibold">{t.label}</h2>
+                <h2 className="text-lg font-semibold text-gray-100">{t.label}</h2>
                 <p className="mt-1 text-xs text-gray-400">{t.desc}</p>
 
                 <div className="mt-4 space-y-2">
@@ -371,11 +373,11 @@ function phaseLabel(p: Phase): string {
     case "idle":
       return "대기";
     case "login":
-      return "원격 로그인";
+      return "원격 관리자 인증";
     case "begin":
       return "TRUNCATE";
     case "count":
-      return "카운트 조회";
+      return "건수 조회";
     case "chunk":
       return "전송 중";
     case "done":
@@ -410,16 +412,14 @@ function handleEvent(
     if (evt === "progress") {
       if (typeof data.phase === "string") next.phase = data.phase as Phase;
       if (typeof data.total === "number") next.total = data.total;
-      if (typeof data.transferred === "number")
-        next.transferred = data.transferred;
+      if (typeof data.transferred === "number") next.transferred = data.transferred;
       if (typeof data.percent === "number") next.percent = data.percent;
       if (typeof data.message === "string") next.message = data.message;
     } else if (evt === "done") {
       next.phase = "done";
       next.percent = 100;
       if (typeof data.total === "number") next.total = data.total;
-      if (typeof data.transferred === "number")
-        next.transferred = data.transferred;
+      if (typeof data.transferred === "number") next.transferred = data.transferred;
       next.message = "동기화 완료";
     } else if (evt === "error") {
       next.phase = "error";

--- a/client/app/admin/sync/page.tsx
+++ b/client/app/admin/sync/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { buildGuestNotice, useAdminRole } from "@/lib/admin-role";
 
 type Phase = "idle" | "login" | "begin" | "count" | "chunk" | "done" | "error";
 type SyncDirection = "local-to-prod" | "prod-to-local";
@@ -46,8 +47,11 @@ export default function SyncPage() {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [direction, setDirection] = useState<SyncDirection>("local-to-prod");
+  const [accessNotice, setAccessNotice] = useState("");
   const [state, setState] = useState<SyncState>(INITIAL);
   const abortRef = useRef<AbortController | null>(null);
+  const role = useAdminRole();
+  const isGuest = role === "guest";
 
   useEffect(() => {
     const host = window.location.hostname;
@@ -62,7 +66,14 @@ export default function SyncPage() {
   const directionLabel =
     direction === "local-to-prod" ? "Local → Prod" : "Prod → Local";
 
+  function requireMaster(action: string) {
+    if (!isGuest) return true;
+    setAccessNotice(buildGuestNotice(action));
+    return false;
+  }
+
   const handleSyncClick = (tableKey: "users" | "sites") => {
+    if (!requireMaster("DB 동기화")) return;
     const table = TABLES.find((item) => item.key === tableKey);
     const actionText =
       direction === "local-to-prod"
@@ -186,6 +197,11 @@ export default function SyncPage() {
             동기화 방향을 선택한 뒤 실행합니다. 대상 측 테이블은{" "}
             <strong className="text-red-400">TRUNCATE</strong> 후 전체 재삽입됩니다.
           </p>
+          {accessNotice && (
+            <pre className="mt-3 whitespace-pre-wrap rounded border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+              {accessNotice}
+            </pre>
+          )}
         </header>
 
         <div className="flex gap-2 text-sm">

--- a/client/app/admin/youtube/page.tsx
+++ b/client/app/admin/youtube/page.tsx
@@ -10,6 +10,7 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import type { YoutubeVideo } from "@/types";
+import { buildGuestNotice, useAdminRole } from "@/lib/admin-role";
 
 // ===== 유틸 =====
 
@@ -111,6 +112,15 @@ export default function AdminYoutubePage() {
     { date: string; avg: number }[]
   >([]);
   const [historyLoading, setHistoryLoading] = useState(false);
+  const [accessNotice, setAccessNotice] = useState("");
+  const role = useAdminRole();
+  const isGuest = role === "guest";
+
+  function requireMaster(action: string) {
+    if (!isGuest) return true;
+    setAccessNotice(buildGuestNotice(action));
+    return false;
+  }
 
   function cycleView() {
     setViewSort(
@@ -174,6 +184,7 @@ export default function AdminYoutubePage() {
   }, [rangeDay]);
 
   async function handlePurge() {
+    if (!requireMaster("유튜브 캐시 새로고침")) return;
     setPurging(true);
     setPurgeResult("idle");
     const res = await fetch("/api/admin/cache", {
@@ -192,6 +203,7 @@ export default function AdminYoutubePage() {
   >("idle");
 
   async function handleSnapshot() {
+    if (!requireMaster("유튜브 스냅샷 저장")) return;
     setSnapshotting(true);
     setSnapshotResult("idle");
     try {
@@ -275,6 +287,11 @@ export default function AdminYoutubePage() {
               ? `총 ${total}개의 인기 영상이 캐시되어 있습니다.`
               : "캐시된 영상 목록을 확인합니다."}
           </p>
+          {accessNotice && (
+            <pre className="mt-3 whitespace-pre-wrap rounded border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+              {accessNotice}
+            </pre>
+          )}
         </div>
         <div className="flex items-center gap-2">
           {purgeResult === "done" && (

--- a/client/app/api/admin/auth/login/route.ts
+++ b/client/app/api/admin/auth/login/route.ts
@@ -19,18 +19,26 @@ export async function POST(req: Request) {
 
   if (!upstream.ok) {
     return NextResponse.json(
-      { message: data.message ?? "인증 실패" },
+      { message: data.message ?? "인증에 실패했습니다." },
       { status: upstream.status },
     );
   }
 
   const res = NextResponse.json({ role: data.role });
-  res.cookies.set("admin_token", data.sessionId ?? "", {
-    httpOnly: true,
+  const cookieBase = {
     secure: process.env.NODE_ENV === "production",
-    sameSite: "lax",
+    sameSite: "lax" as const,
     path: "/",
-    maxAge: 60 * 60 * 8, // 8시간
+    maxAge: 60 * 60 * 8,
+  };
+
+  res.cookies.set("admin_token", data.sessionId ?? "", {
+    ...cookieBase,
+    httpOnly: true,
+  });
+  res.cookies.set("admin_role", data.role ?? "", {
+    ...cookieBase,
+    httpOnly: false,
   });
   return res;
 }

--- a/client/app/api/admin/auth/logout/route.ts
+++ b/client/app/api/admin/auth/logout/route.ts
@@ -22,5 +22,12 @@ export async function POST() {
     path: "/",
     maxAge: 0,
   });
+  res.cookies.set("admin_role", "", {
+    httpOnly: false,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: 0,
+  });
   return res;
 }

--- a/client/app/api/admin/sync/[table]/route.ts
+++ b/client/app/api/admin/sync/[table]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from "next/server";
+import { cookies } from "next/headers";
 const NEST_API = process.env.NEST_API_URL ?? "http://localhost:3001";
 
 export const dynamic = "force-dynamic";
@@ -10,6 +11,8 @@ export async function GET(
   const { table } = await params;
   const sessionId = req.nextUrl.searchParams.get("sessionId")?.trim() ?? "";
   const direction = req.nextUrl.searchParams.get("direction")?.trim() ?? "";
+  const store = await cookies();
+  const localSession = store.get("admin_token")?.value ?? "";
 
   if (!sessionId) {
     return new Response("missing remote session", { status: 401 });
@@ -29,6 +32,7 @@ export async function GET(
     method: "GET",
     headers: {
       accept: "text/event-stream",
+      ...(localSession ? { "x-admin-session": localSession } : {}),
     },
     signal: req.signal,
   });

--- a/client/app/api/admin/sync/[table]/route.ts
+++ b/client/app/api/admin/sync/[table]/route.ts
@@ -9,6 +9,7 @@ export async function GET(
 ) {
   const { table } = await params;
   const sessionId = req.nextUrl.searchParams.get("sessionId")?.trim() ?? "";
+  const direction = req.nextUrl.searchParams.get("direction")?.trim() ?? "";
 
   if (!sessionId) {
     return new Response("missing remote session", { status: 401 });
@@ -16,10 +17,14 @@ export async function GET(
   if (table !== "users" && table !== "sites") {
     return new Response("invalid table", { status: 400 });
   }
+  if (direction !== "local-to-prod" && direction !== "prod-to-local") {
+    return new Response("invalid direction", { status: 400 });
+  }
 
-  const url = `${NEST_API}/api/admin/sync/${table}/run?sessionId=${encodeURIComponent(
-    sessionId,
-  )}`;
+  const url =
+    `${NEST_API}/api/admin/sync/${table}/run` +
+    `?sessionId=${encodeURIComponent(sessionId)}` +
+    `&direction=${encodeURIComponent(direction)}`;
   const upstream = await fetch(url, {
     method: "GET",
     headers: {

--- a/client/lib/admin-role.ts
+++ b/client/lib/admin-role.ts
@@ -1,32 +1,25 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 export type AdminRole = "master" | "guest" | null;
 
 export function readAdminRole(): AdminRole {
   if (typeof document === "undefined") return null;
-  const match = document.cookie.match(
-    /(?:^|;\s*)admin_role=([^;]+)/,
-  );
+  const match = document.cookie.match(/(?:^|;\s*)admin_role=([^;]+)/);
   if (!match) return null;
   const value = decodeURIComponent(match[1]);
   return value === "master" || value === "guest" ? value : null;
 }
 
 export function useAdminRole(): AdminRole {
-  const [role, setRole] = useState<AdminRole>(null);
-
-  useEffect(() => {
-    setRole(readAdminRole());
-  }, []);
-
+  const [role] = useState<AdminRole>(() => readAdminRole());
   return role;
 }
 
 export function buildGuestNotice(action: string): string {
   return [
-    `게스트 계정은 ${action}을 할 수 없습니다.`,
-    "흐름: 로그인된 세션 확인 -> role 검사 -> 작업 차단",
+    `게스트 계정은 ${action} 작업을 할 수 없습니다.`,
+    "흐름: 로그인 세션 확인 -> 역할(role) 확인 -> 쓰기 작업 차단",
   ].join("\n");
 }

--- a/client/lib/admin-role.ts
+++ b/client/lib/admin-role.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export type AdminRole = "master" | "guest" | null;
+
+export function readAdminRole(): AdminRole {
+  if (typeof document === "undefined") return null;
+  const match = document.cookie.match(
+    /(?:^|;\s*)admin_role=([^;]+)/,
+  );
+  if (!match) return null;
+  const value = decodeURIComponent(match[1]);
+  return value === "master" || value === "guest" ? value : null;
+}
+
+export function useAdminRole(): AdminRole {
+  const [role, setRole] = useState<AdminRole>(null);
+
+  useEffect(() => {
+    setRole(readAdminRole());
+  }, []);
+
+  return role;
+}
+
+export function buildGuestNotice(action: string): string {
+  return [
+    `게스트 계정은 ${action}을 할 수 없습니다.`,
+    "흐름: 로그인된 세션 확인 -> role 검사 -> 작업 차단",
+  ].join("\n");
+}

--- a/server/src/admin/admin-sync.controller.spec.ts
+++ b/server/src/admin/admin-sync.controller.spec.ts
@@ -27,7 +27,11 @@ function createController(nodeEnv = 'production') {
     login: jest.fn(),
   } as never;
 
-  const controller = new AdminSyncController(pool as never, config, authService);
+  const controller = new AdminSyncController(
+    pool as never,
+    config,
+    authService,
+  );
   return { controller, pool };
 }
 
@@ -35,8 +39,18 @@ function mockResponse(body: string) {
   return {
     ok: true,
     status: 200,
-    text: async () => body,
+    text: () => Promise.resolve(body),
   } as Response;
+}
+
+function requestUrl(input: RequestInfo | URL | undefined): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.href;
+  if (input && typeof input === 'object' && 'url' in input) {
+    const url = input.url;
+    return typeof url === 'string' ? url : '';
+  }
+  return '';
 }
 
 function collectEvents<T>(stream: Observable<T>) {
@@ -104,24 +118,33 @@ describe('AdminSyncController', () => {
 
   it('prod-to-local sends local rows to the remote target without truncating the local DB', async () => {
     const { controller, pool } = createController('production');
-    const fetchSpy = jest.spyOn(globalThis, 'fetch').mockImplementation(
-      async (input: RequestInfo | URL) => {
-        const url = String(input);
+    const fetchSpy = jest
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation((input: RequestInfo | URL) => {
+        const url = requestUrl(input);
         if (url.endsWith('/begin')) {
-          return mockResponse('{"ok":true}') as never;
+          return Promise.resolve(mockResponse('{"ok":true}')) as never;
         }
         if (url.endsWith('/chunk')) {
-          return mockResponse('{"inserted":2}') as never;
+          return Promise.resolve(mockResponse('{"inserted":2}')) as never;
         }
-        throw new Error(`unexpected fetch: ${url}`);
-      },
-    );
-    jest.spyOn(globalThis, 'setTimeout').mockImplementation((cb: TimerHandler) => {
-      if (typeof cb === 'function') {
-        cb();
-      }
-      return 0 as never;
-    });
+        if (url.endsWith('/auth/logout')) {
+          return Promise.resolve(mockResponse('{"ok":true}')) as never;
+        }
+        return Promise.reject(
+          new Error(`unexpected fetch: ${requestUrl(input)}`),
+        ) as never;
+      });
+
+    jest
+      .spyOn(globalThis, 'setTimeout')
+      .mockImplementation((cb: TimerHandler): never => {
+        if (typeof cb === 'function') {
+          const fn = cb as () => void;
+          fn();
+        }
+        return 0 as never;
+      });
 
     pool.query
       .mockResolvedValueOnce([[{ total: 2 }]])
@@ -162,9 +185,9 @@ describe('AdminSyncController', () => {
     expect(pool.getConnection).not.toHaveBeenCalled();
     expect(pool.query).toHaveBeenCalledTimes(3);
     expect(fetchSpy).toHaveBeenCalledTimes(3);
-    expect(String(fetchSpy.mock.calls[0]?.[0])).toContain('/begin');
-    expect(String(fetchSpy.mock.calls[1]?.[0])).toContain('/chunk');
-    expect(String(fetchSpy.mock.calls[2]?.[0])).toContain('/auth/logout');
+    expect(requestUrl(fetchSpy.mock.calls[0]?.[0])).toContain('/begin');
+    expect(requestUrl(fetchSpy.mock.calls[1]?.[0])).toContain('/chunk');
+    expect(requestUrl(fetchSpy.mock.calls[2]?.[0])).toContain('/auth/logout');
     expect(events.some((event) => event.type === 'done')).toBe(true);
   });
 });

--- a/server/src/admin/admin-sync.controller.spec.ts
+++ b/server/src/admin/admin-sync.controller.spec.ts
@@ -1,0 +1,170 @@
+import { ConfigService } from '@nestjs/config';
+import { Observable } from 'rxjs';
+import { AdminSyncController } from './admin-sync.controller';
+
+type MockPool = {
+  getConnection: jest.Mock;
+  query: jest.Mock;
+};
+
+function createController(nodeEnv = 'production') {
+  const pool: MockPool = {
+    getConnection: jest.fn(),
+    query: jest.fn(),
+  };
+
+  const config = {
+    get: jest.fn((key: string) => {
+      const values: Record<string, string | undefined> = {
+        NODE_ENV: nodeEnv,
+        SYNC_TARGET_API_URL: 'https://remote.example.com',
+      };
+      return values[key];
+    }),
+  } as unknown as ConfigService;
+
+  const authService = {
+    login: jest.fn(),
+  } as never;
+
+  const controller = new AdminSyncController(pool as never, config, authService);
+  return { controller, pool };
+}
+
+function mockResponse(body: string) {
+  return {
+    ok: true,
+    status: 200,
+    text: async () => body,
+  } as Response;
+}
+
+function collectEvents<T>(stream: Observable<T>) {
+  return new Promise<T[]>((resolve, reject) => {
+    const items: T[] = [];
+    stream.subscribe({
+      next: (value) => items.push(value),
+      error: reject,
+      complete: () => resolve(items),
+    });
+  });
+}
+
+describe('AdminSyncController', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('chunkRead uses a dynamic seq index and bound parameters', async () => {
+    const { controller, pool } = createController();
+    pool.query.mockResolvedValueOnce([
+      [
+        {
+          seq: 42,
+          name: 'site-a',
+          href: 'https://example.com',
+          category: 'news',
+          description: null,
+          icon: null,
+          is_active: 1,
+          last_title: 'title',
+          last_status: 'ok',
+          checked_at: '2025-01-01 00:00:00',
+        },
+      ],
+    ]);
+
+    const result = await controller.chunkRead('sites', {
+      afterSeq: 5,
+      limit: 100,
+    });
+
+    expect(pool.query).toHaveBeenCalledWith(
+      'SELECT `seq`, `name`, `href`, `category`, `description`, `icon`, `is_active`, `last_title`, `last_status`, `checked_at` FROM `loa_sites` WHERE seq > ? ORDER BY seq ASC LIMIT ?',
+      [5, 25],
+    );
+    expect(result).toEqual({
+      rows: [
+        [
+          42,
+          'site-a',
+          'https://example.com',
+          'news',
+          null,
+          null,
+          1,
+          'title',
+          'ok',
+          '2025-01-01 00:00:00',
+        ],
+      ],
+      lastSeq: 42,
+    });
+  });
+
+  it('prod-to-local sends local rows to the remote target without truncating the local DB', async () => {
+    const { controller, pool } = createController('production');
+    const fetchSpy = jest.spyOn(globalThis, 'fetch').mockImplementation(
+      async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith('/begin')) {
+          return mockResponse('{"ok":true}') as never;
+        }
+        if (url.endsWith('/chunk')) {
+          return mockResponse('{"inserted":2}') as never;
+        }
+        throw new Error(`unexpected fetch: ${url}`);
+      },
+    );
+    jest.spyOn(globalThis, 'setTimeout').mockImplementation((cb: TimerHandler) => {
+      if (typeof cb === 'function') {
+        cb();
+      }
+      return 0 as never;
+    });
+
+    pool.query
+      .mockResolvedValueOnce([[{ total: 2 }]])
+      .mockResolvedValueOnce([
+        [
+          {
+            seq: 1,
+            name: 'site-a',
+            href: 'https://example.com/a',
+            category: 'news',
+            description: 'desc-a',
+            icon: 'icon-a',
+            is_active: 1,
+            last_title: 'title-a',
+            last_status: 'ok',
+            checked_at: '2025-01-01 00:00:00',
+          },
+          {
+            seq: 2,
+            name: 'site-b',
+            href: 'https://example.com/b',
+            category: 'news',
+            description: 'desc-b',
+            icon: 'icon-b',
+            is_active: 1,
+            last_title: 'title-b',
+            last_status: 'ok',
+            checked_at: '2025-01-01 00:00:01',
+          },
+        ],
+      ])
+      .mockResolvedValueOnce([[]]);
+
+    const events = await collectEvents(
+      controller.run('sites', 'remote-session', 'prod-to-local'),
+    );
+
+    expect(pool.getConnection).not.toHaveBeenCalled();
+    expect(pool.query).toHaveBeenCalledTimes(3);
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+    expect(String(fetchSpy.mock.calls[0]?.[0])).toContain('/begin');
+    expect(String(fetchSpy.mock.calls[1]?.[0])).toContain('/chunk');
+    expect(String(fetchSpy.mock.calls[2]?.[0])).toContain('/auth/logout');
+    expect(events.some((event) => event.type === 'done')).toBe(true);
+  });
+});

--- a/server/src/admin/admin-sync.controller.ts
+++ b/server/src/admin/admin-sync.controller.ts
@@ -198,6 +198,8 @@ export class AdminSyncController {
   }
 
   @Sse(':table/run')
+  @UseGuards(AdminWriteGuard)
+  @RequireOwner()
   run(
     @Param('table') table: string,
     @Query('sessionId') sessionId?: string,

--- a/server/src/admin/admin-sync.controller.ts
+++ b/server/src/admin/admin-sync.controller.ts
@@ -217,10 +217,14 @@ export class AdminSyncController {
       this.config.get<string>('NODE_ENV', '').trim() !== 'production';
 
     if (syncDirection === 'local-to-prod' && !isLocalRuntime) {
-      throw new BadRequestException('local-to-prod is allowed only on local runtime');
+      throw new BadRequestException(
+        'local-to-prod is allowed only on local runtime',
+      );
     }
     if (syncDirection === 'prod-to-local' && isLocalRuntime) {
-      throw new BadRequestException('prod-to-local is allowed only on production runtime');
+      throw new BadRequestException(
+        'prod-to-local is allowed only on production runtime',
+      );
     }
 
     return new Observable<MessageEvent>((subscriber) => {
@@ -296,13 +300,12 @@ export class AdminSyncController {
             for (const rows of splitRowsByPayloadSize(values)) {
               if (cancelled) break;
 
-              const res =
-                await callTargetRaw(
-                  targetUrl,
-                  `/api/admin/sync/${table}/chunk`,
-                  remoteToken,
-                  { rows },
-                );
+              const res = await callTargetRaw(
+                targetUrl,
+                `/api/admin/sync/${table}/chunk`,
+                remoteToken,
+                { rows },
+              );
               const inserted = Number(
                 (res as { inserted?: number })?.inserted ?? 0,
               );
@@ -433,7 +436,9 @@ async function callTargetRaw(
   });
   const text = await res.text();
   if (!res.ok) {
-    throw new Error(`target ${path} failed (${res.status}): ${text.slice(0, 300)}`);
+    throw new Error(
+      `target ${path} failed (${res.status}): ${text.slice(0, 300)}`,
+    );
   }
   try {
     return JSON.parse(text) as unknown;

--- a/server/src/admin/admin-sync.controller.ts
+++ b/server/src/admin/admin-sync.controller.ts
@@ -1,26 +1,27 @@
 import {
-  Controller,
-  Post,
-  Param,
-  Body,
-  Sse,
-  Query,
-  UseGuards,
   BadRequestException,
-  Inject,
-  MessageEvent,
+  Body,
+  Controller,
   HttpCode,
   HttpStatus,
+  Inject,
+  MessageEvent,
+  Param,
+  Post,
+  Query,
+  Sse,
+  UseGuards,
 } from '@nestjs/common';
-import type { Pool } from 'mysql2/promise';
-import type { RowDataPacket, ResultSetHeader } from 'mysql2';
-import { Observable } from 'rxjs';
 import { ConfigService } from '@nestjs/config';
-import { DB_POOL } from '../db/db.module';
-import { AdminWriteGuard, RequireOwner } from './admin.guard';
+import type { RowDataPacket, ResultSetHeader } from 'mysql2';
+import type { Pool } from 'mysql2/promise';
+import { Observable } from 'rxjs';
 import { AdminAuthService } from './admin-auth.service';
+import { AdminWriteGuard, RequireOwner } from './admin.guard';
+import { DB_POOL } from '../db/db.module';
 
 type TableKey = 'users' | 'sites';
+type SyncDirection = 'local-to-prod' | 'prod-to-local';
 
 interface TableSpec {
   table: string;
@@ -65,16 +66,22 @@ const TABLE_SPECS: Record<TableKey, TableSpec> = {
   },
 };
 
-// Keep each JSON payload below the default Nest/Express body limit.
 const SYNC_CHUNK_SIZE = 25;
 const SYNC_MAX_PAYLOAD_BYTES = 32 * 1024;
 const SYNC_CHUNK_DELAY_MS = 1000;
 
 function specOrThrow(table: string): TableSpec {
   if (!(table in TABLE_SPECS)) {
-    throw new BadRequestException(`지원하지 않는 테이블: ${table}`);
+    throw new BadRequestException(`unsupported table: ${table}`);
   }
   return TABLE_SPECS[table as TableKey];
+}
+
+function directionOrThrow(direction: string): SyncDirection {
+  if (direction === 'local-to-prod' || direction === 'prod-to-local') {
+    return direction;
+  }
+  throw new BadRequestException(`unsupported direction: ${direction}`);
 }
 
 @Controller('api/admin/sync')
@@ -85,7 +92,6 @@ export class AdminSyncController {
     private readonly authService: AdminAuthService,
   ) {}
 
-  /** target 측: 동기화 시작 - TRUNCATE */
   @Post(':table/begin')
   @UseGuards(AdminWriteGuard)
   @RequireOwner()
@@ -102,7 +108,6 @@ export class AdminSyncController {
     return { ok: true, table: spec.table };
   }
 
-  /** target 측: 행 청크 bulk INSERT */
   @Post(':table/chunk')
   @UseGuards(AdminWriteGuard)
   @RequireOwner()
@@ -115,10 +120,11 @@ export class AdminSyncController {
     if (!Array.isArray(rows) || rows.length === 0) {
       return { inserted: 0 };
     }
+
     for (const row of rows) {
       if (!Array.isArray(row) || row.length !== spec.columns.length) {
         throw new BadRequestException(
-          `행 길이가 컬럼 수와 다릅니다 (expected=${spec.columns.length})`,
+          `row length mismatch (expected=${spec.columns.length})`,
         );
       }
     }
@@ -138,26 +144,66 @@ export class AdminSyncController {
     }
   }
 
+  @Post(':table/count')
+  @UseGuards(AdminWriteGuard)
+  @RequireOwner()
+  async count(@Param('table') table: string) {
+    const spec = specOrThrow(table);
+    const [rows] = await this.pool.query<RowDataPacket[]>(
+      `SELECT COUNT(*) AS total FROM \`${spec.table}\``,
+    );
+    return { total: Number(rows[0]?.total ?? 0) };
+  }
+
+  @Post(':table/chunk-read')
+  @UseGuards(AdminWriteGuard)
+  @RequireOwner()
+  async chunkRead(
+    @Param('table') table: string,
+    @Body() body: { afterSeq?: number; limit?: number },
+  ) {
+    const spec = specOrThrow(table);
+    const afterSeq = Number(body?.afterSeq ?? 0);
+    const limit = Number(body?.limit ?? SYNC_CHUNK_SIZE);
+    const safeLimit = Math.max(1, Math.min(SYNC_CHUNK_SIZE, limit));
+    const colList = spec.columns.map((c) => `\`${c}\``).join(', ');
+
+    const [rows] = await this.pool.query<RowDataPacket[]>(
+      `SELECT ${colList} FROM \`${spec.table}\` WHERE seq > ${afterSeq} ORDER BY seq ASC LIMIT ${safeLimit}`,
+    );
+    const values = rows.map((r) => spec.columns.map((c) => normalize(r[c])));
+    const lastSeq = rows.length > 0 ? Number(rows[rows.length - 1].seq) : afterSeq;
+    return { rows: values, lastSeq };
+  }
+
   @Post('check')
   @HttpCode(HttpStatus.OK)
-  async sync_login_check(
-    @Body() body: { username?: string; password?: string },
-  ) {
+  async syncLoginCheck(@Body() body: { username?: string; password?: string }) {
     if (!body.username || !body.password) {
-      throw new BadRequestException('username과 password는 필수입니다');
+      throw new BadRequestException('username/password required');
     }
     return this.authService.login(body.username, body.password);
   }
 
-  /** source/orchestrator 측: 로컬 DB → 원격 target API로 SSE 진행률 스트림 */
   @Sse(':table/run')
   run(
     @Param('table') table: string,
     @Query('sessionId') sessionId?: string,
+    @Query('direction') direction?: string,
   ): Observable<MessageEvent> {
     const spec = specOrThrow(table);
+    const syncDirection = directionOrThrow(direction?.trim() ?? '');
     const targetUrl = this.config.get<string>('SYNC_TARGET_API_URL', '').trim();
     const remoteToken = sessionId?.trim() ?? '';
+    const isLocalRuntime =
+      this.config.get<string>('NODE_ENV', '').trim() !== 'production';
+
+    if (syncDirection === 'local-to-prod' && !isLocalRuntime) {
+      throw new BadRequestException('local-to-prod is allowed only on local runtime');
+    }
+    if (syncDirection === 'prod-to-local' && isLocalRuntime) {
+      throw new BadRequestException('prod-to-local is allowed only on production runtime');
+    }
 
     return new Observable<MessageEvent>((subscriber) => {
       let cancelled = false;
@@ -172,40 +218,46 @@ export class AdminSyncController {
       void (async () => {
         try {
           if (!targetUrl) {
-            throw new Error(
-              'SYNC_TARGET_API_URL 환경변수가 설정되지 않았습니다',
-            );
+            throw new Error('SYNC_TARGET_API_URL is required');
           }
           if (!remoteToken) {
-            throw new Error('원격 관리자 세션이 없습니다');
+            throw new Error('remote admin session is required');
           }
 
-          // run은 로컬 DB를 읽는 orchestrator입니다.
-          // 원격 세션은 Next의 sync/check가 EC2에서 발급받아 전달합니다.
           emit('progress', {
             phase: 'login',
-            message: '원격 관리자 세션 확인 중',
+            message:
+              syncDirection === 'local-to-prod'
+                ? 'validating remote session'
+                : 'validating remote source session',
             percent: 0,
           });
 
-          // 1) target 측 begin (TRUNCATE)
           emit('progress', {
             phase: 'begin',
-            message: `${spec.table} TRUNCATE 중...`,
+            message:
+              syncDirection === 'local-to-prod'
+                ? `${spec.table} remote TRUNCATE`
+                : `${spec.table} local TRUNCATE`,
             percent: 0,
           });
-          await callTargetRaw(
-            targetUrl,
-            `/api/admin/sync/${table}/begin`,
-            remoteToken,
-            {},
-          );
 
-          // 2) total count
-          const [countRows] = await this.pool.query<RowDataPacket[]>(
-            `SELECT COUNT(*) AS total FROM \`${spec.table}\``,
-          );
-          const total = Number(countRows[0]?.total ?? 0);
+          if (syncDirection === 'local-to-prod') {
+            await callTargetRaw(
+              targetUrl,
+              `/api/admin/sync/${table}/begin`,
+              remoteToken,
+              {},
+            );
+          } else {
+            await this.begin(table);
+          }
+
+          const total =
+            syncDirection === 'local-to-prod'
+              ? await readLocalCount(this.pool, spec.table)
+              : await readRemoteCount(targetUrl, table, remoteToken);
+
           emit('progress', {
             phase: 'count',
             total,
@@ -219,33 +271,38 @@ export class AdminSyncController {
             return;
           }
 
-          // 3) chunked read + push
-          const colList = spec.columns.map((c) => `\`${c}\``).join(', ');
           let transferred = 0;
           let lastSeq = 0;
 
           while (!cancelled) {
-            const [chunkRows] = await this.pool.query<RowDataPacket[]>(
-              `SELECT ${colList} FROM \`${spec.table}\` WHERE seq > ${lastSeq} ORDER BY seq ASC LIMIT ${SYNC_CHUNK_SIZE}`,
-            );
-            if (chunkRows.length === 0) break;
+            const values =
+              syncDirection === 'local-to-prod'
+                ? await readLocalChunk(this.pool, spec, lastSeq, SYNC_CHUNK_SIZE)
+                : await readRemoteChunk(
+                    targetUrl,
+                    table,
+                    spec,
+                    remoteToken,
+                    lastSeq,
+                    SYNC_CHUNK_SIZE,
+                  );
 
-            const values = chunkRows.map((r) =>
-              spec.columns.map((c) => normalize(r[c])),
-            );
-
-            const last = chunkRows[chunkRows.length - 1];
-            lastSeq = Number(last.seq);
+            if (values.length === 0) break;
+            const last = values[values.length - 1];
+            lastSeq = Number(last[0] ?? lastSeq);
 
             for (const rows of splitRowsByPayloadSize(values)) {
               if (cancelled) break;
 
-              const res = await callTargetRaw(
-                targetUrl,
-                `/api/admin/sync/${table}/chunk`,
-                remoteToken,
-                { rows },
-              );
+              const res =
+                syncDirection === 'local-to-prod'
+                  ? await callTargetRaw(
+                      targetUrl,
+                      `/api/admin/sync/${table}/chunk`,
+                      remoteToken,
+                      { rows },
+                    )
+                  : await this.chunk(table, { rows });
               const inserted = Number(
                 (res as { inserted?: number })?.inserted ?? 0,
               );
@@ -255,10 +312,7 @@ export class AdminSyncController {
                 phase: 'chunk',
                 total,
                 transferred,
-                percent: Math.min(
-                  99,
-                  Math.floor((transferred / total) * 100),
-                ),
+                percent: Math.min(99, Math.floor((transferred / total) * 100)),
                 lastSeq,
               });
 
@@ -269,7 +323,7 @@ export class AdminSyncController {
           }
 
           if (cancelled) {
-            emit('error', { message: '취소됨' });
+            emit('error', { message: 'cancelled' });
             subscriber.complete();
             return;
           }
@@ -299,10 +353,61 @@ export class AdminSyncController {
   }
 }
 
+async function readLocalCount(pool: Pool, table: string): Promise<number> {
+  const [rows] = await pool.query<RowDataPacket[]>(
+    `SELECT COUNT(*) AS total FROM \`${table}\``,
+  );
+  return Number(rows[0]?.total ?? 0);
+}
+
+async function readLocalChunk(
+  pool: Pool,
+  spec: TableSpec,
+  lastSeq: number,
+  limit: number,
+): Promise<unknown[][]> {
+  const colList = spec.columns.map((c) => `\`${c}\``).join(', ');
+  const [rows] = await pool.query<RowDataPacket[]>(
+    `SELECT ${colList} FROM \`${spec.table}\` WHERE seq > ${lastSeq} ORDER BY seq ASC LIMIT ${limit}`,
+  );
+  return rows.map((r) => spec.columns.map((c) => normalize(r[c])));
+}
+
+async function readRemoteCount(
+  baseUrl: string,
+  table: string,
+  token: string,
+): Promise<number> {
+  const res = await callTargetRaw(baseUrl, `/api/admin/sync/${table}/count`, token, {});
+  return Number((res as { total?: number })?.total ?? 0);
+}
+
+async function readRemoteChunk(
+  baseUrl: string,
+  table: string,
+  spec: TableSpec,
+  token: string,
+  lastSeq: number,
+  limit: number,
+): Promise<unknown[][]> {
+  const res = await callTargetRaw(
+    baseUrl,
+    `/api/admin/sync/${table}/chunk-read`,
+    token,
+    { afterSeq: lastSeq, limit },
+  );
+  const rows = Array.isArray((res as { rows?: unknown[][] })?.rows)
+    ? ((res as { rows: unknown[][] }).rows as unknown[][])
+    : [];
+
+  return rows.map((row) =>
+    spec.columns.map((_, idx) => (Array.isArray(row) ? row[idx] ?? null : null)),
+  );
+}
+
 function normalize(v: unknown): unknown {
   if (v === undefined) return null;
   if (v instanceof Date) {
-    // mysql2는 DATETIME을 Date 객체로 반환. ISO 대신 'YYYY-MM-DD HH:mm:ss' 사용
     const pad = (n: number) => String(n).padStart(2, '0');
     return `${v.getFullYear()}-${pad(v.getMonth() + 1)}-${pad(v.getDate())} ${pad(v.getHours())}:${pad(v.getMinutes())}:${pad(v.getSeconds())}`;
   }
@@ -359,9 +464,7 @@ async function callTargetRaw(
   });
   const text = await res.text();
   if (!res.ok) {
-    throw new Error(
-      `target ${path} 실패 (${res.status}): ${text.slice(0, 300)}`,
-    );
+    throw new Error(`target ${path} failed (${res.status}): ${text.slice(0, 300)}`);
   }
   try {
     return JSON.parse(text) as unknown;

--- a/server/src/admin/admin-sync.controller.ts
+++ b/server/src/admin/admin-sync.controller.ts
@@ -77,6 +77,14 @@ function specOrThrow(table: string): TableSpec {
   return TABLE_SPECS[table as TableKey];
 }
 
+function seqIndexOrThrow(spec: TableSpec): number {
+  const seqIndex = spec.columns.indexOf('seq');
+  if (seqIndex === -1) {
+    throw new BadRequestException(`seq column not found for ${spec.table}`);
+  }
+  return seqIndex;
+}
+
 function directionOrThrow(direction: string): SyncDirection {
   if (direction === 'local-to-prod' || direction === 'prod-to-local') {
     return direction;
@@ -163,6 +171,7 @@ export class AdminSyncController {
     @Body() body: { afterSeq?: number; limit?: number },
   ) {
     const spec = specOrThrow(table);
+    const seqIndex = seqIndexOrThrow(spec);
     const afterSeq = Number(body?.afterSeq ?? 0);
     const limit = Number(body?.limit ?? SYNC_CHUNK_SIZE);
     const safeLimit = Math.max(1, Math.min(SYNC_CHUNK_SIZE, limit));
@@ -172,7 +181,10 @@ export class AdminSyncController {
       `SELECT ${colList} FROM \`${spec.table}\` WHERE seq > ${afterSeq} ORDER BY seq ASC LIMIT ${safeLimit}`,
     );
     const values = rows.map((r) => spec.columns.map((c) => normalize(r[c])));
-    const lastSeq = rows.length > 0 ? Number(rows[rows.length - 1].seq) : afterSeq;
+    const lastRow = rows[rows.length - 1];
+    const seqColumn = spec.columns[seqIndex];
+    const lastSeq =
+      rows.length > 0 ? Number(lastRow[seqColumn] ?? afterSeq) : afterSeq;
     return { rows: values, lastSeq };
   }
 
@@ -192,6 +204,7 @@ export class AdminSyncController {
     @Query('direction') direction?: string,
   ): Observable<MessageEvent> {
     const spec = specOrThrow(table);
+    const seqIndex = seqIndexOrThrow(spec);
     const syncDirection = directionOrThrow(direction?.trim() ?? '');
     const targetUrl = this.config.get<string>('SYNC_TARGET_API_URL', '').trim();
     const remoteToken = sessionId?.trim() ?? '';
@@ -289,7 +302,7 @@ export class AdminSyncController {
 
             if (values.length === 0) break;
             const last = values[values.length - 1];
-            lastSeq = Number(last[0] ?? lastSeq);
+            lastSeq = Number(last[seqIndex] ?? lastSeq);
 
             for (const rows of splitRowsByPayloadSize(values)) {
               if (cancelled) break;

--- a/server/src/admin/admin-sync.controller.ts
+++ b/server/src/admin/admin-sync.controller.ts
@@ -174,11 +174,14 @@ export class AdminSyncController {
     const seqIndex = seqIndexOrThrow(spec);
     const afterSeq = Number(body?.afterSeq ?? 0);
     const limit = Number(body?.limit ?? SYNC_CHUNK_SIZE);
-    const safeLimit = Math.max(1, Math.min(SYNC_CHUNK_SIZE, limit));
+    const safeAfterSeq = Number.isFinite(afterSeq) ? afterSeq : 0;
+    const safeLimitInput = Number.isFinite(limit) ? limit : SYNC_CHUNK_SIZE;
+    const safeLimit = Math.max(1, Math.min(SYNC_CHUNK_SIZE, safeLimitInput));
     const colList = spec.columns.map((c) => `\`${c}\``).join(', ');
 
     const [rows] = await this.pool.query<RowDataPacket[]>(
-      `SELECT ${colList} FROM \`${spec.table}\` WHERE seq > ${afterSeq} ORDER BY seq ASC LIMIT ${safeLimit}`,
+      `SELECT ${colList} FROM \`${spec.table}\` WHERE seq > ? ORDER BY seq ASC LIMIT ?`,
+      [safeAfterSeq, safeLimit],
     );
     const values = rows.map((r) => spec.columns.map((c) => normalize(r[c])));
     const lastRow = rows[rows.length - 1];
@@ -222,6 +225,8 @@ export class AdminSyncController {
 
     return new Observable<MessageEvent>((subscriber) => {
       let cancelled = false;
+      const targetLabel =
+        syncDirection === 'local-to-prod' ? 'production' : 'local';
 
       const emit = (
         type: 'progress' | 'done' | 'error',
@@ -241,37 +246,24 @@ export class AdminSyncController {
 
           emit('progress', {
             phase: 'login',
-            message:
-              syncDirection === 'local-to-prod'
-                ? 'validating remote session'
-                : 'validating remote source session',
+            message: 'validating remote session',
             percent: 0,
           });
 
           emit('progress', {
             phase: 'begin',
-            message:
-              syncDirection === 'local-to-prod'
-                ? `${spec.table} remote TRUNCATE`
-                : `${spec.table} local TRUNCATE`,
+            message: `${spec.table} ${targetLabel} TRUNCATE`,
             percent: 0,
           });
 
-          if (syncDirection === 'local-to-prod') {
-            await callTargetRaw(
-              targetUrl,
-              `/api/admin/sync/${table}/begin`,
-              remoteToken,
-              {},
-            );
-          } else {
-            await this.begin(table);
-          }
+          await callTargetRaw(
+            targetUrl,
+            `/api/admin/sync/${table}/begin`,
+            remoteToken,
+            {},
+          );
 
-          const total =
-            syncDirection === 'local-to-prod'
-              ? await readLocalCount(this.pool, spec.table)
-              : await readRemoteCount(targetUrl, table, remoteToken);
+          const total = await readLocalCount(this.pool, spec.table);
 
           emit('progress', {
             phase: 'count',
@@ -290,17 +282,12 @@ export class AdminSyncController {
           let lastSeq = 0;
 
           while (!cancelled) {
-            const values =
-              syncDirection === 'local-to-prod'
-                ? await readLocalChunk(this.pool, spec, lastSeq, SYNC_CHUNK_SIZE)
-                : await readRemoteChunk(
-                    targetUrl,
-                    table,
-                    spec,
-                    remoteToken,
-                    lastSeq,
-                    SYNC_CHUNK_SIZE,
-                  );
+            const values = await readLocalChunk(
+              this.pool,
+              spec,
+              lastSeq,
+              SYNC_CHUNK_SIZE,
+            );
 
             if (values.length === 0) break;
             const last = values[values.length - 1];
@@ -310,14 +297,12 @@ export class AdminSyncController {
               if (cancelled) break;
 
               const res =
-                syncDirection === 'local-to-prod'
-                  ? await callTargetRaw(
-                      targetUrl,
-                      `/api/admin/sync/${table}/chunk`,
-                      remoteToken,
-                      { rows },
-                    )
-                  : await this.chunk(table, { rows });
+                await callTargetRaw(
+                  targetUrl,
+                  `/api/admin/sync/${table}/chunk`,
+                  remoteToken,
+                  { rows },
+                );
               const inserted = Number(
                 (res as { inserted?: number })?.inserted ?? 0,
               );
@@ -383,41 +368,10 @@ async function readLocalChunk(
 ): Promise<unknown[][]> {
   const colList = spec.columns.map((c) => `\`${c}\``).join(', ');
   const [rows] = await pool.query<RowDataPacket[]>(
-    `SELECT ${colList} FROM \`${spec.table}\` WHERE seq > ${lastSeq} ORDER BY seq ASC LIMIT ${limit}`,
+    `SELECT ${colList} FROM \`${spec.table}\` WHERE seq > ? ORDER BY seq ASC LIMIT ?`,
+    [lastSeq, limit],
   );
   return rows.map((r) => spec.columns.map((c) => normalize(r[c])));
-}
-
-async function readRemoteCount(
-  baseUrl: string,
-  table: string,
-  token: string,
-): Promise<number> {
-  const res = await callTargetRaw(baseUrl, `/api/admin/sync/${table}/count`, token, {});
-  return Number((res as { total?: number })?.total ?? 0);
-}
-
-async function readRemoteChunk(
-  baseUrl: string,
-  table: string,
-  spec: TableSpec,
-  token: string,
-  lastSeq: number,
-  limit: number,
-): Promise<unknown[][]> {
-  const res = await callTargetRaw(
-    baseUrl,
-    `/api/admin/sync/${table}/chunk-read`,
-    token,
-    { afterSeq: lastSeq, limit },
-  );
-  const rows = Array.isArray((res as { rows?: unknown[][] })?.rows)
-    ? ((res as { rows: unknown[][] }).rows as unknown[][])
-    : [];
-
-  return rows.map((row) =>
-    spec.columns.map((_, idx) => (Array.isArray(row) ? row[idx] ?? null : null)),
-  );
 }
 
 function normalize(v: unknown): unknown {

--- a/server/src/characters/characters.service.spec.ts
+++ b/server/src/characters/characters.service.spec.ts
@@ -54,7 +54,10 @@ describe('CharactersService', () => {
 
   beforeEach(async () => {
     mockPool = { execute: jest.fn() };
-    mockRedis = { get: jest.fn().mockResolvedValue(null), set: jest.fn().mockResolvedValue('OK') };
+    mockRedis = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn().mockResolvedValue('OK'),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [

--- a/server/src/characters/characters.service.ts
+++ b/server/src/characters/characters.service.ts
@@ -79,10 +79,16 @@ export class CharactersService {
 
   async findStatBuilds() {
     const cached = await this.redis.get(CACHE_KEY);
-    if (cached) return JSON.parse(cached) as ReturnType<typeof this._buildResult>;
+    if (cached)
+      return JSON.parse(cached) as ReturnType<typeof this._buildResult>;
 
     const result = await this._buildResult();
-    await this.redis.set(CACHE_KEY, JSON.stringify(result), 'EX', CACHE_TTL_SEC);
+    await this.redis.set(
+      CACHE_KEY,
+      JSON.stringify(result),
+      'EX',
+      CACHE_TTL_SEC,
+    );
     return result;
   }
 

--- a/server/src/common/http-exception.filter.ts
+++ b/server/src/common/http-exception.filter.ts
@@ -21,8 +21,8 @@ export class AllExceptionsFilter implements ExceptionFilter {
 
   // 상태코드별 마지막 알림 시각 (스팸 방지)
   private readonly lastNotifiedAt = new Map<number, number>();
-  private readonly COOLDOWN_5XX_MS = 60_000;   // 5xx: 1분
-  private readonly COOLDOWN_4XX_MS = 300_000;  // 4xx: 5분
+  private readonly COOLDOWN_5XX_MS = 60_000; // 5xx: 1분
+  private readonly COOLDOWN_4XX_MS = 300_000; // 4xx: 5분
 
   // 알림 제외 상태코드 (빈번하거나 의미 없는 에러)
   private readonly SKIP_STATUSES = new Set([401, 404]);
@@ -40,9 +40,7 @@ export class AllExceptionsFilter implements ExceptionFilter {
         : HttpStatus.INTERNAL_SERVER_ERROR;
 
     const errorName =
-      exception instanceof Error
-        ? exception.constructor.name
-        : 'UnknownError';
+      exception instanceof Error ? exception.constructor.name : 'UnknownError';
 
     const message =
       exception instanceof HttpException
@@ -56,7 +54,8 @@ export class AllExceptionsFilter implements ExceptionFilter {
     // 알림 전송 (401, 404 제외)
     if (!this.SKIP_STATUSES.has(status)) {
       const now = Date.now();
-      const cooldown = status >= 500 ? this.COOLDOWN_5XX_MS : this.COOLDOWN_4XX_MS;
+      const cooldown =
+        status >= 500 ? this.COOLDOWN_5XX_MS : this.COOLDOWN_4XX_MS;
       const lastAt = this.lastNotifiedAt.get(status) ?? 0;
 
       if (now - lastAt > cooldown) {


### PR DESCRIPTION
## 요약
- `prod-to-local` 동기화가 자기 DB를 비우지 않고, source DB를 읽어서 원격으로 전송하도록 수정했습니다.
- `chunkRead` 쿼리를 파라미터 바인딩으로 바꿔 안전성을 높였습니다.
- `afterSeq` / `limit` 입력값이 비정상일 때도 `NaN`이 들어가지 않도록 보강했습니다.
- 회귀 테스트를 추가해 동기화 흐름과 원격 전송 동작을 검증했습니다.