### PR TITLE
fix(DarkModeToggle): hydration mismatch 완전 제거 및 UX 개선

### DIFF
--- a/client/app/globals.css
+++ b/client/app/globals.css
@@ -1,10 +1,18 @@
 @import "tailwindcss";
+@custom-variant dark (&:is(.dark, .dark *));
+
+.no-transition * {
+  transition: none !important;
+}
 
 :root {
   --background: #ffffff;
   --foreground: #111827;
 }
-
+.dark {
+  --background: #111827;
+  --foreground: #f9fafb;
+}
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
@@ -16,6 +24,7 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-family: var(--font-geist-sans), "Segoe UI", sans-serif;
+  user-select: none;
 }
 
 .fade-in {

--- a/client/components/DarkModeToggle.tsx
+++ b/client/components/DarkModeToggle.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+export default function DarkModeToggle() {
+  const toggle = () => {
+    const next = !document.documentElement.classList.contains("dark");
+    document.documentElement.classList.add("no-transition");
+    document.documentElement.classList.toggle("dark", next);
+    localStorage.setItem("theme", next ? "dark" : "light");
+    requestAnimationFrame(() => {
+      document.documentElement.classList.remove("no-transition");
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label="다크 모드 전환"
+      className="flex h-8 w-8 items-center justify-center rounded-full border border-slate-200 bg-white/90 text-slate-600 shadow-sm backdrop-blur transition hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-800/90 dark:text-slate-300 dark:hover:bg-slate-700"
+    >
+      {/* 해 - 다크모드일 때 표시 */}
+      <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 hidden dark:block" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d="M12 2.25a.75.75 0 0 1 .75.75v2.25a.75.75 0 0 1-1.5 0V3a.75.75 0 0 1 .75-.75ZM7.5 12a4.5 4.5 0 1 1 9 0 4.5 4.5 0 0 1-9 0ZM18.894 6.166a.75.75 0 0 0-1.06-1.06l-1.591 1.59a.75.75 0 1 0 1.06 1.061l1.591-1.59ZM21.75 12a.75.75 0 0 1-.75.75h-2.25a.75.75 0 0 1 0-1.5H21a.75.75 0 0 1 .75.75ZM17.834 18.894a.75.75 0 0 0 1.06-1.06l-1.59-1.591a.75.75 0 1 0-1.061 1.06l1.59 1.591ZM12 18a.75.75 0 0 1 .75.75V21a.75.75 0 0 1-1.5 0v-2.25A.75.75 0 0 1 12 18ZM7.758 17.303a.75.75 0 0 0-1.061-1.06l-1.591 1.59a.75.75 0 0 0 1.06 1.061l1.591-1.59ZM6 12a.75.75 0 0 1-.75.75H3a.75.75 0 0 1 0-1.5h2.25A.75.75 0 0 1 6 12ZM6.697 7.757a.75.75 0 0 0 1.06-1.06l-1.59-1.591a.75.75 0 0 0-1.061 1.06l1.59 1.591Z" />
+      </svg>
+      {/* 달 - 라이트모드일 때 표시 */}
+      <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 dark:hidden" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path fillRule="evenodd" d="M9.528 1.718a.75.75 0 0 1 .162.819A8.97 8.97 0 0 0 9 6a9 9 0 0 0 9 9 8.97 8.97 0 0 0 3.463-.69.75.75 0 0 1 .981.98 10.503 10.503 0 0 1-9.694 6.46c-5.799 0-10.5-4.7-10.5-10.5 0-4.368 2.667-8.112 6.46-9.694a.75.75 0 0 1 .818.162Z" clipRule="evenodd" />
+      </svg>
+    </button>
+  );
+}


### PR DESCRIPTION
## 변경 사항

### DarkModeToggle 리빌딩
- React state 완전 제거 → SSR/CSR 렌더 결과 항상 동일
- 두 SVG 항상 렌더링 + `dark:hidden` CSS 토글 → hydration mismatch 원천 차단
- `aria-label` 고정 문자열로 변경

### globals.css
- `@custom-variant dark` 위치를 `@import "tailwindcss"` 직후로 이동 (`:is` 사용)
- `.no-transition * { transition: none !important }` — 다크모드 전환 시 즉시 바뀜
- `user-select: none` 전역 적용 — 텍스트 드래그 방지

🤖 Generated with [Claude Code](https://claude.com/claude-code)