### PR TITLE
docs: README 및 context 문서 전면 업데이트

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,13 @@
 
 - Docker
 - TypeScript: 타입 안정성으로 런타임 에러 사전 방지
-- Next.js: SSR
-- NestJS: 개발 편의성
-- MariaDB: 개발 편의성
+- Next.js: SSR (Vercel 배포)
+- NestJS: 백엔드 API 서버
+- PostgreSQL: 주 데이터베이스
+- Prisma 7: ORM (driver adapter 방식)
 - Redis: 캐시로 속도 개선
-- Nginx: 라우팅
-- Vercel: 무료 비용
-- AWS EC2 + Nginx
-- Git Action
+- Nginx: 리버스 프록시
+- AWS EC2 + GitHub Actions: 서버 배포 자동화
 
 ## 개선한 점들
 

--- a/client/README.md
+++ b/client/README.md
@@ -15,8 +15,11 @@ npm run dev   # http://localhost:3000
 `.env.local` 설정:
 
 ```env
-NEST_API_URL=http://localhost:3001            # SSR 서버 측 fetch
-NEXT_PUBLIC_NEST_API_URL=http://localhost:3001 # 클라이언트 컴포넌트 fetch
+NEST_API_URL=http://localhost:3001       # SSR 서버 측 fetch (NEXT_PUBLIC_ 불필요)
+REVALIDATE_SECRET=...                    # ISR 무효화 시크릿 (서버 NEXT_REVALIDATE_SECRET과 동일)
+TELEMETRY_INGEST_TOKEN=...              # SSR 텔레메트리 인증 토큰 (서버와 동일값)
+NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX          # Google Analytics ID (선택)
+SYNC_TARGET_API_URL=https://api.daloa.kr # DB 동기화 대상 API URL (로컬 개발 시 선택)
 ```
 
 ---
@@ -26,51 +29,60 @@ NEXT_PUBLIC_NEST_API_URL=http://localhost:3001 # 클라이언트 컴포넌트 fe
 ```
 client/
 ├── app/
-│   ├── layout.tsx          # RootLayout, 폰트, 메타데이터
-│   ├── page.tsx            # 메인 페이지 (SSR)
-│   └── globals.css         # Tailwind + fade-in 애니메이션
+│   ├── layout.tsx              # RootLayout, 폰트, 메타데이터
+│   ├── page.tsx                # 메인 페이지 (SSR)
+│   ├── sitemap.ts              # SEO 사이트맵
+│   ├── robots.ts               # robots.txt
+│   ├── globals.css
+│   └── admin/                  # 관리자 페이지
+│       ├── sync/               # DB 동기화
+│       ├── monitoring/         # 모니터링 대시보드
+│       ├── characters/         # 캐릭터 관리
+│       └── sites/              # 사이트 관리
+│
+├── app/api/                    # Next.js API Route (NestJS 프록시)
+│   ├── admin/                  # 관리자 API 라우트
+│   └── telemetry/              # 텔레메트리 수집
 │
 ├── components/
 │   ├── characters/
 │   │   └── StatBuildList.tsx   # 특성 빌드 분포 (탭 + 바 차트)
+│   ├── class-summary/
+│   │   └── ClassSummaryList.tsx # 직업 AI 한줄평
 │   ├── sites/
 │   │   └── SiteList.tsx        # 사이트 카드 그리드
-│   └── streamers/
-│       └── StreamerList.tsx    # 유튜브 라이브 목록 (무한 스크롤)
+│   ├── streamers/
+│   │   └── StreamerList.tsx    # 유튜브 라이브 목록
+│   └── youtube/
+│       └── YoutubeList.tsx     # 유튜브 인기 영상
+│
+├── lib/
+│   ├── gtag.ts                 # GA4 헬퍼
+│   └── admin-role.ts           # 관리자 역할 훅
 │
 ├── types/
-│   └── index.ts            # 공유 타입 정의
+│   └── index.ts                # 공유 타입 정의
 │
-├── public/
-│   └── favicon.ico
-│
-├── next.config.ts          # Google favicon remotePatterns 허용
-├── .env.local              # 환경 변수
-└── AGENTS.md               # 코파일럿 에이전트 규칙
+├── proxy.ts                    # Next.js 미들웨어 (API 라우팅)
+├── next.config.ts
+├── vercel.json                 # Vercel ignoreCommand 설정
+└── AGENTS.md                   # 코파일럿 에이전트 규칙
 ```
 
 ---
 
 ## 데이터 흐름
 
-| 컴포넌트       | 방식                              | 엔드포인트                        |
-| -------------- | --------------------------------- | --------------------------------- |
-| `page.tsx`     | SSR (`fetch` + `revalidate: 300`) | `GET /api/sites`                  |
-| `page.tsx`     | SSR (`fetch` + `revalidate: 300`) | `GET /api/characters/stat-builds` |
-| `StreamerList` | 클라이언트 fetch (무한 스크롤)    | `GET /api/streamers?page=&size=`  |
+| 컴포넌트           | 방식                              | 엔드포인트                        |
+| ------------------ | --------------------------------- | --------------------------------- |
+| `page.tsx`         | SSR (`fetch` + `revalidate`)      | `GET /api/sites`                  |
+| `page.tsx`         | SSR (`fetch` + `revalidate`)      | `GET /api/characters/stat-builds` |
+| `StreamerList`     | 클라이언트 fetch (무한 스크롤)    | `GET /api/streamers?pageToken=`   |
+| `YoutubeList`      | 클라이언트 fetch                  | `GET /api/streamers/popular`      |
+| `ClassSummaryList` | 클라이언트 fetch                  | `GET /api/class-summary`          |
 
-모든 API 요청은 NestJS 서버(port 3001)로 직접 전달됩니다.
-
----
-
-## 타입
-
-| 타입            | 용도                             |
-| --------------- | -------------------------------- |
-| `Site`          | 사이트 카드 데이터               |
-| `Streamer`      | 유튜브 라이브 스트리머 단건      |
-| `StatBuildItem` | 특성 빌드 항목 (직업명 + 인원수) |
-| `StatBuildTab`  | 특성 빌드 탭 (치신/신치/치특 등) |
+모든 API 요청은 Next.js API Route → NestJS(port 3001)로 프록시됩니다.  
+브라우저에서 NestJS를 직접 호출하는 코드 없음.
 
 ---
 
@@ -86,32 +98,11 @@ client/
 
 ---
 
-## 테스트 가이드 (요약)
-
-Vitest + Testing Library 기준으로 아래 체크리스트를 기본 적용합니다.
-
-### 실행
+## 테스트
 
 ```bash
 cd client
 npm test
 ```
 
-### 품질 체크리스트
-
-- 테스트 이름과 assertion은 1:1로 대응합니다.
-	- 예: "로딩 메시지 표시" 테스트면 실제 로딩 텍스트를 검증합니다.
-- 인덱스 기반 선택(`getAllByRole(...)[1]`)을 지양하고 이름/레이블 기반 선택을 사용합니다.
-	- 예: `getByRole('button', { name: /다음/i })`
-- 예외 경로 테스트는 실제 런타임 호출 경로를 spy/mock 합니다.
-	- 예: `window.localStorage`를 교체한 테스트에서는 `Storage.prototype`이 아니라 교체 객체를 spy 합니다.
-- React `key` 동작은 DOM 속성 조회로 검증하지 않습니다.
-	- 노드 재생성 여부(참조 변경)와 결과 상태(`scrollTop` 등)로 검증합니다.
-- 목 데이터는 타입 계약을 지킵니다.
-	- 필수 필드(`topLevel`, `updatedAt` 등) 누락 금지
-
-### 권장 패턴
-
-- 사용자 인터랙션은 `userEvent`를 사용합니다.
-- 비동기 렌더링/상태 변경은 `waitFor` 또는 `findBy...`로 안정적으로 기다립니다.
-- `IntersectionObserver`/`ResizeObserver`/`window.open` 같은 브라우저 API는 `vitest.setup.ts`에서 공통 mock을 사용합니다.
+Vitest + Testing Library 기반.

--- a/context/INDEX.md
+++ b/context/INDEX.md
@@ -10,7 +10,7 @@
 | 파일                                         | 내용                                             | 언제 읽는가                              |
 | -------------------------------------------- | ------------------------------------------------ | ---------------------------------------- |
 | [architecture.md](./architecture.md)         | 전체 시스템 구조, 컴포넌트 역할, 포트, 배포 흐름 | 새 기능 추가 / 모듈 간 연결 작업 시      |
-| [db-schema.md](./db-schema.md)               | MariaDB 테이블 스키마 전체                       | 쿼리 작성 / 스키마 변경 시               |
+| [db-schema.md](./db-schema.md)               | PostgreSQL 테이블 스키마 전체                    | 쿼리 작성 / 스키마 변경 시               |
 | [api-contracts.md](./api-contracts.md)       | 서버 REST API 엔드포인트 목록, 요청·응답 형태    | 클라이언트 fetch / 서버 컨트롤러 수정 시 |
 | [env-config.md](./env-config.md)             | 환경변수 목록과 기본값, 필수 여부                | .env 설정 / 새 환경변수 추가 시          |
 | [redis-keys.md](./redis-keys.md)             | Redis 키 네임스페이스, TTL, 캐시 무효화 시점     | Redis 관련 서비스 수정 / 캐시 디버깅 시  |
@@ -53,12 +53,12 @@ cd server && npm run test:e2e  # E2E (docker-compose up -d 선행)
 
 ### 주요 포트
 
-| 서비스  | 포트 |
-| ------- | ---- |
-| Next.js | 3000 |
-| NestJS  | 3001 |
-| MariaDB | 3306 |
-| Redis   | 6379 |
+| 서비스     | 포트 |
+| ---------- | ---- |
+| Next.js    | 3000 |
+| NestJS     | 3001 |
+| PostgreSQL | 5432 |
+| Redis      | 6379 |
 
 ### EC2 SSH 접속
 

