### PR TITLE
feat(admin): 게스트 로그인 버튼 및 메인 사이트 바로가기 추가

### DIFF
--- a/client/app/admin/layout.tsx
+++ b/client/app/admin/layout.tsx
@@ -33,8 +33,14 @@ export default function AdminLayout({
       <aside className="admin-sidebar w-56 flex flex-col shrink-0">
         <div className="px-5 py-6 border-b border-[color:var(--admin-sidebar-border)]">
           <span className="admin-sidebar-brand text-base font-bold">
-            관리자 <span className="text-blue-400">Admin</span>
+            관리자
           </span>
+          <Link
+            href="/"
+            className="mt-2 flex items-center gap-1 text-xs font-medium px-2 py-1 rounded bg-blue-50 text-blue-600 hover:bg-blue-100 transition-colors w-fit"
+          >
+            ↗ 메인 사이트 바로가기
+          </Link>
         </div>
         <nav className="flex-1 py-4 px-3 space-y-1">
           {NAV.map(({ href, label }) => {

--- a/client/app/admin/login/page.test.tsx
+++ b/client/app/admin/login/page.test.tsx
@@ -60,17 +60,20 @@ describe("AdminLoginPage", () => {
     });
   });
 
-  it("게스트 아이디 채우기 버튼 클릭 시 아이디와 비밀번호가 채워짐", async () => {
+  it("게스트 로그인 버튼 클릭 시 guest 계정으로 자동 로그인", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+    );
+
     render(<AdminLoginPage />);
 
     await userEvent.click(
-      screen.getByRole("button", { name: "게스트 아이디 채우기" }),
+      screen.getByRole("button", { name: "게스트 로그인" }),
     );
 
-    expect(screen.getByRole("textbox")).toHaveValue("guest");
-    const passwordInput = document.querySelector<HTMLInputElement>(
-      'input[type="password"]',
-    )!;
-    expect(passwordInput).toHaveValue("1237");
+    await waitFor(() => {
+      expect(replaceSpy).toHaveBeenCalledWith("/admin/monitoring");
+    });
   });
 });

--- a/client/app/admin/login/page.tsx
+++ b/client/app/admin/login/page.tsx
@@ -35,10 +35,8 @@ export default function AdminLoginPage() {
     await login(username, password);
   }
 
-  function handleGuestFill() {
-    setUsername("guest");
-    setPassword("1237");
-    setError("");
+  async function handleGuestLogin() {
+    await login("guest", "1237");
   }
 
   return (
@@ -84,10 +82,10 @@ export default function AdminLoginPage() {
           <button
             type="button"
             disabled={loading}
-            onClick={handleGuestFill}
+            onClick={handleGuestLogin}
             className="admin-btn admin-btn-secondary w-full"
           >
-            게스트 아이디 채우기
+            {loading ? "로그인 중..." : "게스트 로그인"}
           </button>
         </form>
       </div>


### PR DESCRIPTION
## Summary
- 로그인 페이지 게스트 버튼: 아이디만 채우던 방식 → 버튼 클릭 시 자동 로그인
- 사이드바 브랜드 영역: `Admin` 텍스트 제거, `↗ 메인 사이트 바로가기` 링크 추가 (pill 스타일)

🤖 Generated with [Claude Code](https://claude.com/claude-code)