### PR TITLE
chore(ci): PR CI를 통합 브랜치 타겟으로만 실행 (main 제외)

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -2,7 +2,7 @@ name: PR CI
 
 on:
   pull_request:
-    branches: [main]
+    branches-ignore: [main]
 
 concurrency:
   group: pr-ci-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## 변경 내용

`branches: [main]` → `branches-ignore: [main]`

## 이유

- 기존: sub-branch → feat/admin → main 흐름에서 main 머지 시에만 CI 실행
  → feat/admin에서 버그가 발견되면 main 단계까지 안 잡힘
  → 또는 feat/admin에서 이미 검증됐는데 main에서 중복 실행

- 변경 후: sub-branch → feat/admin (여기서 CI 실행) → main은 신뢰 머지
  → feat/*, fix/*, chore/* 등 모든 패턴 자동 커버
  → main 타겟 PR에는 CI 미실행 (중복 제거)

🤖 Generated with [Claude Code](https://claude.com/claude-code)