--- a/context/architecture.md
+++ b/context/architecture.md
@@ -6,18 +6,15 @@
 [사용자 브라우저]
       │
       ▼
-[Nginx (80/443)]  ← EC2 프로덕션
-      │
-      ├── api.daloa.kr → [NestJS :3001]  ←─┐
-      └── daloa.kr     → [Next.js :3000] ──┘
-                                            │ SSR fetch
-                                            ▼
-                                       [NestJS :3001]
-                                            │
-                               ┌────────────┼────────────┐
-                               ▼            ▼            ▼
-                          [MariaDB]     [Redis]    [외부 API]
-                          (lost_ark)   (:6379)    (LostArk / YouTube / Kakao)
+[Vercel (daloa.kr)]     [Nginx (api.daloa.kr, EC2 80/443)]
+      │                          │
+      │ SSR fetch                ▼
+      └──────────────→  [NestJS :3001]
+                                 │
+                    ┌────────────┼────────────┐
+                    ▼            ▼            ▼
+              [PostgreSQL]   [Redis]    [외부 API]
+               (Docker)      (Docker)  (LostArk / YouTube / Gemini / Kakao)
 ```
 
 **로컬 개발**은 Nginx 없이 Next.js(3000) → NestJS(3001) 직접 통신.
@@ -26,36 +23,33 @@
 
 ## 컴포넌트별 역할
 
-### `client/` — Next.js 15 App Router (포트 3000)
+### `client/` — Next.js 15 App Router (Vercel 배포)
 
 - **SSR 전용** — 브라우저에서 NestJS를 직접 호출하지 않음
-- `app/page.tsx`: `Promise.all`로 3개 API 동시 fetch → 한 번에 렌더링
-- `app/sitemap.ts`: SEO용 sitemap.xml 자동 생성
-- `instrumentation.ts`: 서버 시작 시 console 가로채기 → `logs/` 기록
-- 컴포넌트는 `"use client"` 지시자 있는 것만 클라이언트 번들 포함
+- `app/page.tsx`: 메인 페이지, SSR fetch → 사이트 목록·특성빌드·유튜브 렌더링
+- `app/admin/`: 관리자 페이지 (sync, monitoring, characters, sites)
+- `proxy.ts`: Next.js 미들웨어, 관리자 세션 쿠키 검증
+- `vercel.json`: `ignoreCommand`로 변경 없는 브랜치 빌드 스킵
 
-### `server/` — NestJS (포트 3001)
+### `server/` — NestJS (포트 3001, Docker → EC2 배포)
 
-- **글로벌 Provider**: `DbModule`(DB_POOL), `RedisModule`(REDIS_CLIENT), `ConfigModule`
+- **글로벌 Provider**: `PrismaModule`(PostgreSQL), `RedisModule`(REDIS_CLIENT), `ConfigModule`
 - **비즈니스 모듈**: `SitesModule`, `CharactersModule`, `StreamersModule`, `ClassSummaryModule`, `UsersModule`, `LostarkModule`, `KakaoModule`
-- **크론**: `SitesService`(매일 09:00 사이트 점검), `StreamersService`(매시 YouTube 갱신)
+- **관리자 모듈**: `AdminModule` — auth/sync/monitoring/cache/sites/characters
+- **크론**: `SitesService`(매일 09:00 사이트 점검), `StreamersService`(3시간마다 YouTube 갱신)
 - **에러 필터**: `AllExceptionsFilter` — 5xx 발생 시 카카오 알림, 1분 쿨다운
-- **로거**: 
-  - `FileLoggerService` — 서버 애플리케이션 로그를 `logs/app-YYYY-MM-DD.log`, `logs/error-YYYY-MM-DD.log`에 기록 (일별 로테이션)
-  - 개발 시작 스크립트: `scripts/dev.ps1` — 서버/클라이언트 dev 서버의 콘솔 stdout+stderr를 각 `logs/app-YYYY-MM-DD.log`에 append
-  - **로그 정리**: `scripts/cleanup-logs.ps1` — 기본값 30일 이상 경과한 로그 자동 삭제 (dev.ps1에서 시작 시 자동 실행)
+- **로거**: `FileLoggerService` — `logs/app-YYYY-MM-DD.log`, `logs/error-YYYY-MM-DD.log` (일별 로테이션)
 
 ### `crawlers/` — Python (curl_cffi + asyncio)
 
-- `crawl_rank.py`: loawa.com 전투력 순위 → LostArk API → MariaDB 저장
+- `crawl_rank.py`: loawa.com 전투력 순위 → LostArk API → PostgreSQL 저장
 - **파이프라인**: Producer → name_queue → Checker(×30) → search_queue → Searcher
-- **Rate Limiter**: NestJS `LostarkService` 내부 직렬 큐, 분당 80회 제한(한도 100의 80%)
-- 실행 로그: `crawlers/logs/crawl-YYYY-MM-DD_HH-MM-SS.log` (cleanup-logs.ps1 대상)
+- **Rate Limiter**: NestJS `LostarkService` 내부 직렬 큐, 분당 80회 제한
 
 ### `nginx/` — 리버스 프록시 (프로덕션)
 
 - HTTP(80) → HTTPS(301) 리다이렉트
-- `api.daloa.kr` → NestJS, `daloa.kr` → Next.js
+- `api.daloa.kr` → NestJS
 - SSL: Let's Encrypt (`/etc/letsencrypt/`)
 
 ---
@@ -68,7 +62,7 @@
 브라우저 → Next.js SSR
            → GET /api/sites (NestJS)
                → Redis 체크 (sites:all, TTL 10분)
-               → 캐시 미스 시 MariaDB 조회
+               → 캐시 미스 시 PostgreSQL 조회
                → Redis 저장 후 반환
 ```
 
@@ -78,16 +72,19 @@
 GET /api/streamers?pageToken=xxx
   → Redis 체크 (youtube:videos:page:N)
   → 캐시 미스 → YouTube Data API v3
-  → quota_exceeded 키 존재 시 API 차단(자동 재개: KST 16:00)
+  → quota_exceeded 키 존재 시 API 차단 (자동 재개: KST 16:00)
   → Redis TTL 1시간
 ```
 
-### 크롤러 → DB 저장 흐름
+### DB 동기화 (admin-sync)
 
 ```
-loawa.com API → character_name 수집
-  → GET /api/users/exists/:name → 신규만 필터
-  → POST /api/users/search → LostArk API → DB upsert
+관리자 → local → production 선택
+  → 원격 관리자 인증 (sessionId 발급)
+  → SSE 스트림 시작
+  → FK 의존 테이블 선처리 (loa_class, loa_ark_grid)
+  → 대상 테이블 TRUNCATE → chunk 단위 INSERT
+  → 진행률 실시간 스트림
 ```
 
 ---
@@ -98,23 +95,27 @@ loawa.com API → character_name 수집
 AppModule
 ├── ConfigModule (global)
 ├── ScheduleModule
-├── DbModule (global) ──────────── DB_POOL 제공
-├── RedisModule (global) ────────── REDIS_CLIENT 제공
-├── KakaoModule (global) ────────── KakaoService 제공
-├── SitesModule       ← DB_POOL, REDIS_CLIENT, KakaoService
-├── CharactersModule  ← DB_POOL
+├── PrismaModule (global) ────── PrismaService 제공
+├── RedisModule (global) ─────── REDIS_CLIENT 제공
+├── KakaoModule (global) ─────── KakaoService 제공
+├── SitesModule       ← PrismaService, REDIS_CLIENT, KakaoService
+├── CharactersModule  ← PrismaService
 ├── StreamersModule   ← REDIS_CLIENT, ConfigService
-├── ClassSummaryModule← DB_POOL, REDIS_CLIENT, ConfigService(Gemini AI)
-├── UsersModule       ← DB_POOL, LostarkService
+├── ClassSummaryModule← PrismaService, REDIS_CLIENT, ConfigService (Gemini AI)
+├── UsersModule       ← PrismaService, LostarkService
 ├── LostarkModule     ← ConfigService
-└── KakaoModule       ← ConfigService
+├── AdminModule       ← PrismaService, REDIS_CLIENT, ConfigService
+└── RevalidateService (standalone)
 ```
 
 ---
 
 ## 배포 환경 (EC2)
 
-- `docker-compose.yml`: `nest`(NestJS), `nginx` 컨테이너
-- Next.js는 EC2에서 `pm2`로 직접 실행 (컨테이너 외부)
-- MariaDB는 EC2 호스트에 직접 설치 (컨테이너 미사용)
-- Redis는 EC2 호스트에 직접 설치
+- `docker-compose.yml`: `nest`(NestJS), `postgres`(PostgreSQL), `redis`, `nginx` 컨테이너
+- Next.js는 Vercel에서 호스팅 (EC2 미사용)
+- **자동 배포**: `main` 브랜치 push → GitHub Actions (`main-post-merge.yml`) → AWS SSM으로 EC2 명령 실행
+  1. `git reset --hard HEAD && git pull origin main`
+  2. `cd server && npm run build`
+  3. `docker compose up -d --build nest`
+  4. `docker restart daloa-nginx`

--- a/context/db-schema.md
+++ b/context/db-schema.md
@@ -1,10 +1,10 @@
 # DB 스키마
 
-**DB 이름**: `lost_ark`  
-**DB 엔진**: MariaDB 10.6  
-**Charset**: `utf8mb4`, `utf8mb4_general_ci`
+**DB 엔진**: PostgreSQL 16  
+**ORM**: Prisma 7 (`@prisma/adapter-pg` driver adapter)  
+**스키마 파일**: `server/prisma/schema.prisma`
 
-> 변경 시 `docs/기획.md`와 이 파일을 동시에 업데이트한다.
+> 변경 시 이 파일도 동시에 업데이트한다.
 
 ---
 
