### PR TITLE
fix: Dockerfile에 generated/ 복사 추가 (Prisma 클라이언트 누락으로 502 발생)

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -8,6 +8,7 @@ ENV NODE_ENV=production
 COPY package*.json ./
 RUN npm ci --omit=dev
 
+COPY generated ./generated
 COPY dist ./dist
 
 EXPOSE 3001


### PR DESCRIPTION
## 원인

`server/Dockerfile`에 `COPY generated ./generated` 가 없어서 Docker 컨테이너 실행 시 Prisma 클라이언트(`generated/prisma/`)를 찾지 못해 NestJS 서버가 시작 즉시 종료 → nginx 502 Bad Gateway 발생.

## 수정

```dockerfile
COPY generated ./generated   # ← 추가
COPY dist ./dist
```

EC2에서 `git pull` 후 `generated/` 디렉토리가 존재하므로 Docker 빌드 시 이미지에 포함됨.

## 확인

머지 후 `main-post-merge` 워크플로우 재실행 → Nest 컨테이너 정상 기동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)