### PR TITLE
fix(ci): 배포 후 nginx 재시작 추가

### DIFF
--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -60,7 +60,8 @@ jobs:
           sed -i '/^NEXT_REVALIDATE_SECRET=/d' .env
           echo 'NEXT_REVALIDATE_SECRET=${NEXT_REVALIDATE_SECRET}' >> .env
           cd server && npm run build && cd ..
-          docker compose up -d --build nest"
+          docker compose up -d --build nest
+          docker restart daloa-nginx"
 
           encoded=$(printf '%s' "$remote_script" | base64 -w0)
 


### PR DESCRIPTION
## Summary

- nest 컨테이너 재생성 후 nginx가 이전 연결을 유지해 502 발생
- `docker restart daloa-nginx` 추가로 자동 해결

🤖 Generated with [Claude Code](https://claude.com/claude-code)