@@ -36,9 +36,9 @@
 
 ```sql
 -- 각인명 있을 때
-SELECT idx FROM loa_class WHERE class_detail = ? AND class_engraving = ? LIMIT 1;
+SELECT idx FROM loa_class WHERE class_detail = $1 AND class_engraving = $2 LIMIT 1;
 -- fallback: 직업명만
-SELECT idx FROM loa_class WHERE class_detail = ? LIMIT 1;
+SELECT idx FROM loa_class WHERE class_detail = $1 LIMIT 1;
 ```
 
 ---

--- a/context/deployment.md
+++ b/context/deployment.md
@@ -1,367 +1,145 @@
-﻿# 諛고룷 諛⑸쾿
+# 배포 절차
 
 ---
 
-## 1. ?쒕쾭 (EC2 諛고룷)
+## 1. 서버 배포 (EC2 — 자동)
 
-### ?ъ쟾 議곌굔
+### 자동 배포 조건
 
-- AWS EC2 ?몄뒪?댁뒪 (Ubuntu)
-- Docker + Docker Compose ?ㅼ튂??
-- SSH ???뚯씪: `daloa-key.pem` (寃쎈줈: `C:\Users\tjdtn\Desktop\?닿??앷컖?섎뒗誘몃옒\媛쒕컻\濡쒖븘?ъ씠??紐⑥쓬\daloa-key.pem`)
-- EC2 IP: `3.39.239.9`
-- Let's Encrypt SSL ?몄쬆??諛쒓툒 ?꾨즺 (`api.daloa.kr`)
+`main` 브랜치에 `server/**` 또는 `client/**` 변경이 push되면  
+GitHub Actions (`main-post-merge.yml`)가 자동으로 EC2에 배포합니다.
 
-### 1-1. SSH ?묒냽
+**배포 순서:**
 
-```powershell
-ssh -i "C:\\Users\\tjdtn\\Desktop\\내가생각하는미래\\개발\\로아사이트 모음\\daloa-key.pem" ubuntu@3.39.239.9
-```
+1. GitHub Actions → AWS SSM으로 EC2에 명령 전송
+2. `git reset --hard HEAD && git pull origin main`
+3. `cd server && npm run build`
+4. `docker compose up -d --build nest`
+5. `docker restart daloa-nginx`
 
-### 1-2. 肄붾뱶 ?낅뜲?댄듃 + 鍮뚮뱶 + ?ъ떆??
+### 수동 배포 (GitHub Actions)
+
+GitHub → Actions → `Main Post Merge` → `Run workflow` → `main` 선택
+
+### 수동 배포 (SSH 직접)
 
 ```bash
-# EC2 ?쒕쾭 ?덉뿉???ㅽ뻾
+ssh -i "C:\Users\tjdtn\Desktop\ingit\daloa\daloa-key.pem" ubuntu@3.39.239.9
+
+# EC2 접속 후
 cd daloa
-
-# 理쒖떊 肄붾뱶 媛?몄삤湲?
-git pull
-
-# NestJS 鍮뚮뱶 (EC2?먯꽌 吏곸젒 ??Docker ??硫붾え由??덉빟)
-cd server
-npm run build
-
-# Docker 而⑦뀒?대꼫 ?щ퉴??+ ?ъ떆??(--build ?꾩닔 ???놁쑝硫??댁쟾 ?대?吏 ?ъ궗??
-cd ..
+git pull origin main
+cd server && npm run build && cd ..
 docker compose up -d --build nest
+docker restart daloa-nginx
 ```
 
-### 1-3. ?먯빱留⑤뱶 諛고룷 (濡쒖뺄?먯꽌)
-
-```powershell
-ssh -i "C:\\Users\\tjdtn\\Desktop\\내가생각하는미래\\개발\\로아사이트 모음\\daloa-key.pem" -o StrictHostKeyChecking=no ubuntu@3.39.239.9 "cd daloa && git pull && cd server && npm run build 2>&1 | tail -3 && cd .. && docker compose up -d --build nest 2>&1 | tail -3"
-```
-
-### 1-4. ?꾩껜 ?쒕퉬???ъ떆??(MySQL, Redis, Nginx ?ы븿)
+### EC2 환경변수 (.env) 설정
 
 ```bash
-# EC2 ?덉뿉??(mysql, nginx??production profile)
-cd daloa
-docker compose --profile production down
-docker compose --profile production up -d
+# EC2 접속 후 직접 편집
+nano /home/ubuntu/daloa/server/.env
+
+# 변경 후 컨테이너 재시작 (--build 없이도 env 반영됨)
+cd /home/ubuntu/daloa && docker compose restart nest
 ```
 
-### 1-6. EC2 ?섍꼍蹂??.env) ?섏젙
-
-> ?좑툘 Docker??`/home/ubuntu/daloa/.env`瑜??쎌쓬. `server/.env`??濡쒖뺄 媛쒕컻?⑹씠硫?EC2 Docker???쎌? ?딅뒗??
+### 로그 확인
 
 ```bash
-# EC2 ?묒냽 ??吏곸젒 ?몄쭛
-nano /home/ubuntu/daloa/.env
-
-# ?섏젙 ??nest 而⑦뀒?대꼫 ?ъ떆??(--build ?꾩닔)
-cd daloa && docker compose up -d --build nest
-```
-
-濡쒖뺄?먯꽌 SCP濡???뼱??寃쎌슦 **諛섎뱶??`/home/ubuntu/daloa/.env`** 寃쎈줈濡??꾩넚:
-
-```powershell
-# ?? EC2 ?꾩슜 ??鍮꾨?踰덊샇媛 ?ы븿??EC2 .env瑜?濡쒖뺄?먯꽌 ??뼱?곗? ?딅룄濡?二쇱쓽
-scp -i "C:\\Users\\tjdtn\\Desktop\\내가생각하는미래\\개발\\로아사이트 모음\\daloa-key.pem" .env ubuntu@3.39.239.9:/home/ubuntu/daloa/.env
-```
-
-### 1-5. 濡쒓렇 ?뺤씤
-
-```bash
-# NestJS 而⑦뀒?대꼫 濡쒓렇
 docker logs daloa-nest --tail 50
-
-# Nginx 濡쒓렇
 docker logs daloa-nginx --tail 50
-
-# Redis 濡쒓렇
 docker logs daloa-redis --tail 50
+docker logs daloa-postgres --tail 50
 ```
 
 ---
 
-## 2. ?대씪?댁뼵??(Vercel 諛고룷)
+## 2. 클라이언트 배포 (Vercel — 자동)
 
-### ?ъ쟾 議곌굔
+`main` 브랜치에 push하면 Vercel이 자동으로 빌드 + 배포합니다.
 
-- Vercel 怨꾩젙??GitHub 由ы룷吏?좊━ ?곌껐??
-- Root Directory: `client` ?ㅼ젙
-- Framework Preset: `Next.js`
+### Vercel 환경변수
 
-### 2-1. ?먮룞 諛고룷
+Vercel 프로젝트 Settings → Environment Variables:
 
-**`main` 釉뚮옖移섏뿉 push?섎㈃ Vercel???먮룞?쇰줈 鍮뚮뱶 + 諛고룷?쒕떎.**
+| 변수명                    | 환경        | 값                      |
+| ------------------------- | ----------- | ----------------------- |
+| `NEST_API_URL`            | All         | `https://api.daloa.kr`  |
+| `REVALIDATE_SECRET`       | All         | (서버와 동일값)          |
+| `TELEMETRY_INGEST_TOKEN`  | All         | (서버와 동일값)          |
+| `NEXT_PUBLIC_GA_ID`       | Production  | `G-XXXXXXXXXX`          |
+| `SYNC_TARGET_API_URL`     | All         | `https://api.daloa.kr`  |
 
-```powershell
-git add .
-git commit -m "蹂寃??댁슜"
+### ISR 캐시 강제 무효화
+
+```bash
+# Vercel 캐시 무효화 없이 강제 재빌드
+git commit --allow-empty -m "chore: 캐시 무효화"
 git push origin main
 ```
 
-??Vercel ??쒕낫?쒖뿉??鍮뚮뱶 吏꾪뻾 ?곹깭 ?뺤씤 媛??
-
-### 2-2. Vercel ?섍꼍蹂??
-
-Vercel ?꾨줈?앺듃 Settings ??Environment Variables???ㅼ젙:
-
-| 蹂?섎챸                    | ?섍꼍      | 媛?                    |
-| -------------------------- | ---------- | ---------------------- |
-| `NEST_API_URL`             | All        | `https://api.daloa.kr` |
-| `NEXT_PUBLIC_NEST_API_URL` | Production | `https://api.daloa.kr` |
-
-- `NEST_API_URL` ??SSR fetch ???쒕쾭?먯꽌 ?ъ슜 (`page.tsx`??`process.env.NEST_API_URL`)
-- `NEXT_PUBLIC_NEST_API_URL` ???대씪?댁뼵??而댄룷?뚰듃?먯꽌 ?ъ슜
-
-### 2-3. ?꾨━酉?諛고룷
-
-- `main` ?댁쇅 釉뚮옖移섏뿉 push?섎㈃ ?꾨━酉?URL???먮룞 ?앹꽦??
-- PR?먯꽌 ?꾨━酉??뺤씤 ??癒몄?
-
 ---
 
-## 3. ?щ·??(EC2 ?섎룞 ?ㅽ뻾)
+## 3. 크롤러 (EC2 수동 실행)
 
 ```bash
-# EC2 ?덉뿉??
+# EC2 접속 후
 cd daloa/crawlers
 python3 crawl_rank.py
 ```
 
