### PR TITLE
fix(어드민): 동기화 화면 문구 및 CI 불통과 정리

### DIFF
--- a/client/app/admin/sync/page.tsx
+++ b/client/app/admin/sync/page.tsx
@@ -39,9 +39,7 @@ const TABLES: { key: "users" | "sites"; label: string; desc: string }[] = [
 
 export default function SyncPage() {
   const [showForm, setShowForm] = useState(false);
-  const [activeTable, setActiveTable] = useState<"users" | "sites" | null>(
-    null,
-  );
+  const [activeTable, setActiveTable] = useState<"users" | "sites" | null>(null);
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
@@ -64,7 +62,7 @@ export default function SyncPage() {
     state.phase !== "idle" && state.phase !== "done" && state.phase !== "error";
 
   const directionLabel =
-    direction === "local-to-prod" ? "Local → Prod" : "Prod → Local";
+    direction === "local-to-prod" ? "프로덕션으로 동기화" : "로컬과 동기화";
 
   function requireMaster(action: string) {
     if (!isGuest) return true;
@@ -77,10 +75,10 @@ export default function SyncPage() {
     const table = TABLES.find((item) => item.key === tableKey);
     const actionText =
       direction === "local-to-prod"
-        ? "프로덕션 테이블을 삭제 후 로컬 데이터로 재삽입"
-        : "로컬 테이블을 삭제 후 프로덕션 데이터로 재삽입";
+        ? "프로덕션 테이블을 비우고 로컬 데이터를 복사합니다."
+        : "로컬 테이블을 비우고 프로덕션 데이터를 복사합니다.";
     const ok = window.confirm(
-      `[${table?.label ?? tableKey}] (${directionLabel})\n\n${actionText} 합니다.\n계속하시겠습니까?`,
+      `[${table?.label ?? tableKey}] (${directionLabel})\n\n${actionText}\n계속하시겠습니까?`,
     );
     if (!ok) return;
 
@@ -136,7 +134,9 @@ export default function SyncPage() {
         ...s,
         phase: "error",
         error:
-          err instanceof Error ? err.message : "동기화 중 오류가 발생했습니다.",
+          err instanceof Error
+            ? err.message
+            : "동기화 중 오류가 발생했습니다.",
       }));
     } finally {
       abortRef.current = null;
@@ -145,7 +145,7 @@ export default function SyncPage() {
 
   function cancel() {
     abortRef.current?.abort();
-    setState((s) => ({ ...s, phase: "error", error: "사용자가 취소함" }));
+    setState((s) => ({ ...s, phase: "error", error: "사용자가 취소했습니다." }));
   }
 
   async function syncCheck(u: string, p: string) {
@@ -176,7 +176,9 @@ export default function SyncPage() {
       await start(data.sessionId);
     } catch (err) {
       setError(
-        err instanceof Error ? err.message : "원격 관리자 인증 중 오류가 발생했습니다.",
+        err instanceof Error
+          ? err.message
+          : "원격 관리자 인증 중 오류가 발생했습니다.",
       );
     } finally {
       setLoading(false);
@@ -194,8 +196,8 @@ export default function SyncPage() {
         <header>
           <h1 className="text-2xl font-bold">서버 동기화</h1>
           <p className="mt-2 text-sm text-gray-400">
-            동기화 방향을 선택한 뒤 실행합니다. 대상 측 테이블은{" "}
-            <strong className="text-red-400">TRUNCATE</strong> 후 전체 재삽입됩니다.
+            동기화 방향을 선택한 뒤 실행합니다. 대상 테이블은{" "}
+            <strong className="text-red-400">TRUNCATE</strong> 후 전체 복사됩니다.
           </p>
           {accessNotice && (
             <pre className="mt-3 whitespace-pre-wrap rounded border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
@@ -215,7 +217,7 @@ export default function SyncPage() {
                 : "bg-gray-800 text-gray-300"
             }`}
           >
-            Local → Prod
+            프로덕션으로 동기화
           </button>
           <button
             type="button"
@@ -227,7 +229,7 @@ export default function SyncPage() {
                 : "bg-gray-800 text-gray-300"
             }`}
           >
-            Prod → Local
+            로컬과 동기화
           </button>
         </div>
 
@@ -239,7 +241,7 @@ export default function SyncPage() {
                 className="rounded-xl border border-gray-700 bg-gray-900 p-5"
                 key={t.key}
               >
-                <h2 className="text-lg font-semibold">{t.label}</h2>
+                <h2 className="text-lg font-semibold text-gray-100">{t.label}</h2>
                 <p className="mt-1 text-xs text-gray-400">{t.desc}</p>
 
                 <div className="mt-4 space-y-2">
@@ -371,11 +373,11 @@ function phaseLabel(p: Phase): string {
     case "idle":
       return "대기";
     case "login":
-      return "원격 로그인";
+      return "원격 관리자 인증";
     case "begin":
       return "TRUNCATE";
     case "count":
-      return "카운트 조회";
+      return "건수 조회";
     case "chunk":
       return "전송 중";
     case "done":
@@ -410,16 +412,14 @@ function handleEvent(
     if (evt === "progress") {
       if (typeof data.phase === "string") next.phase = data.phase as Phase;
       if (typeof data.total === "number") next.total = data.total;
-      if (typeof data.transferred === "number")
-        next.transferred = data.transferred;
+      if (typeof data.transferred === "number") next.transferred = data.transferred;
       if (typeof data.percent === "number") next.percent = data.percent;
       if (typeof data.message === "string") next.message = data.message;
     } else if (evt === "done") {
       next.phase = "done";
       next.percent = 100;
       if (typeof data.total === "number") next.total = data.total;
-      if (typeof data.transferred === "number")
-        next.transferred = data.transferred;
+      if (typeof data.transferred === "number") next.transferred = data.transferred;
       next.message = "동기화 완료";
     } else if (evt === "error") {
       next.phase = "error";

--- a/client/lib/admin-role.ts
+++ b/client/lib/admin-role.ts
@@ -1,32 +1,25 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 export type AdminRole = "master" | "guest" | null;
 
 export function readAdminRole(): AdminRole {
   if (typeof document === "undefined") return null;
-  const match = document.cookie.match(
-    /(?:^|;\s*)admin_role=([^;]+)/,
-  );
+  const match = document.cookie.match(/(?:^|;\s*)admin_role=([^;]+)/);
   if (!match) return null;
   const value = decodeURIComponent(match[1]);
   return value === "master" || value === "guest" ? value : null;
 }
 
 export function useAdminRole(): AdminRole {
-  const [role, setRole] = useState<AdminRole>(null);
-
-  useEffect(() => {
-    setRole(readAdminRole());
-  }, []);
-
+  const [role] = useState<AdminRole>(() => readAdminRole());
   return role;
 }
 
 export function buildGuestNotice(action: string): string {
   return [
-    `게스트 계정은 ${action}을 할 수 없습니다.`,
-    "흐름: 로그인된 세션 확인 -> role 검사 -> 작업 차단",
+    `게스트 계정은 ${action} 작업을 할 수 없습니다.`,
+    "흐름: 로그인 세션 확인 -> 역할(role) 확인 -> 쓰기 작업 차단",
   ].join("\n");
 }

--- a/server/src/admin/admin-sync.controller.spec.ts
+++ b/server/src/admin/admin-sync.controller.spec.ts
@@ -27,7 +27,11 @@ function createController(nodeEnv = 'production') {
     login: jest.fn(),
   } as never;
 
-  const controller = new AdminSyncController(pool as never, config, authService);
+  const controller = new AdminSyncController(
+    pool as never,
+    config,
+    authService,
+  );
   return { controller, pool };
 }
 
@@ -35,8 +39,18 @@ function mockResponse(body: string) {
   return {
     ok: true,
     status: 200,
-    text: async () => body,
+    text: () => Promise.resolve(body),
   } as Response;
+}
+
+function requestUrl(input: RequestInfo | URL | undefined): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.href;
+  if (input && typeof input === 'object' && 'url' in input) {
+    const url = input.url;
+    return typeof url === 'string' ? url : '';
+  }
+  return '';
 }
 
 function collectEvents<T>(stream: Observable<T>) {
@@ -104,24 +118,33 @@ describe('AdminSyncController', () => {
 
   it('prod-to-local sends local rows to the remote target without truncating the local DB', async () => {
     const { controller, pool } = createController('production');
-    const fetchSpy = jest.spyOn(globalThis, 'fetch').mockImplementation(
-      async (input: RequestInfo | URL) => {
-        const url = String(input);
+    const fetchSpy = jest
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation((input: RequestInfo | URL) => {
+        const url = requestUrl(input);
         if (url.endsWith('/begin')) {
-          return mockResponse('{"ok":true}') as never;
+          return Promise.resolve(mockResponse('{"ok":true}')) as never;
         }
         if (url.endsWith('/chunk')) {
-          return mockResponse('{"inserted":2}') as never;
+          return Promise.resolve(mockResponse('{"inserted":2}')) as never;
         }
-        throw new Error(`unexpected fetch: ${url}`);
-      },
-    );
-    jest.spyOn(globalThis, 'setTimeout').mockImplementation((cb: TimerHandler) => {
-      if (typeof cb === 'function') {
-        cb();
-      }
-      return 0 as never;
-    });
+        if (url.endsWith('/auth/logout')) {
+          return Promise.resolve(mockResponse('{"ok":true}')) as never;
+        }
+        return Promise.reject(
+          new Error(`unexpected fetch: ${requestUrl(input)}`),
+        ) as never;
+      });
+
+    jest
+      .spyOn(globalThis, 'setTimeout')
+      .mockImplementation((cb: TimerHandler): never => {
+        if (typeof cb === 'function') {
+          const fn = cb as () => void;
+          fn();
+        }
+        return 0 as never;
+      });
 
     pool.query
       .mockResolvedValueOnce([[{ total: 2 }]])
@@ -162,9 +185,9 @@ describe('AdminSyncController', () => {
     expect(pool.getConnection).not.toHaveBeenCalled();
     expect(pool.query).toHaveBeenCalledTimes(3);
     expect(fetchSpy).toHaveBeenCalledTimes(3);
-    expect(String(fetchSpy.mock.calls[0]?.[0])).toContain('/begin');
-    expect(String(fetchSpy.mock.calls[1]?.[0])).toContain('/chunk');
-    expect(String(fetchSpy.mock.calls[2]?.[0])).toContain('/auth/logout');
+    expect(requestUrl(fetchSpy.mock.calls[0]?.[0])).toContain('/begin');
+    expect(requestUrl(fetchSpy.mock.calls[1]?.[0])).toContain('/chunk');
+    expect(requestUrl(fetchSpy.mock.calls[2]?.[0])).toContain('/auth/logout');
     expect(events.some((event) => event.type === 'done')).toBe(true);
   });
 });

--- a/server/src/admin/admin-sync.controller.ts
+++ b/server/src/admin/admin-sync.controller.ts
@@ -217,10 +217,14 @@ export class AdminSyncController {
       this.config.get<string>('NODE_ENV', '').trim() !== 'production';
 
     if (syncDirection === 'local-to-prod' && !isLocalRuntime) {
-      throw new BadRequestException('local-to-prod is allowed only on local runtime');
+      throw new BadRequestException(
+        'local-to-prod is allowed only on local runtime',
+      );
     }
     if (syncDirection === 'prod-to-local' && isLocalRuntime) {
-      throw new BadRequestException('prod-to-local is allowed only on production runtime');
+      throw new BadRequestException(
+        'prod-to-local is allowed only on production runtime',
+      );
     }
 
     return new Observable<MessageEvent>((subscriber) => {
@@ -296,13 +300,12 @@ export class AdminSyncController {
             for (const rows of splitRowsByPayloadSize(values)) {
               if (cancelled) break;
 
-              const res =
-                await callTargetRaw(
-                  targetUrl,
-                  `/api/admin/sync/${table}/chunk`,
-                  remoteToken,
-                  { rows },
-                );
+              const res = await callTargetRaw(
+                targetUrl,
+                `/api/admin/sync/${table}/chunk`,
+                remoteToken,
+                { rows },
+              );
               const inserted = Number(
                 (res as { inserted?: number })?.inserted ?? 0,
               );
@@ -433,7 +436,9 @@ async function callTargetRaw(
   });
   const text = await res.text();
   if (!res.ok) {
-    throw new Error(`target ${path} failed (${res.status}): ${text.slice(0, 300)}`);
+    throw new Error(
+      `target ${path} failed (${res.status}): ${text.slice(0, 300)}`,
+    );
   }
   try {
     return JSON.parse(text) as unknown;

--- a/server/src/characters/characters.service.spec.ts
+++ b/server/src/characters/characters.service.spec.ts
@@ -54,7 +54,10 @@ describe('CharactersService', () => {
 
   beforeEach(async () => {
     mockPool = { execute: jest.fn() };
-    mockRedis = { get: jest.fn().mockResolvedValue(null), set: jest.fn().mockResolvedValue('OK') };
+    mockRedis = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn().mockResolvedValue('OK'),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [

--- a/server/src/characters/characters.service.ts
+++ b/server/src/characters/characters.service.ts
@@ -79,10 +79,16 @@ export class CharactersService {
 
   async findStatBuilds() {
     const cached = await this.redis.get(CACHE_KEY);
-    if (cached) return JSON.parse(cached) as ReturnType<typeof this._buildResult>;
+    if (cached)
+      return JSON.parse(cached) as ReturnType<typeof this._buildResult>;
 
     const result = await this._buildResult();
-    await this.redis.set(CACHE_KEY, JSON.stringify(result), 'EX', CACHE_TTL_SEC);
+    await this.redis.set(
+      CACHE_KEY,
+      JSON.stringify(result),
+      'EX',
+      CACHE_TTL_SEC,
+    );
     return result;
   }
 

--- a/server/src/common/http-exception.filter.ts
+++ b/server/src/common/http-exception.filter.ts
@@ -21,8 +21,8 @@ export class AllExceptionsFilter implements ExceptionFilter {
 
   // 상태코드별 마지막 알림 시각 (스팸 방지)
   private readonly lastNotifiedAt = new Map<number, number>();
-  private readonly COOLDOWN_5XX_MS = 60_000;   // 5xx: 1분
-  private readonly COOLDOWN_4XX_MS = 300_000;  // 4xx: 5분
+  private readonly COOLDOWN_5XX_MS = 60_000; // 5xx: 1분
+  private readonly COOLDOWN_4XX_MS = 300_000; // 4xx: 5분
 
   // 알림 제외 상태코드 (빈번하거나 의미 없는 에러)
   private readonly SKIP_STATUSES = new Set([401, 404]);
@@ -40,9 +40,7 @@ export class AllExceptionsFilter implements ExceptionFilter {
         : HttpStatus.INTERNAL_SERVER_ERROR;
 
     const errorName =
-      exception instanceof Error
-        ? exception.constructor.name
-        : 'UnknownError';
+      exception instanceof Error ? exception.constructor.name : 'UnknownError';
 
     const message =
       exception instanceof HttpException
@@ -56,7 +54,8 @@ export class AllExceptionsFilter implements ExceptionFilter {
     // 알림 전송 (401, 404 제외)
     if (!this.SKIP_STATUSES.has(status)) {
       const now = Date.now();
-      const cooldown = status >= 500 ? this.COOLDOWN_5XX_MS : this.COOLDOWN_4XX_MS;
+      const cooldown =
+        status >= 500 ? this.COOLDOWN_5XX_MS : this.COOLDOWN_4XX_MS;
       const lastAt = this.lastNotifiedAt.get(status) ?? 0;
 
       if (now - lastAt > cooldown) {


### PR DESCRIPTION
## 요약
- GitHub Actions에서 반복되던 lint/test 불통과 이슈를 정리했습니다.
- 동기화 화면의 한글 깨짐을 복구하고 `loa_users (캐릭터)` 텍스트가 보이도록 수정했습니다.
- 동기화 방향 문구를 한국어로 정리했습니다. (`로컬과 동기화`)
- CI 자동 수정 과정에서 함께 반영된 서버 코드 포맷/테스트 보강 변경도 포함했습니다.