### PR TITLE
ci(workflow): PR 머지 후 하위 브랜치 자동 삭제

### DIFF
--- a/.github/workflows/auto-delete-branch.yml
+++ b/.github/workflows/auto-delete-branch.yml
@@ -1,0 +1,28 @@
+name: Auto Delete Branch
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  delete-branch:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Delete sub-branch after merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+          REPO: ${{ github.repository }}
+        run: |
+          parent_branches="main ci/cd feat/admin feat/mainPage fix/admin fix/mainPage"
+          for branch in $parent_branches; do
+            if [ "$HEAD_BRANCH" = "$branch" ]; then
+              echo "$HEAD_BRANCH is a parent branch, skipping deletion."
+              exit 0
+            fi
+          done
+          echo "Deleting sub-branch: $HEAD_BRANCH"
+          gh api --method DELETE "repos/$REPO/git/refs/heads/$HEAD_BRANCH"


### PR DESCRIPTION
## Summary

PR 머지 후 하위 브랜치를 자동 삭제하는 워크플로우 추가.

## 동작 방식

- **상위 브랜치** (`main`, `ci/cd`, `feat/admin`, `feat/mainPage`, `fix/admin`, `fix/mainPage`) → 삭제하지 않음
- **하위 브랜치** (`ci/auto-delete-branch`, `fix/admin-login` 등) → PR 머지 후 자동 삭제

## 추가된 파일

- `.github/workflows/auto-delete-branch.yml`

## Test plan

- [ ] 하위 브랜치 PR 머지 후 해당 브랜치 자동 삭제 확인
- [ ] 상위 브랜치 PR 머지 후 삭제되지 않음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)