-- 濡쒓렇??`crawlers/logs/crawl-YYYY-MM-DD_HH-MM-SS.log`?????
-- ?щ줎?≪쑝濡??먮룞?뷀븯?ㅻ㈃:
+- 로그: `crawlers/logs/crawl-YYYY-MM-DD_HH-MM-SS.log`
+- 자동 실행 (cron):
   ```bash
-  # 留ㅼ씪 04:00 KST ?ㅽ뻾 (UTC 19:00)
+  # 매일 04:00 KST (UTC 19:00)
   crontab -e
   0 19 * * * cd /home/ubuntu/daloa/crawlers && python3 crawl_rank.py >> /dev/null 2>&1
   ```
 
 ---
 
-## 4. ?꾨찓??(媛鍮꾩븘 DNS)
+## 4. DNS (가비아)
 
-| ?꾨찓??        | ???   | 媛?                    | ?⑸룄                 |
+| 도메인         | 타입  | 값                     | 용도                  |
 | -------------- | ----- | ---------------------- | -------------------- |
-| `daloa.kr`     | CNAME | `cname.vercel-dns.com` | ?대씪?댁뼵??(Vercel) |
-| `api.daloa.kr` | A     | `3.39.239.9`           | ?쒕쾭 API (EC2)      |
-
-### ?꾨찓??蹂寃???
-
-1. 媛鍮꾩븘 DNS 愿由????덉퐫???섏젙
-2. EC2 IP媛 諛붾뚮㈃ `api.daloa.kr` A ?덉퐫???낅뜲?댄듃
-3. Vercel ?꾨찓???ㅼ젙?먯꽌 `daloa.kr` ?뺤씤
+| `daloa.kr`     | CNAME | `cname.vercel-dns.com` | 클라이언트 (Vercel)  |
+| `api.daloa.kr` | A     | `3.39.239.9`           | 서버 API (EC2)       |
 
 ---
 
-## 5. SSL ?몄쬆??(Let's Encrypt)
+## 5. SSL 인증서 (Let's Encrypt)
 
 ```bash
-# EC2 ?덉뿉????理쒖큹 諛쒓툒
+# EC2에서 최초 발급
 sudo certbot certonly --standalone -d api.daloa.kr
 
-# ?먮룞 媛깆떊 ?뺤씤
+# 자동 갱신 확인
 sudo certbot renew --dry-run
 ```
 
-- ?몄쬆??寃쎈줈: `/etc/letsencrypt/live/api.daloa.kr/`
-- Nginx 而⑦뀒?대꼫媛 ?대떦 寃쎈줈瑜??쎄린 ?꾩슜 留덉슫??
-- 媛깆떊 ??Nginx ?ъ떆?? `docker restart daloa-nginx`
+- 인증서 경로: `/etc/letsencrypt/live/api.daloa.kr/`
+- Nginx 컨테이너가 해당 경로를 마운트해서 사용
+- 갱신 후 Nginx 재시작: `docker restart daloa-nginx`
 
 ---
 
-## 6. DB 愿由?
-
-### ?쒓? 源⑥쭚 諛⑹? (utf8mb4)
-
-???곌껐(NestJS `db.module.ts`)? ?대? `charset: utf8mb4`濡??ㅼ젙?섏뼱 ?덈떎.  
-?쒓???源⑥????먯씤? **諛고룷/?섎룞 SQL ?ㅽ뻾 ?몄뀡**?먯꽌 ?몄퐫?⑹씠 鍮좎???寃쎌슦?대떎.
-
-**?꾩닔 ?섏튃:**
-
-1. **MySQL 而⑦뀒?대꼫** ???쒕쾭 湲곕낯媛?+ ?몄뀡 紐⑤몢 utf8mb4 媛뺤젣  
-   (`docker-compose.yml`??`command` ?먮뒗 `my.cnf`?먯꽌 ?ㅼ젙)
-2. **?섎룞 SQL ?ㅽ뻾** ????긽 `--default-character-set=utf8mb4` ?듭뀡 ?ъ슜
-3. **PowerShell?먯꽌 ?쒓? SQL 吏곸젒 ?낅젰** ??`chcp 65001` (UTF-8 肄섏넄) ?ㅼ젙 ???ㅽ뻾?섍굅?? UTF-8濡???λ맂 `.sql` ?뚯씪濡??ㅽ뻾
-
-#### EC2 ?몄퐫???먭? 荑쇰━
-
-MySQL 而⑦뀒?대꼫???묒냽:
-
-```bash
-docker exec -it daloa-mysql mysql -udaloa -p1234 --default-character-set=utf8mb4 lost_ark
-```
-
-?묒냽 ???꾨옒 荑쇰━?ㅼ쓣 ?쒖꽌?濡??ㅽ뻾:
-
-```sql
--- 1) ?쒕쾭 湲곕낯媛??뺤씤 (?꾨? utf8mb4?ъ빞 ?뺤긽)
-SHOW VARIABLES LIKE 'character_set_%';
-SHOW VARIABLES LIKE 'collation_%';
-
--- 2) ?꾩옱 ?몄뀡 ?몄퐫???뺤씤
-SELECT @@character_set_client, @@character_set_connection, @@character_set_results;
-
--- 3) ?뚯씠釉붾퀎 charset/collation ?뺤씤
-SELECT TABLE_NAME, TABLE_COLLATION
-  FROM information_schema.TABLES
- WHERE TABLE_SCHEMA = 'lost_ark';
-
--- 4) 而щ읆蹂?charset ?뺤씤 (臾몄젣 ?덈뒗 而щ읆 李얘린)
-SELECT TABLE_NAME, COLUMN_NAME, CHARACTER_SET_NAME, COLLATION_NAME
-  FROM information_schema.COLUMNS
- WHERE TABLE_SCHEMA = 'lost_ark'
-   AND CHARACTER_SET_NAME IS NOT NULL
-   AND CHARACTER_SET_NAME != 'utf8mb4';
-```
-
-#### 源⑥쭊 ???먯? 荑쇰━
-
-?쒓? 而щ읆??`?` ?먮뒗 鍮꾩젙??諛붿씠?멸? ?ㅼ뼱媛??됱쓣 ?먯?:
-
-```sql
--- loa_users: 罹먮┃?곕챸/?쒕쾭紐?湲몃뱶紐?源⑥쭚
-SELECT name, server_name, guild
-  FROM loa_users
- WHERE name REGEXP '[?]{2,}'
-    OR name != CONVERT(CONVERT(name USING utf8mb4) USING binary)
- LIMIT 20;
-
--- loa_sites: ?ъ씠?몃챸/?ㅻ챸 源⑥쭚
-SELECT name, description
-  FROM loa_sites
- WHERE name REGEXP '[?]{2,}'
-    OR description REGEXP '[?]{2,}'
- LIMIT 20;
-
--- loa_class: 吏곸뾽紐?媛곸씤紐?源⑥쭚
-SELECT class_detail, class_engraving
-  FROM loa_class
- WHERE class_detail REGEXP '[?]{2,}'
-    OR class_engraving REGEXP '[?]{2,}'
- LIMIT 20;
-
--- loa_class_summaries: AI ?쒖쨪??源⑥쭚
-SELECT class_name, summary
-  FROM loa_class_summaries
- WHERE summary REGEXP '[?]{2,}'
- LIMIT 20;
-```
-
-#### ?덉쟾???ъ쟻??紐낅졊 ?쒖꽌
-
-源⑥쭊 ?곗씠?곌? 諛쒓껄?섎㈃ ?꾨옒 ?쒖꽌濡?蹂듦뎄:
-
-```bash
-# 1) NestJS 而⑦뀒?대꼫 以묒? (?곌린 諛⑹?)
-docker compose stop nest
-
-# 2) 源⑥쭊 ?뚯씠釉?鍮꾩슦湲?(?먮뒗 ?뱀젙 ?됰쭔 DELETE)
-docker exec -i daloa-mysql mysql -udaloa -p1234 \
-  --default-character-set=utf8mb4 lost_ark \
-  -e "TRUNCATE TABLE loa_users;"
-
-# 3) 源⑤걮???ㅽ봽 ?뚯씪 ?곸옱 (諛섎뱶??utf8mb4)
-docker exec -i daloa-mysql mysql -udaloa -p1234 \
-  --default-character-set=utf8mb4 lost_ark < /home/ubuntu/daloa/scripts/dump.sql
-
-# 4) ?곸옱 ??源⑥쭚 ?ы솗??
-docker exec -i daloa-mysql mysql -udaloa -p1234 \
-  --default-character-set=utf8mb4 lost_ark \
-  -e "SELECT name, server_name FROM loa_users WHERE name REGEXP '[?]{2,}' LIMIT 5;"
-
-# 5) Redis 罹먯떆 ?꾩껜 ??젣 (???곗씠???쒓굅)
-docker exec daloa-redis redis-cli -a $REDIS_PASSWORD FLUSHALL
-
-# 6) NestJS 而⑦뀒?대꼫 ?ъ떆??
-docker compose up -d --build nest
-
-# 7) API濡??뺤긽 ?묐떟 ?뺤씤
-curl -s https://api.daloa.kr/api/sites | head -c 200
-```
-
-> **二쇱쓽:** `dump.sql` ?뚯씪 ?먯껜媛 UTF-8(BOM ?놁쓬)濡???λ릺???덉뼱???쒕떎.  
-> 濡쒖뺄?먯꽌 `node scripts/dump-db.js` ?ㅽ뻾 ??Node.js??湲곕낯 UTF-8濡?異쒕젰?섎?濡?蹂꾨룄 ?ㅼ젙 遺덊븘??
-
-### ?ㅽ궎留?珥덇린??
-
-```bash
-# EC2 ?덉뿉????MySQL 而⑦뀒?대꼫 理쒖큹 湲곕룞 ???먮룞 ?ㅽ뻾
-# scripts/init-db.sql ??docker-entrypoint-initdb.d/01-schema.sql
-# scripts/dump.sql    ??docker-entrypoint-initdb.d/02-data.sql
-```
-
-### ?섎룞 ?ㅽ봽 (濡쒖뺄 ??EC2)
-
-```bash
-# 濡쒖뺄?먯꽌 ?ㅽ봽 ?앹꽦
-node scripts/dump-db.js
-
-# EC2濡??꾩넚
-scp -i "daloa-key.pem" scripts/dump.sql ubuntu@3.39.239.9:~/daloa/scripts/
-```
-
-### DB ?곗씠???섎룞 ?섏젙 (SQL ?뚯씪 ?ㅽ뻾)
-
-> ?좑툘 mysql ?ㅽ뻾 ??諛섎뱶??`--default-character-set=utf8mb4` ?듭뀡??遺숈뿬???쒓???源⑥?吏 ?딅뒗??
+## 6. EC2 SSH 접속
 
 ```powershell
-# 1. 濡쒖뺄?먯꽌 SQL ?뚯씪 ?묒꽦 ??EC2濡??꾩넚
-scp -i "C:\\Users\\tjdtn\\Desktop\\내가생각하는미래\\개발\\로아사이트 모음\\daloa-key.pem" fix.sql ubuntu@3.39.239.9:/tmp/fix.sql
-
-# 2. EC2 MySQL 而⑦뀒?대꼫?먯꽌 ?ㅽ뻾
-ssh -i "C:\\Users\\tjdtn\\Desktop\\내가생각하는미래\\개발\\로아사이트 모음\\daloa-key.pem" -o StrictHostKeyChecking=no ubuntu@3.39.239.9 \
-  "docker exec -i daloa-mysql mysql -udaloa -p1234 --default-character-set=utf8mb4 lost_ark < /tmp/fix.sql"
-
-# 3. 愿??Redis 罹먯떆 ??젣 (?? sites)
-ssh -i "C:\\Users\\tjdtn\\Desktop\\내가생각하는미래\\개발\\로아사이트 모음\\daloa-key.pem" -o StrictHostKeyChecking=no ubuntu@3.39.239.9 \
-  "docker exec daloa-redis redis-cli -a Redis9999! DEL sites:all"
+ssh -i "C:\Users\tjdtn\Desktop\ingit\daloa\daloa-key.pem" ubuntu@3.39.239.9
 ```
