### PR TITLE
fix(class-summary): DISABLE_CLASS_SUMMARY 전용 env로 분리

### DIFF
--- a/server/src/class-summary/class-summary.service.ts
+++ b/server/src/class-summary/class-summary.service.ts
@@ -7,7 +7,7 @@ import { REDIS_CLIENT } from '../redis/redis.module';
 import axios from 'axios';
 import * as cheerio from 'cheerio';
 import { GoogleGenerativeAI } from '@google/generative-ai';
-import { isLocalQuotaApisDisabled } from '../common/local-dev-flags';
+import { isClassSummaryDisabled } from '../common/local-dev-flags';
 import { ClassSummaryRepository } from './class-summary.repository';
 
 // 직업별 인벤 게시판 ID (기획.md 기준)
@@ -58,7 +58,7 @@ const hashKey = (className: string) => `class-summary:hash:${className}`;
 export class ClassSummaryService implements OnModuleInit {
   private readonly logger = new Logger(ClassSummaryService.name);
   private readonly genAI: GoogleGenerativeAI | null;
-  private readonly quotaApisDisabled: boolean;
+  private readonly disabled: boolean;
   private isRunning = false; // 동시 실행 방지
 
   constructor(
@@ -66,7 +66,7 @@ export class ClassSummaryService implements OnModuleInit {
     @Inject(REDIS_CLIENT) private readonly redis: Redis,
     private readonly config: ConfigService,
   ) {
-    this.quotaApisDisabled = isLocalQuotaApisDisabled(config);
+    this.disabled = isClassSummaryDisabled(config);
     const apiKey = this.config.get<string>('GEMINI_API_KEY');
     if (apiKey) {
       this.genAI = new GoogleGenerativeAI(apiKey);
@@ -77,9 +77,9 @@ export class ClassSummaryService implements OnModuleInit {
   }
 
   async onModuleInit() {
-    if (this.quotaApisDisabled) {
+    if (this.disabled) {
       this.logger.log(
-        'LOCAL_DISABLE_QUOTA_APIS 활성화 — 초기 직업 크롤링 스킵',
+        'DISABLE_CLASS_SUMMARY 활성화 — 초기 직업 크롤링 스킵',
       );
       return;
     }
@@ -98,9 +98,9 @@ export class ClassSummaryService implements OnModuleInit {
   /** 매 시간 정각 실행 — 29개 직업을 60분에 걸쳐 분산 처리 */
   @Cron('0 0 * * * *')
   async scheduledRun() {
-    if (this.quotaApisDisabled) {
+    if (this.disabled) {
       this.logger.log(
-        'LOCAL_DISABLE_QUOTA_APIS 활성화 — 시간별 직업 크롤링 스킵',
+        'DISABLE_CLASS_SUMMARY 활성화 — 시간별 직업 크롤링 스킵',
       );
       return;
     }
@@ -111,9 +111,9 @@ export class ClassSummaryService implements OnModuleInit {
 
   /** 전체 직업 순차 처리 */
   async runAll() {
-    if (this.quotaApisDisabled) {
+    if (this.disabled) {
       this.logger.log(
-        'LOCAL_DISABLE_QUOTA_APIS 활성화 — Gemini 직업 요약 갱신 스킵',
+        'DISABLE_CLASS_SUMMARY 활성화 — Gemini 직업 요약 갱신 스킵',
       );
       return;
     }

--- a/server/src/common/local-dev-flags.ts
+++ b/server/src/common/local-dev-flags.ts
@@ -2,8 +2,16 @@ import { ConfigService } from '@nestjs/config';
 
 const TRUE_VALUES = new Set(['1', 'true', 'yes', 'on']);
 
-export function isLocalQuotaApisDisabled(config: ConfigService): boolean {
-  const raw = config.get<string>('LOCAL_DISABLE_QUOTA_APIS');
+function isTrueEnv(config: ConfigService, key: string): boolean {
+  const raw = config.get<string>(key);
   if (!raw) return false;
   return TRUE_VALUES.has(raw.trim().toLowerCase());
+}
+
+export function isLocalQuotaApisDisabled(config: ConfigService): boolean {
+  return isTrueEnv(config, 'LOCAL_DISABLE_QUOTA_APIS');
+}
+
+export function isClassSummaryDisabled(config: ConfigService): boolean {
+  return isTrueEnv(config, 'DISABLE_CLASS_SUMMARY');
 }


### PR DESCRIPTION
## 배경

`LOCAL_DISABLE_QUOTA_APIS=true`로 인벤 크롤링/Gemini를 끄려 하면 `StreamersService`(YouTube)까지 함께 비활성화되는 문제가 있었음.

## 변경 사항

- `local-dev-flags.ts`에 `isClassSummaryDisabled()` 함수 추가 (`DISABLE_CLASS_SUMMARY` env 읽음)
- `ClassSummaryService`가 `LOCAL_DISABLE_QUOTA_APIS` 대신 `DISABLE_CLASS_SUMMARY`를 바라보도록 변경

## EC2 적용 방법

배포 후 `.env`에 추가하고 컨테이너 재시작:
```
DISABLE_CLASS_SUMMARY=true
```