### PR TITLE
fix: MySQL NULL → PostgreSQL COPY 호환 처리

### DIFF
--- a/scripts/migrate-apm-data.sh
+++ b/scripts/migrate-apm-data.sh
@@ -12,6 +12,8 @@ set +a
 
 MYSQL_ROOT_PWD="${MYSQL_ROOT_PWD:-Daloa1234!}"
 MYSQL="docker exec daloa-mysql mysql -u root -p${MYSQL_ROOT_PWD} lost_ark -N -B --default-character-set=utf8mb4 -e"
+# NULL 'NULL': MySQL batch mode outputs the word "NULL" for NULL values (not \N)
+COPY_OPT="WITH (FORMAT text, NULL 'NULL')"
 PSQL="docker exec -i daloa-postgres psql -U ${DB_USER} -d ${DB_NAME} -v ON_ERROR_STOP=1"
 
 echo "================================================"
@@ -20,38 +22,48 @@ echo "================================================"
 
 # ── 1. apm_site_clicks ──────────────────────────────
 echo "[1/5] apm_site_clicks..."
-{
-  echo "COPY apm_site_clicks (site_name, site_href, site_category, device_type, created_at) FROM STDIN;"
-  ${MYSQL} "SELECT
-    site_name,
-    site_href,
-    COALESCE(site_category, 'unknown'),
-    COALESCE(device_type,   'unknown'),
-    DATE_FORMAT(created_at, '%Y-%m-%d %H:%i:%s+00')
-  FROM apm_site_clicks ORDER BY id;"
-  echo "\\."
-} | ${PSQL}
-echo "  done."
+existing=$(docker exec daloa-postgres psql -U "${DB_USER}" -d "${DB_NAME}" -tAc "SELECT COUNT(*) FROM apm_site_clicks;")
+if [ "$existing" -gt 0 ]; then
+  echo "  already has ${existing} rows, skipping."
+else
+  {
+    echo "COPY apm_site_clicks (site_name, site_href, site_category, device_type, created_at) FROM STDIN ${COPY_OPT};"
+    ${MYSQL} "SELECT
+      site_name,
+      site_href,
+      COALESCE(site_category, 'unknown'),
+      COALESCE(device_type,   'unknown'),
+      DATE_FORMAT(created_at, '%Y-%m-%d %H:%i:%s+00')
+    FROM apm_site_clicks ORDER BY id;"
+    echo "\\."
+  } | ${PSQL}
+  echo "  done."
+fi
 
 # ── 2. apm_youtube_clicks ───────────────────────────
 echo "[2/5] apm_youtube_clicks..."
-{
-  echo "COPY apm_youtube_clicks (video_id, video_title, channel_title, device_type, created_at) FROM STDIN;"
-  ${MYSQL} "SELECT
-    video_id,
-    COALESCE(video_title,    ''),
-    COALESCE(channel_title,  ''),
-    COALESCE(device_type,    'unknown'),
-    DATE_FORMAT(created_at, '%Y-%m-%d %H:%i:%s+00')
-  FROM apm_youtube_clicks ORDER BY id;"
-  echo "\\."
-} | ${PSQL}
-echo "  done."
+existing=$(docker exec daloa-postgres psql -U "${DB_USER}" -d "${DB_NAME}" -tAc "SELECT COUNT(*) FROM apm_youtube_clicks;")
+if [ "$existing" -gt 0 ]; then
+  echo "  already has ${existing} rows, skipping."
+else
+  {
+    echo "COPY apm_youtube_clicks (video_id, video_title, channel_title, device_type, created_at) FROM STDIN ${COPY_OPT};"
+    ${MYSQL} "SELECT
+      video_id,
+      COALESCE(video_title,    ''),
+      COALESCE(channel_title,  ''),
+      COALESCE(device_type,    'unknown'),
+      DATE_FORMAT(created_at, '%Y-%m-%d %H:%i:%s+00')
+    FROM apm_youtube_clicks ORDER BY id;"
+    echo "\\."
+  } | ${PSQL}
+  echo "  done."
+fi
 
 # ── 3. apm_request_timings ──────────────────────────
 echo "[3/5] apm_request_timings..."
 {
-  echo "COPY apm_request_timings (scope, name, path, method, status_code, duration_ms, created_at) FROM STDIN;"
+  echo "COPY apm_request_timings (scope, name, path, method, status_code, duration_ms, created_at) FROM STDIN ${COPY_OPT};"
   ${MYSQL} "SELECT
     scope,
     name,
@@ -80,7 +92,7 @@ echo "[4/5] apm_page_visits (conflict → merge visits)..."
     os_name      VARCHAR(64),
     browser_name VARCHAR(64)
   );"