+
+- PEM 키 위치: 프로젝트 루트 `daloa-key.pem`
+- EC2 IP: `3.39.239.9`
 
 ---
 
-## 7. 鍮좊Ⅸ 李몄“ ??諛고룷 泥댄겕由ъ뒪??
+## 7. DB 동기화 (관리자 페이지)
 
-> **諛고룷 ?ㅽ겕由쏀듃瑜??ъ슜?섎㈃ 罹먯떆 ??젣瑜??먮룞?쇰줈 泥섎━?쒕떎.**
+관리자 페이지(`/admin/sync`)에서 `local → production` 방향으로 동기화.
 
-### ?쒕쾭留?蹂寃쏀뻽????
-
-```powershell
-# ?ㅽ겕由쏀듃 ?ъ슜 (沅뚯옣 ??dist/ ??젣 ?ы븿)
-powershell -File scripts/deploy.ps1
-
-# Redis 罹먯떆???좊━?ㅻ㈃
-powershell -File scripts/deploy.ps1 -FlushRedis
-```
-
-### ?대씪?댁뼵?몃쭔 蹂寃쏀뻽????
-
-```powershell
-git push origin main
-# ??Vercel ?먮룞 諛고룷 (.next 罹먯떆??Vercel??愿由?
-```
-
-### ????蹂寃쏀뻽????
-
-```powershell
-# 1) push (Vercel ?먮룞 諛고룷)
-git push origin main
-
-# 2) EC2 ?쒕쾭 諛고룷 (罹먯떆 ??젣 ?ы븿)
-powershell -File scripts/deploy.ps1
-```
-
-### ?꾩껜 ?쒕퉬???ъ떆??(MySQL/Redis/Nginx ?ы븿)
-
-```powershell
-powershell -File scripts/deploy.ps1 -Full
-```
-
-### Vercel???쏅궇 ?곗씠?곕? 蹂댁뿬以???(罹먯떆 媛뺤젣 媛깆떊)
-
-```powershell
-git commit --allow-empty -m "chore: ?щ같??; git push origin main
-```
+- 로컬에서 실행 시 `local → production`만 허용
+- 프로덕션에서 실행 시 `production → local`만 허용
+- 동기화 전 원격 관리자 인증(오너 계정) 필요
+- FK 의존 테이블(`loa_class`, `loa_ark_grid`) 자동 선처리

--- a/context/env-config.md
+++ b/context/env-config.md
@@ -1,6 +1,6 @@
 # 환경변수 설정
 
-**위치**: 프로젝트 루트 `.env` (`.gitignore`에 포함 — 커밋 금지)
+**위치**: `server/.env` (`.gitignore`에 포함 — 커밋 금지)
 
 ---
 
@@ -10,14 +10,12 @@
 | -------------------------- | ----------------------- | -------- | ------------------------------------------- |
 | `PORT`                     | `3001`                  | -        | NestJS 리스닝 포트                          |
 | `CLIENT_ORIGIN`            | `http://localhost:3000` | -        | CORS 허용 출처 (쉼표 구분 복수 허용)        |
-| `DB_HOST`                  | `127.0.0.1`             | -        | MariaDB 호스트                              |
-| `DB_PORT`                  | `3306`                  | -        | MariaDB 포트                                |
-| `DB_NAME`                  | `lost_ark`              | -        | DB 이름                                     |
-| `DB_USER`                  | `root`                  | -        | DB 유저                                     |
-| `DB_PASS`                  | `''`                    | **필수** | DB 비밀번호                                 |
+| `DATABASE_URL`             | -                       | **필수** | PostgreSQL 연결 문자열 (`postgresql://user:pass@host:5432/db`) |
+| `PRISMA_DB_SCHEMA`         | `public`                | -        | Prisma 스키마 이름                          |
+| `BODY_LIMIT`               | (없음)                  | -        | HTTP 요청 바디 최대 크기                    |
 | `REDIS_HOST`               | `127.0.0.1`             | -        | Redis 호스트                                |
 | `REDIS_PORT`               | `6379`                  | -        | Redis 포트                                  |
-| `REDIS_PASSWORD`           | (없음)                  | -        | Redis 비밀번호 (없으면 미설정)              |
+| `REDIS_PASSWORD`           | (없음)                  | -        | Redis 비밀번호                              |
 | `REDIS_DB`                 | `0`                     | -        | Redis DB 번호                               |
 | `YOUTUBE_REDIS_HOST`       | (없음)                  | -        | YouTube 캐시 전용 Redis 호스트              |
 | `YOUTUBE_REDIS_PORT`       | `6379`                  | -        | YouTube 캐시 전용 Redis 포트                |
@@ -28,11 +26,19 @@
 | `LOSTARK_API_KEY`          | -                       | **필수** | LostArk Open API 키                         |
 | `YOUTUBE_API_KEY`          | -                       | **필수** | YouTube Data API v3 키 (첫 번째 키)         |
 | `YOUTUBE_API_KEY_2`        | -                       | -        | YouTube API 추가 키 (`_3`, `_4` ... 형식으로 계속 추가 가능) |
-| `GEMINI_API_KEY`           | -                       | **필수** | Google Gemini API 키                        |
+| `GEMINI_API_KEY`           | -                       | **필수** | Google Gemini API 키 (직업 한줄평 생성)     |
 | `KAKAO_REST_API_KEY`       | -                       | **필수** | 카카오 REST API 키                          |
+| `KAKAO_CLIENT_SECRET`      | -                       | -        | 카카오 클라이언트 시크릿                    |
 | `KAKAO_REFRESH_TOKEN`      | -                       | **필수** | 카카오 OAuth 리프레시 토큰                  |
-| `NEXT_REVALIDATE_URL`      | (없음)                  | -        | Vercel ISR 무효화 엔드포인트 URL (`https://www.daloa.kr/api/revalidate`) |
-| `NEXT_REVALIDATE_SECRET`   | (없음)                  | -        | Vercel ISR 무효화 시크릿 (Vercel `REVALIDATE_SECRET`과 동일값) |
+| `KAKAO_REFRESH_TOKEN_ISSUED_AT` | (없음)             | -        | 카카오 토큰 발급 시각 (자동 갱신 추적용)    |
+| `ADMIN_OWNER_PASSWORD`     | -                       | **필수** | 관리자 오너 계정 비밀번호                   |
+| `ADMIN_DEMO_PASSWORD`      | -                       | -        | 게스트 데모 계정 비밀번호                   |
+| `SYNC_TARGET_API_URL`      | -                       | -        | DB 동기화 대상 서버 URL (예: `https://api.daloa.kr`) |
+| `TELEMETRY_INGEST_TOKEN`   | (없음)                  | -        | 텔레메트리 수집 인증 토큰 (미설정 시 Origin/Referer 검증) |
+| `MONITORING_PROBE_BASE_URL`| (없음)                  | -        | 모니터링 헬스체크 프로브 대상 URL           |
+| `NEXT_REVALIDATE_URL`      | (없음)                  | -        | Vercel ISR 무효화 엔드포인트 URL            |
+| `NEXT_REVALIDATE_SECRET`   | (없음)                  | -        | Vercel ISR 무효화 시크릿 (클라이언트 `REVALIDATE_SECRET`과 동일값) |
+| `NODE_ENV`                 | `development`           | -        | 환경 구분 (`production` 시 일부 동작 변경)  |
 
 ### CORS 설정 주의
 
@@ -43,10 +49,13 @@
 
 ## 클라이언트 (Next.js)
 
