### PR TITLE
fix: SSR telemetry 403 오류 수정 - x-telemetry-token 헤더 추가

### DIFF
--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -11,9 +11,13 @@ async function recordServerTiming(input: {
   path: string;
   durationMs: number;
 }) {
+  const telemetryToken = process.env.TELEMETRY_INGEST_TOKEN;
   await fetch(`${API}/api/telemetry/request`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      ...(telemetryToken ? { "x-telemetry-token": telemetryToken } : {}),
+    },
     body: JSON.stringify({
       type: "request",
       scope: "section",


### PR DESCRIPTION
## Summary
- SSR 환경에서 `/api/telemetry/request` 호출 시 `Origin`/`Referer` 헤더가 없어 403 (`telemetry origin missing`) 오류 발생
- `TELEMETRY_INGEST_TOKEN` 환경변수를 `x-telemetry-token` 헤더로 함께 전송하도록 수정

## Test plan
- [x] EC2 서버 `.env`에 `TELEMETRY_INGEST_TOKEN=<value>` 추가
- [x] Vercel 환경변수에 동일한 `TELEMETRY_INGEST_TOKEN=<value>` 추가
- [x] 배포 후 `/api/telemetry/request` 403 오류 미발생 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)