### PR TITLE
fix: admin login redirect test expectation

### DIFF
--- a/client/app/admin/login/page.test.tsx
+++ b/client/app/admin/login/page.test.tsx
@@ -34,7 +34,7 @@ describe("AdminLoginPage", () => {
     await userEvent.click(screen.getByRole("button", { name: "로그인" }));
 
     await waitFor(() => {
-      expect(replaceSpy).toHaveBeenCalledWith("/admin/sites");
+      expect(replaceSpy).toHaveBeenCalledWith("/admin/monitoring");
     });
   });
 


### PR DESCRIPTION
## 작업 내용
- 관리자 로그인 성공 후 기본 이동 경로가 /admin/monitoring으로 변경된 흐름에 맞춰 테스트 기대값을 수정합니다.

## 확인
- npm test -- app/admin/login/page.test.tsx 통과