-| 변수명         | 기본값                  | 필수 | 설명                      |
-| -------------- | ----------------------- | ---- | ------------------------- |
-| `NEST_API_URL`        | `http://localhost:3001` | -        | SSR fetch 대상 NestJS URL |
-| `REVALIDATE_SECRET`   | (없음)                  | **필수** | ISR 캐시 무효화 인증 시크릿 (NestJS `NEXT_REVALIDATE_SECRET`과 동일값) |
+| 변수명                        | 기본값                  | 필수     | 설명                                        |
+| ----------------------------- | ----------------------- | -------- | ------------------------------------------- |
+| `NEST_API_URL`                | `http://localhost:3001` | -        | SSR fetch 대상 NestJS URL                   |
+| `REVALIDATE_SECRET`           | (없음)                  | **필수** | ISR 캐시 무효화 인증 시크릿 (서버 `NEXT_REVALIDATE_SECRET`과 동일값) |
+| `TELEMETRY_INGEST_TOKEN`      | (없음)                  | -        | SSR 텔레메트리 인증 토큰 (서버 `TELEMETRY_INGEST_TOKEN`과 동일값) |
+| `SYNC_TARGET_API_URL`         | `https://api.daloa.kr`  | -        | DB 동기화 check 엔드포인트 대상 URL         |
+| `NEXT_PUBLIC_GA_ID`           | (없음)                  | -        | Google Analytics 측정 ID                    |
 
 > Next.js에서 서버 전용 변수는 `NEXT_PUBLIC_` 접두사 없이 사용.  
 > 브라우저에서 NestJS를 직접 호출하는 코드 없음.
@@ -56,15 +65,15 @@
 ## 로컬 개발 `.env` 예시
 
 ```dotenv
-# DB
-DB_PASS=1234
+# PostgreSQL
+DATABASE_URL=postgresql://daloa:1234@localhost:5432/daloa
 
 # Redis (로컬은 패스워드 없음)
 REDIS_HOST=127.0.0.1
 
 # 로컬에서 유튜브만 운영 Redis 읽기
-YOUTUBE_REDIS_HOST=ec2-redis-host
-YOUTUBE_REDIS_PORT=6379
+YOUTUBE_REDIS_HOST=127.0.0.1
+YOUTUBE_REDIS_PORT=6380
 YOUTUBE_REDIS_PASSWORD=your-redis-password
 YOUTUBE_REDIS_DB=0
 YOUTUBE_REDIS_READONLY=true
@@ -83,6 +92,9 @@ KAKAO_REFRESH_TOKEN=xyz456...
 
 # CORS
 CLIENT_ORIGIN=http://localhost:3000
+
+# 관리자
+ADMIN_OWNER_PASSWORD=mypassword
 ```
 
 ---

--- a/context/folder-structure.md
+++ b/context/folder-structure.md
@@ -7,18 +7,16 @@ daloa/
 ├── .env                          # 환경변수 (Git 미포함)
 ├── .gitignore
 ├── AGENTS.md                     # 에이전트 공통 규칙
-├── docker-compose.yml            # 프로덕션 + 공용 서비스 정의
-├── docker-compose.override.yml   # 로컬 개발 전용 오버라이드 (Git 미포함)
+├── docker-compose.yml            # 프로덕션 서비스 정의 (nest, postgres, redis, nginx)
 │
 ├── .github/
-│   ├── copilot-instructions.md   # Copilot 워크스페이스 지침
 │   ├── pull_request_template.md  # PR 템플릿
 │   ├── BRANCH_PROTECTION_CHECKLIST.md
 │   ├── SETUP_GUIDE.md
 │   └── workflows/
-│       ├── pr-check.yml          # PR 빌드·테스트 CI (main 직접 푸시 방어)
+│       ├── pr-check.yml          # PR 빌드·테스트 CI
 │       ├── pr-ci.yml             # PR 추가 CI
-│       ├── main-post-merge.yml   # main 머지 후 배포 트리거
+│       ├── main-post-merge.yml   # main 머지 후 EC2 자동 배포
 │       └── server-e2e.yml        # E2E 테스트
 │
 ├── client/                       # ── Next.js 15 App Router (Vercel 배포) ──
@@ -26,27 +24,45 @@ daloa/
 │   ├── package.json
 │   ├── next.config.ts
 │   ├── tsconfig.json
-│   ├── vitest.config.ts          # Vitest 테스트 설정
+│   ├── vercel.json               # ignoreCommand (변경 없을 때 빌드 스킵)
+│   ├── vitest.config.ts
 │   ├── vitest.setup.ts
-│   ├── instrumentation.ts        # 서버 부팅 시 로그 가로채기
+│   ├── proxy.ts                  # Next.js 미들웨어 (관리자 세션 검증)
 │   ├── app/
 │   │   ├── layout.tsx            # 루트 레이아웃
-│   │   ├── page.tsx              # 메인 페이지 (SSR, cache: 'no-store')
+│   │   ├── page.tsx              # 메인 페이지 (SSR)
 │   │   ├── sitemap.ts            # SEO 사이트맵
 │   │   ├── robots.ts             # robots.txt 생성
 │   │   ├── globals.css
 │   │   ├── favicon.ico
-│   │   └── icon.png
+│   │   ├── icon.png
+│   │   ├── admin/                # 관리자 페이지
+│   │   │   ├── layout.tsx
+│   │   │   ├── page.tsx          # 관리자 대시보드
+│   │   │   ├── sync/page.tsx     # DB 동기화 (SSE)
+│   │   │   ├── monitoring/page.tsx # 모니터링 대시보드
+│   │   │   ├── characters/page.tsx # 캐릭터 목록
+│   │   │   └── sites/page.tsx    # 사이트 CRUD
+│   │   └── api/                  # Next.js API Route (NestJS 프록시)
+│   │       ├── admin/
+│   │       │   ├── auth/         # 로그인·로그아웃
+│   │       │   ├── sync/         # DB 동기화 + check
+│   │       │   ├── monitoring/   # 모니터링 API
+│   │       │   ├── characters/   # 캐릭터 API
+│   │       │   ├── sites/        # 사이트 CRUD API
+│   │       │   └── cache/        # Redis 캐시 삭제
+│   │       ├── revalidate/       # ISR 캐시 무효화
+│   │       └── telemetry/        # 텔레메트리 수집
 │   ├── components/
-│   │   ├── GoogleAnalytics.tsx   # GA4 태그 삽입
+│   │   ├── GoogleAnalytics.tsx
 │   │   ├── characters/
-│   │   │   ├── StatBuildList.tsx  # 특성 빌드 통계
+│   │   │   ├── StatBuildList.tsx
 │   │   │   └── StatBuildList.test.tsx
 │   │   ├── class-summary/
 │   │   │   ├── ClassSummaryList.tsx
 │   │   │   └── ClassSummaryList.test.tsx
 │   │   ├── sites/
-│   │   │   ├── SiteList.tsx      # 사이트 목록
+│   │   │   ├── SiteList.tsx
 │   │   │   └── SiteList.test.tsx
 │   │   ├── streamers/
 │   │   │   ├── StreamerList.tsx
@@ -55,7 +71,8 @@ daloa/
 │   │       ├── YoutubeList.tsx
 │   │       └── YoutubeList.test.tsx
 │   ├── lib/
-│   │   └── gtag.ts               # GA4 헬퍼 함수
+│   │   ├── gtag.ts               # GA4 헬퍼 함수
+│   │   └── admin-role.ts         # 관리자 역할 훅
 │   ├── types/
 │   │   └── index.ts              # 공용 타입 정의
 │   ├── public/                   # 정적 에셋
@@ -67,74 +84,99 @@ daloa/
 │   ├── package.json
 │   ├── tsconfig.json
 │   ├── nest-cli.json
+│   ├── prisma/
+│   │   └── schema.prisma         # Prisma 스키마 정의
+│   ├── prisma.config.ts          # Prisma CLI 설정 (DATABASE_URL 주입)
+│   ├── generated/
+│   │   └── prisma/               # Prisma 생성 클라이언트 (Git 포함)
 │   ├── src/
 │   │   ├── main.ts               # 엔트리포인트 (포트 3001)
 │   │   ├── app.module.ts         # 루트 모듈
+│   │   ├── prisma/               # PrismaService (PrismaPg adapter)
+│   │   │   ├── prisma.module.ts
+│   │   │   └── prisma.service.ts
+│   │   ├── redis/
+│   │   │   └── redis.module.ts   # Redis 커넥션 (ioredis)
+│   │   ├── admin/                # 관리자 API (/api/admin/*)
+│   │   │   ├── admin.module.ts
+│   │   │   ├── admin.guard.ts    # AdminGuard, AdminWriteGuard
+│   │   │   ├── admin-auth.controller.ts
+│   │   │   ├── admin-auth.service.ts
+│   │   │   ├── admin-cache.controller.ts
+│   │   │   ├── admin-characters.controller.ts
+│   │   │   ├── admin-monitoring.controller.ts
+│   │   │   ├── admin-monitoring.middleware.ts
+│   │   │   ├── admin-monitoring.service.ts
+│   │   │   ├── admin-sites.controller.ts
+│   │   │   ├── admin-sync.controller.ts
+│   │   │   └── repositories/
+│   │   │       ├── admin-auth.repository.ts
+│   │   │       ├── admin-characters.repository.ts
+│   │   │       ├── admin-sync.repository.ts
+│   │   │       └── monitoring.repository.ts
 │   │   ├── characters/           # 특성 빌드 API
 │   │   │   ├── characters.module.ts
 │   │   │   ├── characters.controller.ts
+│   │   │   ├── characters.repository.ts
 │   │   │   ├── characters.service.ts
 │   │   │   └── characters.service.spec.ts
-│   │   ├── class-summary/        # 직업 요약 API
+│   │   ├── class-summary/        # 직업 요약 API (Gemini AI)
 │   │   │   ├── class-summary.module.ts
 │   │   │   ├── class-summary.controller.ts
+│   │   │   ├── class-summary.repository.ts
 │   │   │   ├── class-summary.service.ts
 │   │   │   └── class-summary.service.spec.ts
 │   │   ├── lostark/              # LostArk Open API 프록시 + Rate Limiter
 │   │   │   ├── lostark.module.ts
 │   │   │   ├── lostark.controller.ts
 │   │   │   └── lostark.service.ts
