### PR TITLE
fix(monitoring): 컨테이너 현황 UX + EC2 호스트 자원 + 페이지 방문 추이 수정

### DIFF
--- a/client/app/admin/monitoring/page.tsx
+++ b/client/app/admin/monitoring/page.tsx
@@ -144,7 +144,12 @@ export default function MonitoringPage() {
           }
           prevVisitCountRef.current = nextVisitCount;
 
-          return { ...base, sectionSeries: prev.sectionSeries };
+          return {
+            ...base,
+            sectionSeries: prev.sectionSeries,
+            pageVisitSeries: prev.pageVisitSeries ?? base.pageVisitSeries,
+            youtubeClickTotal: prev.youtubeClickTotal ?? base.youtubeClickTotal,
+          };
         });
         hasLoadedRef.current = true;
       } catch {

--- a/client/app/admin/monitoring/page.tsx
+++ b/client/app/admin/monitoring/page.tsx
@@ -148,7 +148,6 @@ export default function MonitoringPage() {
             ...base,
             sectionSeries: prev.sectionSeries,
             pageVisitSeries: prev.pageVisitSeries ?? base.pageVisitSeries,
-            youtubeClickTotal: prev.youtubeClickTotal ?? base.youtubeClickTotal,
           };
         });
         hasLoadedRef.current = true;


### PR DESCRIPTION
## Summary
fix/admin에 누적된 모니터링 개선 사항을 main에 반영 (EC2 배포).

- 컨테이너 현황 로딩 표시 + 탭 재진입 시 캐시 즉시 표시
- "통합" 합산 카드 → **EC2 호스트 전체** 카드 (호스트 `/proc`·`df` 실측 CPU·메모리·디스크)
- 컨테이너 카드: CPU / 메모리(%) / 네트워크(↓↑)
- docker_metrics INSERT `::numeric::int` 캐스팅으로 22P02 저장 오류 수정 (nest/postgres/redis 전부 영향)
- 페이지 방문 추이 7/30일 선택이 3초 폴링에 덮어써지던 버그 수정
- youtubeClickTotal은 폴링으로 실시간 갱신 유지

## Test plan
- [ ] 배포 후 `/admin/monitoring`에서 EC2 호스트 카드 CPU/메모리/디스크 표시 확인
- [ ] 컨테이너 탭 전환 동작 확인
- [ ] `docker_metrics_*` 테이블 5분 크론 적재 확인
- [ ] 페이지 방문 추이 7/30일 선택 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)