### PR TITLE
fix: 유튜브 조회 기록 API 프록시 추가

### DIFF
--- a/client/app/api/streamers/view-history/route.ts
+++ b/client/app/api/streamers/view-history/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const NEST_API = process.env.NEST_API_URL ?? "http://localhost:3001";
+
+export async function GET(req: NextRequest) {
+  const days = req.nextUrl.searchParams.get("days") ?? "30";
+  const upstream = `${NEST_API}/api/streamers/view-history?days=${encodeURIComponent(days)}`;
+
+  const res = await fetch(upstream, {
+    cache: "no-store",
+  });
+
+  const data: unknown = await res.json().catch(() => []);
+  return NextResponse.json(data, { status: res.status });
+}


### PR DESCRIPTION
## 작업 내용
- admin 유튜브 페이지에서 호출하는 /api/streamers/view-history Next API 프록시를 추가했습니다.
- Nest의 /api/streamers/view-history?days=... 엔드포인트로 전달합니다.

## 원인
- 클라이언트에는 /api/streamers/popular 프록시만 있고 iew-history 프록시가 없어 배포 환경에서 404가 발생했습니다.

## 확인
- 
pm run lint 통과