-│   │   ├── sites/                # 사이트 목록 API (Redis 캐시 + 한글 깨짐 복구)
+│   │   ├── sites/                # 사이트 목록 API (Redis 캐시 + 매일 점검)
 │   │   │   ├── sites.module.ts
 │   │   │   ├── sites.controller.ts
+│   │   │   ├── sites.repository.ts
 │   │   │   ├── sites.service.ts
 │   │   │   └── sites.service.spec.ts
-│   │   ├── streamers/            # 스트리머 API
+│   │   ├── streamers/            # 스트리머 API (YouTube, 3시간 갱신)
 │   │   │   ├── streamers.module.ts
 │   │   │   ├── streamers.controller.ts
+│   │   │   ├── streamers.repository.ts
 │   │   │   ├── streamers.service.ts
 │   │   │   └── streamers.service.spec.ts
 │   │   ├── users/                # 유저(원정대) API
 │   │   │   ├── users.module.ts
 │   │   │   ├── users.controller.ts
+│   │   │   ├── users.repository.ts
 │   │   │   └── users.service.ts
-│   │   ├── kakao/                # 카카오 링크 API
+│   │   ├── kakao/                # 카카오 알림 서비스
 │   │   │   ├── kakao.module.ts
 │   │   │   └── kakao.service.ts
-│   │   ├── db/
-│   │   │   └── db.module.ts      # MariaDB 커넥션 풀 (mysql2)
-│   │   ├── redis/
-│   │   │   └── redis.module.ts   # Redis 커넥션 (ioredis)
+│   │   ├── revalidate/
+│   │   │   └── revalidate.service.ts # Vercel ISR 캐시 무효화
 │   │   └── common/
 │   │       ├── http-exception.filter.ts
-│   │       ├── file-logger.service.ts  # 파일 로거 (일별 로테이션, 30일 자동 정리)
+│   │       ├── file-logger.service.ts  # 파일 로거 (일별 로테이션)
 │   │       └── local-dev-flags.ts      # 로컬 개발 전용 플래그
 │   ├── test/
 │   │   ├── jest-e2e.json
 │   │   ├── jest-integration.json
-│   │   ├── app.e2e-spec.ts       # E2E 테스트
-│   │   └── korean-encoding.integration-spec.ts  # 한글 인코딩 통합 테스트
+│   │   ├── app.e2e-spec.ts
+│   │   └── korean-encoding.integration-spec.ts
 │   └── logs/                     # 런타임 로그 (Git 미포함)
 │
 ├── crawlers/                     # ── Python 크롤러 (EC2에서 수동 실행) ──
 │   ├── crawl_rank.py             # loawa.com → LostArk API → DB 파이프라인
-│   ├── requirements.txt          # curl_cffi, aiomysql 등
+│   ├── requirements.txt
 │   └── logs/                     # 크롤러 로그 (Git 미포함)
 │
 ├── nginx/
 │   └── default.conf              # api.daloa.kr → NestJS 리버스 프록시
 │
 ├── scripts/
-│   ├── dev.ps1                   # 로컬 개발 환경 시작 (포트 정리 + 재시작)
-│   ├── test.ps1                  # 전체 테스트 실행
-│   ├── deploy.ps1                # EC2 배포 스크립트
-│   ├── cleanup-logs.ps1          # 30일 이상 로그 자동 삭제 (dev.ps1 시작 시 자동 실행)
-│   ├── init-db.sql               # DB 스키마 초기화
-│   ├── sync-sites.sql            # 사이트 목록 DB 동기화 (desired_sites CTE)
-│   ├── dump.sql                  # DB 데이터 덤프 (Git 미포함)
-│   ├── dump-db.js                # 덤프 스크립트
-│   ├── seed_expedition.mjs       # 원정대 시드 데이터
-│   └── seed_sites.mjs            # 사이트 시드 데이터
+│   ├── dev.ps1                   # 로컬 개발 환경 시작
+│   ├── cleanup-logs.ps1          # 30일 이상 로그 자동 삭제
+│   ├── init-db.sql               # DB 스키마 초기화 (PostgreSQL)
+│   ├── dump-db.js                # DB 덤프 스크립트
+│   └── migrate-mysql-to-postgres.sh # MySQL → PostgreSQL 마이그레이션 (완료)
 │
 ├── context/                      # ── AI 컨텍스트 문서 ──
 │   ├── INDEX.md                  # 목차
@@ -147,11 +189,8 @@ daloa/
 │   └── deployment.md             # EC2·Vercel·DNS·SSL 배포 절차
 │
 └── docs/                         # ── 개발 문서 ──
-    ├── HARNESS.md                # 테스트·워크플로우 규칙 전체
-    ├── record.md                 # 개발 문제/해결 기록
-    ├── 기획.md                   # 기능 기획 문서
-    └── technicalRead/            # 기술 학습 노트
-        └── ES6문제.md            # CJS vs ESM, NestJS와의 충돌 원리
+    ├── project-structure.md
+    └── INDEX.md
 ```
 
 ---
@@ -168,17 +207,14 @@ daloa/
 │  Vercel          │          │  AWS EC2 (Ubuntu)                  │
 │  ┌─────────────┐ │          │  ┌──────────────────────────────┐  │
 │  │ Next.js SSR │ │          │  │ Docker Compose               │  │
-│  │ (client/)   │ │          │  │  ┌────────┐  ┌─────────────┐ │  │
-│  └─────────────┘ │          │  │  │ Nginx  │→│ NestJS:3001 │ │  │
-└─────────────────┘          │  │  │ :80/443│  └──────┬──────┘ │  │
-                              │  │  └────────┘         │        │  │
-                              │  │  ┌────────┐  ┌──────┴──────┐ │  │
-                              │  │  │ Redis  │  │ MySQL 8.0   │ │  │
-                              │  │  │ :6379  │  │ :3306       │ │  │
-                              │  │  └────────┘  └─────────────┘ │  │
-                              │  └──────────────────────────────┘  │
-                              │  ┌──────────────────────────────┐  │
-                              │  │ Python 크롤러 (수동 실행)     │  │
+│  │ (client/)   │─┼──────────┼─▶│  ┌────────┐  ┌───────────┐  │  │
+│  └─────────────┘ │  SSR     │  │  │ Nginx  │→ │NestJS:3001│  │  │
+└─────────────────┘  fetch   │  │  │:80/443 │  └─────┬─────┘  │  │
+                              │  │  └────────┘        │        │  │
+                              │  │  ┌────────┐  ┌─────┴──────┐ │  │
+                              │  │  │ Redis  │  │ PostgreSQL │ │  │
+                              │  │  │ :6379  │  │ :5432      │ │  │
+                              │  │  └────────┘  └────────────┘ │  │
                               │  └──────────────────────────────┘  │
                               └────────────────────────────────────┘
                                         │
@@ -193,19 +229,10 @@ daloa/
 
 ## 포트 정리
 
-| 서비스  | 로컬 포트 | EC2 포트    | 비고                              |
-| ------- | --------- | ----------- | --------------------------------- |
-| Next.js | 3000      | —           | Vercel에서 호스팅                 |
-| NestJS  | 3001      | 3001 (내부) | Nginx가 443 → 3001 프록시         |
-| Nginx   | —         | 80, 443     | SSL 종단점, HTTP→HTTPS 리다이렉트 |
-| MySQL   | 3306      | 3306 (내부) | Docker 내부 네트워크 전용         |
-| Redis   | 6379      | 6379 (내부) | Docker 내부 네트워크 전용         |
-
----
-
-## Docker Compose 프로파일
-
-| 파일                          | 대상 환경    | 실행 서비스                    |
-| ----------------------------- | ------------ | ------------------------------ |
-| `docker-compose.yml`          | EC2 프로덕션 | mysql, redis, nest, nginx      |
-| `docker-compose.override.yml` | 로컬 개발    | redis, nest (MySQL/Nginx 제외) |
+| 서비스     | 로컬 포트 | EC2 포트    | 비고                              |
+| ---------- | --------- | ----------- | --------------------------------- |
+| Next.js    | 3000      | —           | Vercel에서 호스팅                 |
+| NestJS     | 3001      | 3001 (내부) | Nginx가 443 → 3001 프록시         |
+| Nginx      | —         | 80, 443     | SSL 종단점, HTTP→HTTPS 리다이렉트 |
+| PostgreSQL | 5432      | 5432 (내부) | Docker 내부 네트워크 전용         |
+| Redis      | 6379      | 6379 (내부) | Docker 내부 네트워크 전용         |

--- a/server/README.md
+++ b/server/README.md
@@ -1,6 +1,6 @@
 # Server (NestJS)
 
-로스트아크 대시보드 백엔드. NestJS + MySQL + Redis + YouTube Data API + 로스트아크 공식 API.
+로스트아크 대시보드 백엔드. NestJS + PostgreSQL (Prisma 7) + Redis + YouTube Data API + 로스트아크 공식 API.
 
 ---
 
@@ -18,12 +18,9 @@ npm run start:dev  # http://localhost:3001
 PORT=3001
 CLIENT_ORIGIN=http://localhost:3000
 
-# MySQL
-DB_HOST=127.0.0.1
-DB_PORT=3306
-DB_NAME=lost_ark
-DB_USER=root
-DB_PASS=1234
+# PostgreSQL (Prisma)
+DATABASE_URL=postgresql://user:password@localhost:5432/daloa
+PRISMA_DB_SCHEMA=public  # 선택, 기본값 public
 
 # 로스트아크 공식 API
 LOSTARK_API_KEY=...
@@ -32,22 +29,40 @@ LOSTARK_API_KEY=...
 YOUTUBE_API_KEY=...
 YOUTUBE_API_KEY_2=...   # 추가 키 (선택, _3/_4 형식으로 계속 추가 가능)
 
-# YouTube 전용 Redis (로컈 개발: EC2 운영 Redis SSH 터널 연결)
+# Redis
+REDIS_HOST=127.0.0.1
+REDIS_PORT=6379
+REDIS_PASSWORD=...
+REDIS_DB=0
+
+# YouTube 전용 Redis (로컬 개발: EC2 운영 Redis SSH 터널 연결)
 # YOUTUBE_REDIS_HOST=127.0.0.1
 # YOUTUBE_REDIS_PORT=6380
 # YOUTUBE_REDIS_PASSWORD=...
 # YOUTUBE_REDIS_DB=0
-# YOUTUBE_REDIS_READONLY=true  # 로컈에서 갱신 안 함
+# YOUTUBE_REDIS_READONLY=true  # 로컬에서 갱신 안 함
 
-# Redis
-REDIS_HOST=127.0.0.1
-REDIS_PORT=6379
-REDIS_DB=0
+# Gemini AI (직업 한줄평 생성)
+GEMINI_API_KEY=...
 
-# 카카오 알림 (사이트 변경 감지)
+# 카카오 알림 (사이트 변경 감지, 에러 알림)
 KAKAO_REST_API_KEY=...
 KAKAO_CLIENT_SECRET=...
 KAKAO_REFRESH_TOKEN=...
+
+# 관리자
+ADMIN_OWNER_PASSWORD=...   # 오너 계정 비밀번호
+ADMIN_DEMO_PASSWORD=...    # 게스트 데모 계정 비밀번호 (선택)
+
+# DB 동기화 (sync 기능)
+SYNC_TARGET_API_URL=https://api.daloa.kr  # 동기화 대상 서버 URL
+
+# 텔레메트리
+TELEMETRY_INGEST_TOKEN=...  # 클라이언트 SSR에서 전송하는 토큰
+
+# Vercel ISR 캐시 무효화
+NEXT_REVALIDATE_URL=https://www.daloa.kr/api/revalidate
+NEXT_REVALIDATE_SECRET=...
 ```
 
 ---
