### PR TITLE
ci(deploy): EC2 AWS CLI 의존성 제거, GitHub Actions에서 ECR 토큰 발급으로 변경

### DIFF
--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -67,8 +67,9 @@ jobs:
           ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
+          ECR_PASSWORD=$(aws ecr get-login-password --region ${AWS_REGION})
+
           remote_script="set -e
-          export PATH=/usr/local/bin:/snap/bin:/usr/bin:\$PATH
           cd /home/ubuntu/daloa
           git reset --hard HEAD
           git pull origin main
@@ -77,7 +78,7 @@ jobs:
           echo 'NEXT_REVALIDATE_SECRET=${NEXT_REVALIDATE_SECRET}' >> .env
           sed -i '/^NEST_IMAGE=/d' .env
           echo 'NEST_IMAGE=${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}' >> .env
-          aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin ${ECR_REGISTRY}
+          echo '${ECR_PASSWORD}' | docker login --username AWS --password-stdin ${ECR_REGISTRY}
           docker pull ${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}
           docker compose up -d
           docker restart daloa-nginx"


### PR DESCRIPTION
## Summary

ECR 배포 시 `aws: command not found` 에러 발생. EC2에 AWS CLI가 설치되어 있지 않은 것이 원인.

## 원인

기존 배포 스크립트는 AWS CLI를 사용한 적이 없어 EC2에 설치되지 않은 상태. PATH 추가(#194)로도 해결 불가.

## 수정 내용

EC2에서 `aws ecr get-login-password` 실행 대신, **GitHub Actions에서 미리 ECR 토큰을 발급**해 `remote_script`에 주입.

```bash
# GitHub Actions에서 (aws CLI 사용 가능)
ECR_PASSWORD=$(aws ecr get-login-password --region ${AWS_REGION})

# EC2 remote_script에서 (aws CLI 불필요)
echo '${ECR_PASSWORD}' | docker login --username AWS --password-stdin ${ECR_REGISTRY}
```

## Test plan

- [ ] 머지 후 main-post-merge 워크플로우 수동 실행
- [ ] ECR 로그인 및 docker pull 성공 확인
- [ ] EC2 컨테이너 정상 재기동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)