### PR TITLE
ci(deploy): ECR 기반 Docker 이미지 배포 파이프라인 전환

### DIFF
--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -46,11 +46,26 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
 
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push Docker image to ECR
+        env:
+          ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
+          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG ./server
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+
       - name: Deploy to EC2 via SSM
         env:
           EC2_INSTANCE_ID: ${{ secrets.EC2_INSTANCE_ID }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
           NEXT_REVALIDATE_SECRET: ${{ secrets.NEXT_REVALIDATE_SECRET }}
+          ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
+          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
+          IMAGE_TAG: ${{ github.sha }}
         run: |
           remote_script="set -e
           cd /home/ubuntu/daloa
@@ -59,8 +74,11 @@ jobs:
           grep -q '^NEXT_REVALIDATE_URL=' .env || echo 'NEXT_REVALIDATE_URL=https://www.daloa.kr/api/revalidate' >> .env
           sed -i '/^NEXT_REVALIDATE_SECRET=/d' .env
           echo 'NEXT_REVALIDATE_SECRET=${NEXT_REVALIDATE_SECRET}' >> .env
-          cd server && npm run build && cd ..
-          docker compose up -d --build nest
+          sed -i '/^NEST_IMAGE=/d' .env
+          echo 'NEST_IMAGE=${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}' >> .env
+          aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin ${ECR_REGISTRY}
+          docker pull ${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}
+          docker compose up -d
           docker restart daloa-nginx"
 
           encoded=$(printf '%s' "$remote_script" | base64 -w0)
@@ -74,16 +92,16 @@ jobs:
             --query 'Command.CommandId' \
             --output text)
 
-          # SSM waiter 기본값(100s)이 너무 짧으므로 직접 폴링 (최대 10분)
+          # 최대 3분 폴링 (EC2는 pull+start만 하므로 충분)
           wait_exit=1
-          for i in $(seq 1 60); do
+          for i in $(seq 1 18); do
             status=$(aws ssm get-command-invocation \
               --region "$AWS_REGION" \
               --command-id "$command_id" \
               --instance-id "$EC2_INSTANCE_ID" \
               --query 'Status' \
               --output text 2>/dev/null || echo "Pending")
-            echo "[${i}/60] SSM status: $status"
+            echo "[${i}/18] SSM status: $status"
             if [ "$status" = "Success" ]; then
               wait_exit=0; break
             elif [ "$status" = "Failed" ] || [ "$status" = "Cancelled" ] || [ "$status" = "TimedOut" ]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@
 - `feat/admin`
 - `fix/mainPage`
 - `feat/mainPage`
-- `chore/docs`
+- `ci/cd`
 
 운영 방식:
 

--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@
 - feat/admin
 - fix/mainPage
 - feat/mainPage
-- chore/docs
+- ci/cd

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - daloa-net
 
   nest:
+    image: ${NEST_IMAGE:-daloa-nest:dev}
     build:
       context: ./server
       dockerfile: Dockerfile


### PR DESCRIPTION
## Summary

- GitHub Actions에서 Docker 이미지를 빌드해 ECR에 푸시
- EC2는 `docker pull` + `docker compose up -d`만 수행 (빌드 작업 제거)
- `docker-compose.yml`에 `NEST_IMAGE` 환경변수로 ECR 이미지 참조 추가
- SSM 폴링 최대 대기시간 10분 → 3분으로 단축

## 사전 완료된 AWS 작업

- [x] ECR 리포지터리 `daloa-nest` 생성 (수명 주기: 최근 5개 유지)
- [x] `daloa-github-actions-deploy-role`에 ECR push 권한 추가
- [x] `daloa-ec2-ssm-role`에 ECR pull 권한 추가
- [x] GitHub Secrets `ECR_REGISTRY`, `ECR_REPOSITORY` 추가

## Test plan

- [ ] 머지 후 main-post-merge 워크플로우 실행 확인
- [ ] ECR 콘솔에서 이미지 푸시 확인
- [ ] EC2에서 새 컨테이너 정상 기동 확인
- [ ] SSM 실행 시간이 기존보다 단축됐는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)