### PR TITLE
fix(lostark): burst 차단 방지 및 fetch 타임아웃 추가

### DIFF
--- a/server/src/lostark/lostark.service.ts
+++ b/server/src/lostark/lostark.service.ts
@@ -5,6 +5,8 @@ const BASE = 'https://developer-lostark.game.onstove.com';
 
 const RATE_LIMIT = 80; // 분당 최대 요청 수 (100회 한도의 80%)
 const WINDOW_MS = 60_000; // 1분 윈도우
+const MIN_INTERVAL_MS = Math.ceil(WINDOW_MS / RATE_LIMIT); // 호출 간 최소 간격 (burst 방지)
+const FETCH_TIMEOUT_MS = 10_000; // 단일 LostArk 호출 타임아웃 (응답 없으면 직렬 큐가 영구 정지하는 것 방지)
 
 @Injectable()
 export class LostarkService {
@@ -14,6 +16,7 @@ export class LostarkService {
   // 이중 체크용 윈도우 상태
   private windowStart = Date.now();
   private windowCount = 0;
+  private lastCallTime = 0;
 
   constructor(private readonly config: ConfigService) {}
 
@@ -29,6 +32,7 @@ export class LostarkService {
    * 이중 체크 rate limiter
    * ① 시간 체크: 1분 윈도우가 지났으면 카운터 리셋
    * ② 카운트 체크: 80회 도달 시 윈도우 종료까지 대기 후 리셋
+   * ③ 간격 체크: 호출 간 최소 750ms 유지 (burst → 401 방지)
    */
   private async rateCheck(): Promise<void> {
     const now = Date.now();
@@ -50,6 +54,12 @@ export class LostarkService {
       this.windowCount = 0;
     }
 
+    // ③ 간격 체크: 직전 호출로부터 MIN_INTERVAL_MS 미만이면 대기
+    const elapsed = Date.now() - this.lastCallTime;
+    if (elapsed < MIN_INTERVAL_MS) {
+      await new Promise<void>((r) => setTimeout(r, MIN_INTERVAL_MS - elapsed));
+    }
+    this.lastCallTime = Date.now();
     this.windowCount++;
   }
 
@@ -68,6 +78,7 @@ export class LostarkService {
       const enc = encodeURIComponent(characterName);
       const res = await fetch(`${BASE}/characters/${enc}/siblings`, {
         headers: this.getHeaders(),
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
       });
       if (!res.ok) throw new Error(`siblings API error: ${res.status}`);
       const data: unknown = await res.json();
@@ -80,6 +91,7 @@ export class LostarkService {
       const enc = encodeURIComponent(characterName);
       const res = await fetch(`${BASE}/armories/characters/${enc}`, {
         headers: this.getHeaders(),
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
       });
       if (!res.ok) throw new Error(`armory API error: ${res.status}`);
       const data: unknown = await res.json();


### PR DESCRIPTION
## 변경 내용

크롤러 운영 중 발생한 두 가지 LostArk API 관련 문제 수정

### 문제 1: Burst → 401

`rateCheck()`가 개수(80/분)만 체크하고 간격을 체크하지 않아, 80콜을 1초 이내에 몰아쏘는 burst가 발생. LostArk가 분당 100회 제한 내임에도 burst 감지로 401 반환.

- `MIN_INTERVAL_MS = 750ms` 추가 → 호출 간 최소 간격 보장 (80콜/분 균등 분산)

### 문제 2: fetch hang → 직렬 큐 영구 정지

LostArk fetch에 timeout이 없어서, 단 하나의 호출이 응답 없이 멈추면 모든 호출을 직렬 처리하는 `apiQueue` 체인 전체가 영구 정지. 이후 모든 `/api/users/search` 요청이 무한 대기(300초+ timeout).

- `FETCH_TIMEOUT_MS = 10s` + `AbortSignal.timeout()` 적용 → 10초 내 응답 없으면 에러로 처리, 큐 계속 진행

## 테스트

로컬 크롤링으로 검증:
- 수정 전: `/search` 60초+ 무한 대기, 저장 0
- 수정 후: `/search` ~17초 정상 응답, 원정대 22명 저장 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)