### PR TITLE
fix(ci): SSM wait 타임아웃 연장 (npm build 시간 초과 수정)

### DIFF
--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -72,13 +72,23 @@ jobs:
             --query 'Command.CommandId' \
             --output text)
 
-          set +e
-          aws ssm wait command-executed \
-            --region "$AWS_REGION" \
-            --command-id "$command_id" \
-            --instance-id "$EC2_INSTANCE_ID"
-          wait_exit=$?
-          set -e
+          # SSM waiter 기본값(100s)이 너무 짧으므로 직접 폴링 (최대 10분)
+          wait_exit=1
+          for i in $(seq 1 60); do
+            status=$(aws ssm get-command-invocation \
+              --region "$AWS_REGION" \
+              --command-id "$command_id" \
+              --instance-id "$EC2_INSTANCE_ID" \
+              --query 'Status' \
+              --output text 2>/dev/null || echo "Pending")
+            echo "[${i}/60] SSM status: $status"
+            if [ "$status" = "Success" ]; then
+              wait_exit=0; break
+            elif [ "$status" = "Failed" ] || [ "$status" = "Cancelled" ] || [ "$status" = "TimedOut" ]; then
+              wait_exit=1; break
+            fi
+            sleep 10
+          done
 
           aws ssm get-command-invocation \
             --region "$AWS_REGION" \


### PR DESCRIPTION
## 원인

`aws ssm wait command-executed` 기본 타임아웃이 약 100초인데, EC2에서 `npm run build`가 그보다 오래 걸려 `Max attempts exceeded` 오류 발생.

## 수정

기본 waiter 대신 10초 간격 직접 폴링으로 교체 (최대 60회 = 10분):

```bash
for i in $(seq 1 60); do
  status=$(aws ssm get-command-invocation ... --query 'Status')
  if [ "$status" = "Success" ]; then break; fi
  sleep 10
done
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)