### PR TITLE
ci(deploy): Docker BuildKit GHA 캐시 적용 및 SSM 폴링 간격 단축

### DIFF
--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -49,8 +49,13 @@ jobs:
           ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG ./server
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker buildx create --use
+          docker buildx build \
+            --cache-from type=gha \
+            --cache-to type=gha,mode=max \
+            --tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
+            --push \
+            ./server
 
       - name: Deploy to EC2 via SSM
         env:

--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -96,20 +96,20 @@ jobs:
 
           # 최대 3분 폴링 (EC2는 pull+start만 하므로 충분)
           wait_exit=1
-          for i in $(seq 1 18); do
+          for i in $(seq 1 36); do
             status=$(aws ssm get-command-invocation \
               --region "$AWS_REGION" \
               --command-id "$command_id" \
               --instance-id "$EC2_INSTANCE_ID" \
               --query 'Status' \
               --output text 2>/dev/null || echo "Pending")
-            echo "[${i}/18] SSM status: $status"
+            echo "[${i}/36] SSM status: $status"
             if [ "$status" = "Success" ]; then
               wait_exit=0; break
             elif [ "$status" = "Failed" ] || [ "$status" = "Cancelled" ] || [ "$status" = "TimedOut" ]; then
               wait_exit=1; break
             fi
-            sleep 10
+            sleep 5
           done
 
           aws ssm get-command-invocation \


### PR DESCRIPTION
## Summary

main-post-merge 워크플로우 실행 시간 단축을 위한 두 가지 최적화.

- PR #219 포함: `ci/optimize-docker-build` → `ci/cd`

## 변경 내용

**Docker BuildKit GHA 캐시 적용**
- GitHub Actions는 매 실행마다 새 runner가 생성되어 Docker 레이어 캐시가 초기화됨
- BuildKit GHA 캐시로 레이어를 Actions 캐시 스토리지에 저장
- `package-lock.json` 변경 없을 시 `npm ci --omit=dev` 레이어 캐시 히트

**SSM 폴링 간격 단축**: `sleep 10` → `sleep 5` (최대 대기 3분 유지)

## 예상 효과

| 스텝 | 현재 | 변경 후 |
|------|------|---------|
| Install server deps | 20초 | 20초 (이미 캐시 적용) |
| Build and push Docker image to ECR | 59초 | **20초** (캐시 히트 시) |
| Deploy to EC2 via SSM | 44초 | **39초** (폴링 5초 단축) |
| **합계** | **123초** | **79초** |

※ 첫 실행 또는 `package-lock.json` 변경 시 Docker 캐시 미적용으로 기존과 동일

## Test plan

- [ ] 머지 후 main-post-merge 워크플로우 수동 실행
- [ ] 두 번째 실행 시 Build and push 스텝 시간 단축 확인
- [ ] ECR 이미지 정상 배포 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)