### PR TITLE
feat(admin): 탭 재진입 시 캐시 데이터 즉시 표시

### DIFF
--- a/client/app/admin/characters/page.tsx
+++ b/client/app/admin/characters/page.tsx
@@ -40,22 +40,34 @@ const STAT_BUILDS = [
 ];
 const PAGE_SIZE = 20;
 
+let charactersCache: {
+  result: ListResult;
+  search: string;
+  statBuild: string;
+  classDetail: string;
+  page: number;
+} | null = null;
+
 export default function AdminCharactersPage() {
-  const [result, setResult] = useState<ListResult | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [result, setResult] = useState<ListResult | null>(
+    charactersCache?.result ?? null,
+  );
+  const [loading, setLoading] = useState(charactersCache === null);
   const [error, setError] = useState("");
   const [accessNotice, setAccessNotice] = useState("");
   const role = useAdminRole();
   const isGuest = role === "guest";
 
-  const [search, setSearch] = useState("");
-  const [statBuild, setStatBuild] = useState("");
-  const [classDetail, setClassDetail] = useState("");
-  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState(charactersCache?.search ?? "");
+  const [statBuild, setStatBuild] = useState(charactersCache?.statBuild ?? "");
+  const [classDetail, setClassDetail] = useState(
+    charactersCache?.classDetail ?? "",
+  );
+  const [page, setPage] = useState(charactersCache?.page ?? 1);
 
   const load = useCallback(
     async (p = page) => {
-      setLoading(true);
+      if (charactersCache === null) setLoading(true);
       const params = new URLSearchParams({
         page: String(p),
         pageSize: String(PAGE_SIZE),
@@ -71,7 +83,9 @@ export default function AdminCharactersPage() {
         setLoading(false);
         return;
       }
-      setResult((await res.json()) as ListResult);
+      const data = (await res.json()) as ListResult;
+      charactersCache = { result: data, search, statBuild, classDetail, page: p };
+      setResult(data);
       setLoading(false);
     },
     [page, search, statBuild, classDetail],

--- a/client/app/admin/monitoring/page.tsx
+++ b/client/app/admin/monitoring/page.tsx
@@ -90,9 +90,11 @@ function toFixedHundred<T extends { count: number }>(
   return raw.map((r, idx) => ({ ...r.item, pct: pct[idx] }));
 }
 
+let monitoringCache: Dashboard | null = null;
+
 export default function MonitoringPage() {
-  const [data, setData] = useState<Dashboard>(EMPTY_DASHBOARD);
-  const [loading, setLoading] = useState(true);
+  const [data, setData] = useState<Dashboard>(monitoringCache ?? EMPTY_DASHBOARD);
+  const [loading, setLoading] = useState(monitoringCache === null);
   const [rangeDays, setRangeDays] = useState<(typeof RANGE_OPTIONS)[number]>(7);
   const [liveVisitDelta, setLiveVisitDelta] = useState(0);
   const [deviceTab, setDeviceTab] = useState<"device" | "browser">("device");
@@ -103,7 +105,7 @@ export default function MonitoringPage() {
   useEffect(() => {
     let alive = true;
     async function load(initial = false) {
-      if (initial) setLoading(true);
+      if (initial && monitoringCache === null) setLoading(true);
       try {
         const [dashboardRes, currentRes] = await Promise.all([
           fetch("/api/admin/monitoring/dashboard?days=7", { cache: "no-store" }),
@@ -120,6 +122,7 @@ export default function MonitoringPage() {
 
         setData((prev) => {
           const base = dashboard ?? prev;
+          if (dashboard) monitoringCache = base;
           const livePoint = current
             ? {
                 at: current.created_at,

--- a/client/app/admin/sites/page.tsx
+++ b/client/app/admin/sites/page.tsx
@@ -90,9 +90,11 @@ function getCategoryTone(category: string | null) {
   return "border-gray-200 bg-gray-100 text-gray-600";
 }
 
+let sitesCache: Site[] | null = null;
+
 export default function AdminSitesPage() {
-  const [sites, setSites] = useState<Site[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [sites, setSites] = useState<Site[]>(sitesCache ?? []);
+  const [loading, setLoading] = useState(sitesCache === null);
   const [error, setError] = useState("");
   const [accessNotice, setAccessNotice] = useState("");
   const [busyMessage, setBusyMessage] = useState<string | null>(null);
@@ -126,6 +128,7 @@ export default function AdminSitesPage() {
           return null;
         }
         const data = (await res.json()) as Site[];
+        sitesCache = data;
         setSites(data);
         setError("");
         return data;
@@ -142,7 +145,7 @@ export default function AdminSitesPage() {
   );
 
   useEffect(() => {
-    void load({ withSpinner: true });
+    void load({ withSpinner: sitesCache === null });
   }, [load]);
 
   function startEdit(site: Site) {


### PR DESCRIPTION
## Summary

모듈 레벨 캐시 변수로 탭 이동 후 재진입 시 로딩 스피너 없이 즉시 이전 데이터 표시.

- **사이트 관리**: `sitesCache` — 재진입 시 즉시 표시 후 백그라운드 재fetch
- **캐릭터 목록**: `charactersCache` — 필터·페이지 상태 포함, 재진입 시 복원
- **모니터링**: `monitoringCache` — 캐시된 데이터 즉시 표시 후 기존 3초 폴링 재개

## 동작 방식

- 첫 진입: 캐시 없음 → 로딩 스피너 → 데이터 표시 + 캐시 저장
- 탭 재진입: 캐시 있음 → 즉시 표시 (스피너 없음) → 백그라운드 재fetch
- 페이지 새로고침: 캐시 초기화 → 첫 진입과 동일

## Test plan

- [x] 사이트 관리 첫 진입 → 로딩 스피너 표시 확인
- [x] 다른 탭 이동 후 재진입 → 즉시 표시, 스피너 없음 확인
- [x] 모니터링 탭 재진입 → 캐시 데이터 즉시 표시 후 폴링 재개 확인
- [x] 사이트 CRUD 후 → 목록 정상 갱신 확인
- [x] 캐릭터 필터 적용 후 탭 이동 → 재진입 시 필터 상태 복원 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)