### PR TITLE
ci(deploy): SSM 스크립트 AWS CLI PATH 누락 수정

### DIFF
--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -68,6 +68,7 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
         run: |
           remote_script="set -e
+          export PATH=/usr/local/bin:/snap/bin:/usr/bin:\$PATH
           cd /home/ubuntu/daloa
           git reset --hard HEAD
           git pull origin main


### PR DESCRIPTION
## Summary

ECR 배포 첫 실행 시 EC2에서 `aws: command not found` 에러 발생.
SSM 실행 환경에 AWS CLI PATH가 누락된 문제를 수정합니다.

- PR #193 포함: `ci/fix-ecr-path` → `ci/cd`

## 수정 내용

`remote_script` 맨 앞에 PATH 명시적으로 추가:
```bash
export PATH=/usr/local/bin:/snap/bin:/usr/bin:$PATH
```

## Test plan

- [ ] 머지 후 main-post-merge 워크플로우 정상 실행 확인
- [ ] ECR 이미지 푸시 및 EC2 컨테이너 재기동 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)