### PR TITLE
ci(deploy): SSM 스크립트 AWS CLI PATH 누락 수정

### DIFF
--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -68,6 +68,7 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
         run: |
           remote_script="set -e
+          export PATH=/usr/local/bin:/snap/bin:/usr/bin:\$PATH
           cd /home/ubuntu/daloa
           git reset --hard HEAD
           git pull origin main


### PR DESCRIPTION
## Summary

ECR 배포 파이프라인 첫 실행 시 아래 에러 발생:
```
bash: line 10: aws: command not found
password is empty
```

EC2에서 ubuntu 유저로 SSM 실행 시 `aws` CLI가 PATH에 포함되지 않는 문제.

## 원인

SSM이 `sudo -u ubuntu -H bash -lc`로 실행될 때 `/usr/local/bin`, `/snap/bin` 등이 PATH에 없어 `aws` 명령어를 찾지 못함.

## 수정 내용

`remote_script` 맨 앞에 PATH 명시적으로 추가:
```bash
export PATH=/usr/local/bin:/snap/bin:/usr/bin:$PATH
```

## Test plan

- [ ] 머지 후 main-post-merge 워크플로우 재실행
- [ ] `Login to Amazon ECR` 및 `Deploy to EC2 via SSM` 스텝 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)