### PR TITLE
fix(ci): workflow_dispatch 추가 (수동 실행 가능)

### DIFF
--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'server/**'
       - 'client/**'
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- `workflow_dispatch` 트리거 추가
- `.github/workflows/` 변경 시 자동 트리거가 안 되므로, 머지 후 GitHub Actions 탭에서 수동 실행 가능하게

## 사용법

PR 머지 후 → GitHub Actions → Main Post Merge → Run workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)