### PR TITLE
fix: Vercel ignoreCommand shallow clone 오류 수정

### DIFF
--- a/client/vercel.json
+++ b/client/vercel.json
@@ -1,3 +1,3 @@
 {
-  "ignoreCommand": "git diff --quiet ${VERCEL_GIT_PREVIOUS_SHA:-HEAD~1} HEAD -- ."
+  "ignoreCommand": "git diff --quiet ${VERCEL_GIT_PREVIOUS_SHA:-HEAD~1} HEAD -- . || exit 1"
 }


### PR DESCRIPTION
## 문제
`VERCEL_GIT_PREVIOUS_SHA`가 Vercel의 shallow clone에 없으면 `git diff`가 exit 128로 실패, 빌드 자체가 실패함:
```
fatal: bad object 4a716f37d1279c3dc597851f6c6b7d2ffeb71654
Command failed with exit code 128
```

## 수정
`|| exit 1` 추가 — git diff 실패 시(exit 128) exit 1로 처리하여 빌드를 실행하도록 함.
- exit 0 (변경 없음) → 빌드 스킵 ✓
- exit 1 (변경 있음) → 빌드 실행 ✓  
- exit 128 (bad object) → exit 1로 변환 → 빌드 실행 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)