### PR TITLE
fix: migrate-apm-data 워크플로우 git reset --hard 추가

### DIFF
--- a/.github/workflows/migrate-apm-data.yml
+++ b/.github/workflows/migrate-apm-data.yml
@@ -34,6 +34,7 @@ jobs:
         run: |
           remote_script="set -e
           cd /home/ubuntu/daloa
+          git reset --hard HEAD
           git pull origin main
           chmod +x scripts/migrate-apm-data.sh
           bash scripts/migrate-apm-data.sh"


### PR DESCRIPTION
## 문제
EC2에 `scripts/migrate-apm-data.sh`가 로컬 수정 상태로 남아 `git pull`이 중단됨:
```
error: Your local changes to the following files would be overwritten by merge:
	scripts/migrate-apm-data.sh
```

## 수정
`git pull origin main` 전에 `git reset --hard HEAD` 추가.

🤖 Generated with [Claude Code](https://claude.com/claude-code)