### PR TITLE
feat(mainPage): 다크모드 토글 추가 및 전체 컴포넌트 대응

### DIFF
--- a/client/app/globals.css
+++ b/client/app/globals.css
@@ -4,7 +4,11 @@
   --background: #ffffff;
   --foreground: #111827;
 }
-
+.dark {
+  --background: #111827;
+  --foreground: #f9fafb;
+}
+@custom-variant dark (&:where(.dark, .dark *));
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);

--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import { Analytics } from "@vercel/analytics/react";
 import GoogleAnalytics from "@/components/GoogleAnalytics";
 import MonitoringBeacon from "@/components/MonitoringBeacon";
+import DarkModeToggle from "@/components/DarkModeToggle";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -61,9 +62,16 @@ export default function RootLayout({
       suppressHydrationWarning
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
+      <head>
+        {/* 다크모드 FOUC 방지: hydration 전에 동기 실행 */}
+        <script dangerouslySetInnerHTML={{ __html: `(function(){var t=localStorage.getItem('theme'),d=window.matchMedia('(prefers-color-scheme: dark)').matches;if(t==='dark'||(!t&&d))document.documentElement.classList.add('dark')})()` }} />
+      </head>
       <body className="min-h-full flex flex-col">
         <GoogleAnalytics />
         <MonitoringBeacon />
+        <div className="fixed right-4 top-4 z-50">
+          <DarkModeToggle />
+        </div>
         {children}
         <Analytics />
       </body>

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -44,7 +44,11 @@ async function timedFetch<T>(label: string, url: string, revalidate: number) {
 export default async function Home() {
   const [sitesRes, statRes] = await Promise.all([
     timedFetch<Site[]>("sites", `${API}/api/sites`, 3600),
-    timedFetch<StatBuildTab[]>("stat-builds", `${API}/api/characters/stat-builds`, 300),
+    timedFetch<StatBuildTab[]>(
+      "stat-builds",
+      `${API}/api/characters/stat-builds`,
+      300,
+    ),
   ]);
 
   const sites = sitesRes.data;
@@ -58,8 +62,8 @@ export default async function Home() {
 
           <main className="flex flex-col gap-2">
             <header className="fade-in text-center">
-              <h1 className="text-lg font-bold tracking-tight text-slate-900 sm:text-xl">
-                관리자 - 로아 사이트 모음
+              <h1 className="text-lg font-bold tracking-tight text-slate-900 dark:text-slate-100 sm:text-xl">
+                로아 사이트 모음
               </h1>
             </header>
 
@@ -77,12 +81,12 @@ export default async function Home() {
             <Suspense
               fallback={
                 <div className="animate-pulse space-y-2 pt-2">
-                  <div className="h-5 w-36 rounded bg-slate-200" />
+                  <div className="h-5 w-36 rounded bg-slate-200 dark:bg-slate-700" />
                   <div className="flex gap-3 overflow-hidden">
                     {[0, 1, 2].map((i) => (
                       <div
                         key={i}
-                        className="h-[190px] w-[270px] shrink-0 rounded-lg bg-slate-200"
+                        className="h-[190px] w-[270px] shrink-0 rounded-lg bg-slate-200 dark:bg-slate-700"
                       />
                     ))}
                   </div>
@@ -101,8 +105,8 @@ export default async function Home() {
         </div>
       </div>
 
-      <footer className="border-t border-slate-200/80 bg-slate-50/80 px-4 py-4 backdrop-blur">
-        <div className="mx-auto flex max-w-6xl flex-col gap-1 text-center text-xs text-slate-500 sm:text-sm">
+      <footer className="border-t border-slate-200/80 bg-slate-50/80 px-4 py-4 backdrop-blur dark:border-slate-700/80 dark:bg-slate-900/80">
+        <div className="mx-auto flex max-w-6xl flex-col gap-1 text-center text-xs text-slate-500 dark:text-slate-400 sm:text-sm">
           <p>© 2026 로아</p>
         </div>
       </footer>

--- a/client/components/DarkModeToggle.tsx
+++ b/client/components/DarkModeToggle.tsx
@@ -3,10 +3,20 @@
 import { useEffect, useState } from "react";
 
 export default function DarkModeToggle() {
-  const [dark, setDark] = useState(false);
+  const [dark, setDark] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    return document.documentElement.classList.contains("dark");
+  });
 
   useEffect(() => {
-    setDark(document.documentElement.classList.contains("dark"));
+    const observer = new MutationObserver(() => {
+      setDark(document.documentElement.classList.contains("dark"));
+    });
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+    return () => observer.disconnect();
   }, []);
 
   const toggle = () => {
@@ -21,6 +31,7 @@ export default function DarkModeToggle() {
       type="button"
       onClick={toggle}
       aria-label={dark ? "라이트 모드로 전환" : "다크 모드로 전환"}
+      suppressHydrationWarning
       className="flex h-8 w-8 items-center justify-center rounded-full border border-slate-200 bg-white/90 text-slate-600 shadow-sm backdrop-blur transition hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-800/90 dark:text-slate-300 dark:hover:bg-slate-700"
     >
       {dark ? (

--- a/client/components/DarkModeToggle.tsx
+++ b/client/components/DarkModeToggle.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export default function DarkModeToggle() {
+  const [dark, setDark] = useState(false);
+
+  useEffect(() => {
+    setDark(document.documentElement.classList.contains("dark"));
+  }, []);
+
+  const toggle = () => {
+    const next = !dark;
+    document.documentElement.classList.toggle("dark", next);
+    localStorage.setItem("theme", next ? "dark" : "light");
+    setDark(next);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label={dark ? "라이트 모드로 전환" : "다크 모드로 전환"}
+      className="flex h-8 w-8 items-center justify-center rounded-full border border-slate-200 bg-white/90 text-slate-600 shadow-sm backdrop-blur transition hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-800/90 dark:text-slate-300 dark:hover:bg-slate-700"
+    >
+      {dark ? (
+        <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M12 2.25a.75.75 0 0 1 .75.75v2.25a.75.75 0 0 1-1.5 0V3a.75.75 0 0 1 .75-.75ZM7.5 12a4.5 4.5 0 1 1 9 0 4.5 4.5 0 0 1-9 0ZM18.894 6.166a.75.75 0 0 0-1.06-1.06l-1.591 1.59a.75.75 0 1 0 1.06 1.061l1.591-1.59ZM21.75 12a.75.75 0 0 1-.75.75h-2.25a.75.75 0 0 1 0-1.5H21a.75.75 0 0 1 .75.75ZM17.834 18.894a.75.75 0 0 0 1.06-1.06l-1.59-1.591a.75.75 0 1 0-1.061 1.06l1.59 1.591ZM12 18a.75.75 0 0 1 .75.75V21a.75.75 0 0 1-1.5 0v-2.25A.75.75 0 0 1 12 18ZM7.758 17.303a.75.75 0 0 0-1.061-1.06l-1.591 1.59a.75.75 0 0 0 1.06 1.061l1.591-1.59ZM6 12a.75.75 0 0 1-.75.75H3a.75.75 0 0 1 0-1.5h2.25A.75.75 0 0 1 6 12ZM6.697 7.757a.75.75 0 0 0 1.06-1.06l-1.59-1.591a.75.75 0 0 0-1.061 1.06l1.59 1.591Z" />
+        </svg>
+      ) : (
+        <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
+          <path fillRule="evenodd" d="M9.528 1.718a.75.75 0 0 1 .162.819A8.97 8.97 0 0 0 9 6a9 9 0 0 0 9 9 8.97 8.97 0 0 0 3.463-.69.75.75 0 0 1 .981.98 10.503 10.503 0 0 1-9.694 6.46c-5.799 0-10.5-4.7-10.5-10.5 0-4.368 2.667-8.112 6.46-9.694a.75.75 0 0 1 .818.162Z" clipRule="evenodd" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/client/components/characters/StatBuildList.tsx
+++ b/client/components/characters/StatBuildList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { StatBuildTab } from "@/types";
 import { event as gaEvent } from "@/lib/gtag";
 
@@ -55,6 +55,19 @@ export default function StatBuildList({ tabs }: Props) {
         .filter((g) => g.matched.length > 0)
     : [];
 
+  const [isDark, setIsDark] = useState(false);
+  useEffect(() => {
+    const update = () =>
+      setIsDark(document.documentElement.classList.contains("dark"));
+    update();
+    const observer = new MutationObserver(update);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+    return () => observer.disconnect();
+  }, []);
+
   // 탭 뷰
   const current =
     safeTabs.find((t) => t.statBuild === activeTab) ?? safeTabs[0];
@@ -62,10 +75,10 @@ export default function StatBuildList({ tabs }: Props) {
   const maxCount = Math.max(...(current?.items?.map((i) => i.count) ?? [1]), 1);
 
   return (
-    <article className="flex max-h-[40vh] shrink-0 flex-col overflow-hidden rounded-2xl border border-slate-200/70 bg-white/85 p-4 shadow-md backdrop-blur fade-in delay-1 sm:h-[calc((100vh-90px)/3)] sm:max-h-none">
+    <article className="flex max-h-[40vh] shrink-0 flex-col overflow-hidden rounded-2xl border border-slate-200/70 bg-white/85 p-4 shadow-md backdrop-blur fade-in delay-1 dark:border-slate-700/70 dark:bg-slate-800/85 sm:h-[calc((100vh-90px)/3)] sm:max-h-none">
       <div className="mb-3 shrink-0 flex items-start justify-between gap-3">
         <div>
-          <h2 className="text-xl font-semibold text-slate-900">
+          <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">
             특성 빌드 분포
           </h2>
         </div>
@@ -74,7 +87,7 @@ export default function StatBuildList({ tabs }: Props) {
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="직업·각인 검색"
-          className="mt-1 w-36 rounded-lg border border-slate-200 bg-slate-50 px-2.5 py-1.5 text-xs text-slate-700 outline-none placeholder:text-slate-300 focus:border-cyan-400 focus:bg-white transition"
+          className="mt-1 w-36 rounded-lg border border-slate-200 bg-slate-50 px-2.5 py-1.5 text-xs text-slate-700 outline-none placeholder:text-slate-300 focus:border-cyan-400 focus:bg-white transition dark:border-slate-600 dark:bg-slate-700 dark:text-slate-200 dark:placeholder:text-slate-500 dark:focus:bg-slate-600"
         />
       </div>
 
@@ -83,7 +96,7 @@ export default function StatBuildList({ tabs }: Props) {
           /* ── 검색 결과 뷰 ── */
           <div className="flex-1 overflow-y-auto pr-1 [scrollbar-width:thin] [scrollbar-color:theme(colors.slate.200)_transparent]">
             {searchGroups.length === 0 ? (
-              <p className="py-8 text-center text-sm text-slate-400">
+              <p className="py-8 text-center text-sm text-slate-400 dark:text-slate-500">
                 검색 결과 없음
               </p>
             ) : (
@@ -119,26 +132,26 @@ export default function StatBuildList({ tabs }: Props) {
                         return (
                           <li
                             key={`${item.classDetail}-${idx}`}
-                            className="flex items-center gap-2 rounded-lg bg-cyan-50 py-0.5 ring-1 ring-cyan-200"
+                            className="flex items-center gap-2 rounded-lg bg-cyan-50 py-0.5 ring-1 ring-cyan-200 dark:bg-cyan-950/30 dark:ring-cyan-800"
                           >
                             <span className="w-4 shrink-0 text-center text-xs font-bold text-slate-400" />
                             <div className="flex w-32 shrink-0 flex-col">
-                              <span className="truncate text-xs font-semibold leading-tight text-cyan-700">
+                              <span className="truncate text-xs font-semibold leading-tight text-cyan-700 dark:text-cyan-300">
                                 {item.classEngraving}
                               </span>
                               {item.classDetail && (
-                                <span className="truncate text-xs font-normal leading-tight text-cyan-500">
+                                <span className="truncate text-xs font-normal leading-tight text-cyan-500 dark:text-cyan-400">
                                   {item.classDetail}
                                 </span>
                               )}
                             </div>
-                            <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-slate-100">
+                            <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-slate-100 dark:bg-slate-700">
                               <div
                                 className="h-full rounded-full bg-cyan-400 transition-all"
                                 style={{ width: `${pct}%` }}
                               />
                             </div>
-                            <span className="w-10 shrink-0 text-right text-xs font-semibold text-cyan-600">
+                            <span className="w-10 shrink-0 text-right text-xs font-semibold text-cyan-600 dark:text-cyan-400">
                               {pct}%
                             </span>
                           </li>
@@ -203,7 +216,21 @@ export default function StatBuildList({ tabs }: Props) {
                 .sort((a, b) => b.count - a.count)
                 .map((item, idx) => {
                   const style = BUILD_STYLE[activeTab] ?? DEFAULT_STYLE;
-                  const fillOpacity = 0.12 + (item.count / maxCount) * 0.73;
+                  // 다크모드에서 최소 opacity를 높여 가장 옅은 항목도 보이게
+                  const minOpacity = isDark ? 0.28 : 0.12;
+                  const fillOpacity = minOpacity + (item.count / maxCount) * (0.85 - minOpacity);
+                  const onDark = fillOpacity >= 0.5;
+                  // 다크모드에서 fill이 옅을 때 글자가 어두워 안 보이는 문제 보정
+                  const textMain = onDark
+                    ? "text-white"
+                    : isDark
+                      ? "text-slate-200"
+                      : "text-slate-800";
+                  const textSub = onDark
+                    ? "text-white/80"
+                    : isDark
+                      ? "text-slate-300"
+                      : "text-slate-600";
                   return (
                     <li
                       key={`${item.classDetail}-${idx}`}
@@ -213,15 +240,15 @@ export default function StatBuildList({ tabs }: Props) {
                         className={`absolute inset-0 ${style.bar} transition-all`}
                         style={{ opacity: fillOpacity }}
                       />
-                      <span className="relative w-4 shrink-0 text-center text-xs font-bold text-slate-900">
+                      <span className={`relative w-4 shrink-0 text-center text-xs font-bold ${textMain}`}>
                         {idx + 1}
                       </span>
                       <div className="relative flex min-w-0 flex-1 flex-col">
-                        <span className="text-xs font-medium leading-tight text-slate-900">
+                        <span className={`text-xs font-medium leading-tight ${textMain}`}>
                           {item.classEngraving}
                         </span>
                       </div>
-                      <span className="relative w-9 shrink-0 text-right text-xs font-medium text-slate-900">
+                      <span className={`relative w-9 shrink-0 text-right text-xs font-medium ${textSub}`}>
                         {item.count}명
                       </span>
                     </li>
@@ -229,7 +256,7 @@ export default function StatBuildList({ tabs }: Props) {
                 })}
 
               {(!current || !current.items?.length) && (
-                <li className="py-8 text-center text-sm text-slate-400">
+                <li className="py-8 text-center text-sm text-slate-400 dark:text-slate-500">
                   스탯 데이터 없음
                 </li>
               )}

--- a/client/components/sites/SiteList.tsx
+++ b/client/components/sites/SiteList.tsx
@@ -120,7 +120,7 @@ export default function SiteList({ sites }: Props) {
   };
 
   return (
-    <section className="flex max-h-[56vh] flex-col overflow-hidden rounded-2xl border border-slate-200/70 bg-white/80 shadow-md backdrop-blur sm:h-[590px] sm:max-h-none">
+    <section className="flex max-h-[56vh] flex-col overflow-hidden rounded-2xl border border-slate-200/70 bg-white/80 shadow-md backdrop-blur dark:border-slate-700/70 dark:bg-slate-800/80 sm:h-[590px] sm:max-h-none">
       <div className="stagger flex-1 overflow-y-auto p-4 pr-5 sm:pr-4">
         <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
           {sorted.map((site) => {
@@ -188,8 +188,8 @@ export default function SiteList({ sites }: Props) {
                   }}
                   className={`relative flex h-full cursor-pointer select-none flex-col rounded-xl border p-3 transition-all duration-200 hover:-translate-y-0.5 ${
                     isFav
-                      ? "border-blue-400 bg-blue-50 hover:border-blue-500 hover:bg-blue-50"
-                      : "border-slate-200 bg-slate-50 hover:border-cyan-300 hover:bg-cyan-50"
+                      ? "border-blue-400 bg-blue-50 hover:border-blue-500 hover:bg-blue-50 dark:bg-blue-950/40 dark:border-blue-700 dark:hover:bg-blue-950/60"
+                      : "border-slate-200 bg-slate-50 hover:border-cyan-300 hover:bg-cyan-50 dark:border-slate-700 dark:bg-slate-800 dark:hover:border-cyan-700 dark:hover:bg-cyan-950/30"
                   }`}
                 >
                   {/* 별 버튼 */}
@@ -230,19 +230,19 @@ export default function SiteList({ sites }: Props) {
                           }}
                         />
                       )}
-                      <span className="truncate font-semibold text-slate-900">
+                      <span className="truncate font-semibold text-slate-900 dark:text-slate-100">
                         {site.name}
                       </span>
                     </div>
                     <span
                       className={`shrink-0 rounded-full px-2 py-0.5 text-xs text-white ${
-                        isFav ? "bg-blue-500" : "bg-slate-900"
+                        isFav ? "bg-blue-500" : "bg-slate-700 dark:bg-slate-600"
                       }`}
                     >
                       {site.category}
                     </span>
                   </div>
-                  <p className="mt-1.5 text-sm text-slate-600">
+                  <p className="mt-1.5 text-sm text-slate-600 dark:text-slate-400">
                     {site.description}
                   </p>
                 </div>

--- a/client/components/youtube/YoutubeList.tsx
+++ b/client/components/youtube/YoutubeList.tsx
@@ -339,15 +339,15 @@ export default function YoutubeList({
     <section className="fade-in">
       <div className="mb-0 flex flex-row items-center justify-between gap-2">
         <div className="flex items-baseline gap-2 min-w-0">
-          <h2 className="text-lg font-semibold text-slate-900">로아 영상</h2>
-          <span className="hidden text-xs text-slate-400 sm:inline">
+          <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">로아 영상</h2>
+          <span className="hidden text-xs text-slate-400 dark:text-slate-500 sm:inline">
             심심할 때 보는
           </span>
         </div>
         <div className="flex items-center gap-1 shrink-0 sm:gap-2">
           <button
             onClick={() => void handleRefresh()}
-            className="flex h-10 w-10 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-500 shadow-sm transition hover:border-red-300 hover:text-red-500 hover:shadow-md disabled:cursor-default disabled:opacity-40"
+            className="flex h-10 w-10 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-500 shadow-sm transition hover:border-red-300 hover:text-red-500 hover:shadow-md disabled:cursor-default disabled:opacity-40 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-400 dark:hover:border-red-700"
             aria-label="새로고침"
             disabled={loading || refreshing}
             title="최신 영상으로 새로고침"
@@ -367,7 +367,7 @@ export default function YoutubeList({
           </button>
           <button
             onClick={() => scroll("left")}
-            className="flex h-10 w-10 items-center justify-center rounded-full border border-slate-200 bg-white text-xl text-slate-500 shadow-sm transition hover:border-red-300 hover:text-red-500 hover:shadow-md disabled:cursor-default disabled:opacity-40"
+            className="flex h-10 w-10 items-center justify-center rounded-full border border-slate-200 bg-white text-xl text-slate-500 shadow-sm transition hover:border-red-300 hover:text-red-500 hover:shadow-md disabled:cursor-default disabled:opacity-40 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-400 dark:hover:border-red-700"
             aria-label="이전"
             disabled={loading || items.length === 0}
           >
@@ -375,7 +375,7 @@ export default function YoutubeList({
           </button>
           <button
             onClick={() => scroll("right")}
-            className="flex h-10 w-10 items-center justify-center rounded-full border border-slate-200 bg-white text-xl text-slate-500 shadow-sm transition hover:border-red-300 hover:text-red-500 hover:shadow-md disabled:cursor-default disabled:opacity-40"
+            className="flex h-10 w-10 items-center justify-center rounded-full border border-slate-200 bg-white text-xl text-slate-500 shadow-sm transition hover:border-red-300 hover:text-red-500 hover:shadow-md disabled:cursor-default disabled:opacity-40 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-400 dark:hover:border-red-700"
             aria-label="다음"
             disabled={loading || items.length === 0}
           >
@@ -389,7 +389,7 @@ export default function YoutubeList({
           {Array.from({ length: 6 }).map((_, i) => (
             <div
               key={i}
-              className="w-[calc(50%-0.5rem)] shrink-0 animate-pulse rounded-xl bg-slate-100 sm:w-52"
+              className="w-[calc(50%-0.5rem)] shrink-0 animate-pulse rounded-xl bg-slate-100 dark:bg-slate-700 sm:w-52"
               style={{ height: 160 }}
             />
           ))}
@@ -469,7 +469,7 @@ export default function YoutubeList({
                           }).catch(() => {});
                         }
                       }}
-                      className="flex flex-col h-full gap-2 rounded-xl border border-slate-200 bg-white p-2 transition-transform duration-150 hover:-translate-y-0.5 hover:border-red-300 hover:shadow-md"
+                      className="flex flex-col h-full gap-2 rounded-xl border border-slate-200 bg-white p-2 transition-transform duration-150 hover:-translate-y-0.5 hover:border-red-300 hover:shadow-md dark:border-slate-700 dark:bg-slate-800 dark:hover:border-red-700"
                     >
                       {v.thumbnailUrl && (
                         <div className="relative">
@@ -485,19 +485,19 @@ export default function YoutubeList({
                         </div>
                       )}
                       <div className="flex flex-col flex-1 justify-between gap-0.5 px-0.5 pb-0.5 min-h-0">
-                        <p className="line-clamp-2 text-xs font-medium text-slate-800 leading-snug">
+                        <p className="line-clamp-2 text-xs font-medium text-slate-800 leading-snug dark:text-slate-200">
                           {v.title}
                         </p>
                         <div className="mt-1 flex items-center justify-between">
-                          <span className="truncate text-[11px] text-slate-500">
+                          <span className="truncate text-[11px] text-slate-500 dark:text-slate-400">
                             {v.channelTitle}
                           </span>
-                          <span className="ml-1 shrink-0 text-[11px] text-slate-400">
+                          <span className="ml-1 shrink-0 text-[11px] text-slate-400 dark:text-slate-500">
                             {timeAgo(v.publishedAt)}
                           </span>
                         </div>
                         {v.viewCount > 0 && (
-                          <span className="text-[11px] text-slate-400">
+                          <span className="text-[11px] text-slate-400 dark:text-slate-500">
                             조회수 {formatViewCount(v.viewCount)}
                           </span>
                         )}
@@ -512,8 +512,8 @@ export default function YoutubeList({
                 key="loading-more-indicator"
                 className="w-52 shrink-0 flex snap-start"
               >
-                <div className="flex h-full w-full flex-col items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white p-4 text-slate-500">
-                  <span className="h-6 w-6 animate-spin rounded-full border-2 border-slate-200 border-t-red-400" />
+                <div className="flex h-full w-full flex-col items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white p-4 text-slate-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-400">
+                  <span className="h-6 w-6 animate-spin rounded-full border-2 border-slate-200 border-t-red-400 dark:border-slate-600 dark:border-t-red-500" />
                   <span className="text-xs">불러오는 중...</span>
                 </div>
               </li>


### PR DESCRIPTION
## 변경 사항

### DarkModeToggle 컴포넌트
- 우측 상단 고정 (`fixed right-4 top-4 z-50`)
- 달 🌙 / 해 ☀️ SVG 아이콘 버튼
- `localStorage` 저장으로 새로고침 후에도 유지
- 저장값 없으면 시스템 `prefers-color-scheme` 자동 감지

### FOUC 방지
- `layout.tsx` `<head>`에 blocking script 주입 — hydration 전 동기 실행으로 테마 깜빡임 없음

### 다크모드 스타일 대응 (dark: 클래스)
- `page.tsx` — 제목, 스켈레톤, footer
- `StatBuildList.tsx` — 카드 배경, 제목, 검색 입력, 검색 결과, 빈 상태
- `SiteList.tsx` — 카드 배경, 사이트명, 카테고리 배지, 설명
- `YoutubeList.tsx` — 제목, 컨트롤 버튼, 스켈레톤, 영상 카드, 텍스트 전체

### StatBuildList 다크모드 가독성 보정
- `MutationObserver`로 다크모드 전환 즉시 감지
- 다크 배경에서 옅은 항목의 최소 opacity `0.12 → 0.28`
- 저opacity 항목 글자색 3단계 분기 (진한fill → white / 라이트모드 → slate-800 / 다크모드 → slate-200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)