### PR TITLE
fix(ci): EC2 git pull 충돌 방지 - reset --hard 추가

### DIFF
--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -53,6 +53,7 @@ jobs:
         run: |
           remote_script="set -e
           cd /home/ubuntu/daloa
+          git reset --hard HEAD
           git pull origin main
           grep -q '^NEXT_REVALIDATE_URL=' .env || echo 'NEXT_REVALIDATE_URL=https://www.daloa.kr/api/revalidate' >> .env
           sed -i '/^NEXT_REVALIDATE_SECRET=/d' .env


### PR DESCRIPTION
## Summary

- `main-post-merge.yml`: `git pull` 전 `git reset --hard HEAD` 추가
- EC2에 Prisma generated 파일이 로컬 변경으로 남아 git pull이 실패하는 문제 수정

## 원인

`server/generated/prisma/` 파일들이 EC2에서 로컬 수정된 상태로 남아 있어 `git pull origin main`이 아래 오류로 실패:
```
error: Your local changes to the following files would be overwritten by merge
```

## 수정

```bash
git reset --hard HEAD   # ← 추가
git pull origin main
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)