### PR TITLE
fix(DarkModeToggle): hydration mismatch 제거 및 즉시 전환

### DIFF
--- a/client/components/DarkModeToggle.tsx
+++ b/client/components/DarkModeToggle.tsx
@@ -6,10 +6,13 @@ export default function DarkModeToggle() {
     const style = document.createElement("style");
     style.textContent = "* { transition: none !important; }";
     document.head.appendChild(style);
-    document.documentElement.classList.toggle("dark", next);
-    localStorage.setItem("theme", next ? "dark" : "light");
-    void document.documentElement.offsetHeight;
-    document.head.removeChild(style);
+    try {
+      document.documentElement.classList.toggle("dark", next);
+      localStorage.setItem("theme", next ? "dark" : "light");
+      void document.documentElement.offsetHeight;
+    } finally {
+      document.head.removeChild(style);
+    }
   };
 
   return (

--- a/client/components/DarkModeToggle.tsx
+++ b/client/components/DarkModeToggle.tsx
@@ -3,12 +3,13 @@
 export default function DarkModeToggle() {
   const toggle = () => {
     const next = !document.documentElement.classList.contains("dark");
-    document.documentElement.classList.add("no-transition");
+    const style = document.createElement("style");
+    style.textContent = "* { transition: none !important; }";
+    document.head.appendChild(style);
     document.documentElement.classList.toggle("dark", next);
     localStorage.setItem("theme", next ? "dark" : "light");
-    requestAnimationFrame(() => {
-      document.documentElement.classList.remove("no-transition");
-    });
+    void document.documentElement.offsetHeight;
+    document.head.removeChild(style);
   };
 
   return (
@@ -18,11 +19,9 @@ export default function DarkModeToggle() {
       aria-label="다크 모드 전환"
       className="flex h-8 w-8 items-center justify-center rounded-full border border-slate-200 bg-white/90 text-slate-600 shadow-sm backdrop-blur transition hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-800/90 dark:text-slate-300 dark:hover:bg-slate-700"
     >
-      {/* 해 - 다크모드일 때 표시 */}
       <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 hidden dark:block" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
         <path d="M12 2.25a.75.75 0 0 1 .75.75v2.25a.75.75 0 0 1-1.5 0V3a.75.75 0 0 1 .75-.75ZM7.5 12a4.5 4.5 0 1 1 9 0 4.5 4.5 0 0 1-9 0ZM18.894 6.166a.75.75 0 0 0-1.06-1.06l-1.591 1.59a.75.75 0 1 0 1.06 1.061l1.591-1.59ZM21.75 12a.75.75 0 0 1-.75.75h-2.25a.75.75 0 0 1 0-1.5H21a.75.75 0 0 1 .75.75ZM17.834 18.894a.75.75 0 0 0 1.06-1.06l-1.59-1.591a.75.75 0 1 0-1.061 1.06l1.59 1.591ZM12 18a.75.75 0 0 1 .75.75V21a.75.75 0 0 1-1.5 0v-2.25A.75.75 0 0 1 12 18ZM7.758 17.303a.75.75 0 0 0-1.061-1.06l-1.591 1.59a.75.75 0 0 0 1.06 1.061l1.591-1.59ZM6 12a.75.75 0 0 1-.75.75H3a.75.75 0 0 1 0-1.5h2.25A.75.75 0 0 1 6 12ZM6.697 7.757a.75.75 0 0 0 1.06-1.06l-1.59-1.591a.75.75 0 0 0-1.061 1.06l1.59 1.591Z" />
       </svg>
-      {/* 달 - 라이트모드일 때 표시 */}
       <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 dark:hidden" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
         <path fillRule="evenodd" d="M9.528 1.718a.75.75 0 0 1 .162.819A8.97 8.97 0 0 0 9 6a9 9 0 0 0 9 9 8.97 8.97 0 0 0 3.463-.69.75.75 0 0 1 .981.98 10.503 10.503 0 0 1-9.694 6.46c-5.799 0-10.5-4.7-10.5-10.5 0-4.368 2.667-8.112 6.46-9.694a.75.75 0 0 1 .818.162Z" clipRule="evenodd" />
       </svg>


### PR DESCRIPTION
## 변경 사항

- React state/useEffect 완전 제거 → SSR/CSR 렌더 항상 동일 → hydration mismatch 원천 차단
- 두 SVG 항상 렌더링, `dark:hidden` / `hidden dark:block` CSS로 아이콘 토글
- `aria-label` 고정 문자열
- `<style>` 태그 주입 + `offsetHeight` reflow 강제 → transition 없이 즉시 전환

🤖 Generated with [Claude Code](https://claude.com/claude-code)