@@ -59,16 +74,36 @@ server/src/
 ├── main.ts               # 부트스트랩, CORS, 전역 필터
 ├── app.module.ts         # 모듈 조합
 │
-├── db/                   # MySQL 연결 풀 (DB_POOL 토큰)
+├── prisma/               # PostgreSQL 커넥션 (Prisma 7 + PrismaPg adapter)
 ├── redis/                # ioredis 클라이언트 (REDIS_CLIENT 토큰)
-├── common/               # AllExceptionsFilter — 500 에러 시 카카오 알림
+├── common/               # AllExceptionsFilter, FileLoggerService, LocalDevFlags
 │
-├── lostark/              # 로스트아크 API 래퍼 (fetchSiblings, fetchArmory)
+├── admin/                # 관리자 API (/api/admin/*)
+│   ├── admin-auth.controller.ts      # 로그인/로그아웃/세션
+│   ├── admin-auth.service.ts         # 세션 발급 (Redis TTL 1h)
+│   ├── admin-cache.controller.ts     # Redis 캐시 삭제
+│   ├── admin-characters.controller.ts # 캐릭터 목록 조회
+│   ├── admin-monitoring.controller.ts # 모니터링 대시보드 + 텔레메트리 수집
+│   ├── admin-monitoring.service.ts
+│   ├── admin-sites.controller.ts     # 사이트 CRUD
+│   ├── admin-sync.controller.ts      # DB 동기화 (SSE 스트림)
+│   ├── admin.guard.ts                # AdminGuard, AdminWriteGuard
+│   └── repositories/
+│       ├── admin-auth.repository.ts
+│       ├── admin-characters.repository.ts
+│       ├── admin-sync.repository.ts
+│       └── monitoring.repository.ts
+│
+├── lostark/              # 로스트아크 API 래퍼 + Rate Limiter
 ├── sites/                # GET /api/sites  (Redis 캐시 + 매일 09:00 상태 점검)
-├── streamers/            # GET /api/streamers?page=&size=  (YouTube 라이브, 5분 캐시)
+├── streamers/            # GET /api/streamers?pageToken=  (YouTube 영상, 3h 갱신)
 ├── characters/           # GET /api/characters/stat-builds
-└── users/                # POST /api/users/search  (원정대 upsert)
-                          # GET  /api/users/stats
+├── class-summary/        # GET /api/class-summary  (Gemini AI 직업 한줄평)
+├── users/                # POST /api/users/search  (원정대 upsert)
+│                         # GET  /api/users/exists/:name
+│                         # GET  /api/users/stats
+├── kakao/                # 카카오 알림 서비스
+└── revalidate/           # Vercel ISR 캐시 무효화 트리거
 ```
 
 ---
@@ -78,10 +113,17 @@ server/src/
 | 메서드 | 경로                          | 설명                                           |
 | ------ | ----------------------------- | ---------------------------------------------- |
 | GET    | `/api/sites`                  | 사이트 목록 (DB + Redis 캐시)                  |
-| GET    | `/api/streamers`              | 유튜브 라이브 목록 (`page`, `size` 쿼리)       |
+| GET    | `/api/streamers`              | 유튜브 영상 목록 (`pageToken` 쿼리)            |
+| GET    | `/api/streamers/popular`      | 인기 영상 (`offset`, `limit` 쿼리)             |
 | GET    | `/api/characters/stat-builds` | 특성 빌드별 직업 분포                          |
+| GET    | `/api/class-summary`          | 전체 직업 AI 한줄평                            |
 | POST   | `/api/users/search`           | 원정대 검색 및 DB upsert (`{ characterName }`) |
+| GET    | `/api/users/exists/:name`     | 캐릭터명 존재 여부 (크롤러용)                  |
 | GET    | `/api/users/stats`            | 저장된 유저/원정대 통계                        |
+| POST   | `/api/admin/auth/login`       | 관리자 로그인                                  |
+| POST   | `/api/admin/auth/logout`      | 관리자 로그아웃                                |
+| GET    | `/api/admin/sync/:table`      | DB 동기화 (SSE 스트림)                         |
+| GET    | `/api/admin/monitoring/dashboard` | 모니터링 대시보드                         |
 
 ---
 
@@ -89,7 +131,7 @@ server/src/
 
 ### 특성 빌드 분류 (`characters.service.ts`)
 
-`loa_users.stat_crit/spec/swift` (ArmoryProfile.Stats에서 파싱) 기준:
+`loa_users.stat_crit/spec/swift` 기준:
 
 | 조건                | 분류                                                |
 | ------------------- | --------------------------------------------------- |
@@ -98,33 +140,20 @@ server/src/
 | 스탯 1개만 ≥ 100    | 1순위 스탯 기준 쌍으로 분류                         |
 | 모두 < 100          | 미설정                                              |
 
-### 유저 upsert (`users.service.ts`)
-
-1. `characterName`으로 원정대 전체 조회 (`/characters/{name}/siblings`)
-2. 아이템레벨 상위 6명 = `theSix` 플래그
-3. 각 캐릭터 armory 조회 → stat 파싱 → `loa_users` upsert
-4. `loa_class` 테이블과 JOIN으로 `class_engraving` 연결
-
 ### 스트리머 영상 캐시 (`streamers.service.ts`)
 
 - 서버 시작 시 1회 + 이후 **3시간마다** Cron 갱신 (`0 */3 * * *`)
 - Redis TTL **4시간** (만료 공백 없음)
-- `YOUTUBE_API_KEY_N` 형식으로 멀티 키 지원 (할당량 초과 시 다음 키로 자동 주기)
+- `YOUTUBE_API_KEY_N` 형식으로 멀티 키 지원 (할당량 초과 시 다음 키로 자동 교체)
 - 캐시 미스 시 Redis 분산 락으로 Thundering Herd 방지
-- `YOUTUBE_REDIS_HOST` 설정 시 별도 Redis 인스턴스 사용 (로컈 개발용)
 
 ### 사이트 점검 (`sites.service.ts`)
 
 - 매일 09:00 각 사이트 HTTP 상태·타이틀 점검
 - 변경 감지 시 카카오톡 메시지 발송
 
----
+### DB 동기화 (`admin-sync.controller.ts`)
 
-## 크롤러
-
-`crawlers/crawl-loawa.js` — loawa.com 전투력 상위 캐릭터명으로 `/api/users/search` 일괄 호출
-
-```bash
-# 루트에서 실행 (서버가 먼저 실행 중이어야 함)
-node crawlers/crawl-loawa.js
-```
+- SSE(Server-Sent Events)로 진행상황 실시간 스트림
+- `local → production` / `production → local` 양방향 지원
+- `loa_users` 동기화 전 FK 의존 테이블(`loa_class`, `loa_ark_grid`) 선처리


### PR DESCRIPTION
## Summary
- MariaDB → PostgreSQL (Prisma 7 + `@prisma/adapter-pg`) 반영
- `db/` 모듈 → `prisma/` 모듈로 변경사항 반영
- `admin/` 모듈 추가 (auth/sync/monitoring/cache/sites/characters/repositories)
- 환경변수 목록 현행화 (DATABASE_URL, TELEMETRY_INGEST_TOKEN, ADMIN_* 등 추가 / MySQL 변수 제거)
- `context/deployment.md` 전면 재작성 (기존 인코딩 깨짐 해결, GitHub Actions 자동배포 중심으로 재구성)
- `context/folder-structure.md` 현재 폴더 트리 반영 (proxy.ts, admin/, repositories/, vercel.json 등)
- `client/README.md` 구조·env vars 현행화 (`NEXT_PUBLIC_NEST_API_URL` 제거)
- `server/README.md` PostgreSQL/Prisma, admin 모듈, 새 API 엔드포인트 반영

## Test plan
- [x] 문서 내용이 현재 코드베이스와 일치하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)