-  echo "COPY tmp_page_visits (path, device_type, user_agent, referrer, visits, last_seen_at, created_at, country_code, os_name, browser_name) FROM STDIN;"
+  echo "COPY tmp_page_visits (path, device_type, user_agent, referrer, visits, last_seen_at, created_at, country_code, os_name, browser_name) FROM STDIN ${COPY_OPT};"
   ${MYSQL} "SELECT
     path,
     COALESCE(device_type,    'unknown'),
@@ -118,7 +130,7 @@ echo "  done."
 # ── 5. monitoring_api_probes ────────────────────────
 echo "[5/5] monitoring_api_probes..."
 {
-  echo "COPY monitoring_api_probes (api_key, path, method, cache_type, status_code, duration_ms, is_success, created_at) FROM STDIN;"
+  echo "COPY monitoring_api_probes (api_key, path, method, cache_type, status_code, duration_ms, is_success, created_at) FROM STDIN ${COPY_OPT};"
   ${MYSQL} "SELECT
     api_key,
     path,
@@ -138,11 +150,11 @@ echo ""
 echo "===== Row counts after migration ====="
 docker exec daloa-postgres psql -U "${DB_USER}" -d "${DB_NAME}" -c "
 SELECT tbl, rows FROM (
-  SELECT 'apm_site_clicks'      AS tbl, COUNT(*) AS rows FROM apm_site_clicks      UNION ALL
-  SELECT 'apm_youtube_clicks'   AS tbl, COUNT(*) AS rows FROM apm_youtube_clicks    UNION ALL
-  SELECT 'apm_request_timings'  AS tbl, COUNT(*) AS rows FROM apm_request_timings   UNION ALL
-  SELECT 'apm_page_visits'      AS tbl, COUNT(*) AS rows FROM apm_page_visits       UNION ALL
-  SELECT 'monitoring_api_probes'AS tbl, COUNT(*) AS rows FROM monitoring_api_probes
+  SELECT 'apm_site_clicks'       AS tbl, COUNT(*) AS rows FROM apm_site_clicks      UNION ALL
+  SELECT 'apm_youtube_clicks'    AS tbl, COUNT(*) AS rows FROM apm_youtube_clicks    UNION ALL
+  SELECT 'apm_request_timings'   AS tbl, COUNT(*) AS rows FROM apm_request_timings   UNION ALL
+  SELECT 'apm_page_visits'       AS tbl, COUNT(*) AS rows FROM apm_page_visits       UNION ALL
+  SELECT 'monitoring_api_probes' AS tbl, COUNT(*) AS rows FROM monitoring_api_probes
 ) t ORDER BY tbl;
 "
 


### PR DESCRIPTION
## 문제
MySQL batch 모드(`-N -B`)는 NULL 값을 `\N`이 아닌 문자열 `"NULL"`로 출력합니다.
PostgreSQL COPY는 기본적으로 `\N`만 NULL로 인식하므로 정수형 컬럼에서 오류 발생:
```
ERROR: invalid input syntax for type integer: "NULL"
CONTEXT: COPY apm_request_timings, line 3, column status_code: "NULL"
```

## 수정
모든 `COPY ... FROM STDIN` 구문에 `WITH (FORMAT text, NULL 'NULL')` 옵션 추가.
MySQL이 출력한 `"NULL"` 문자열을 PostgreSQL이 NULL로 인식하도록 처리.

재실행 안전성을 위해 site_clicks, youtube_clicks는 기존 데이터가 있으면 건너뜀.

🤖 Generated with [Claude Code](https://claude.com/claude-code)