### PR TITLE
fix(ci): db-migrate에서 psql에 stdin으로 SQL 전달

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -39,11 +39,12 @@ jobs:
           set -e
 
           # Script to run on the remote EC2 host.
+          # SQL 파일은 호스트(EC2)에 있으므로 -f(컨테이너 내부 경로) 대신 stdin으로 전달
           remote_script="cd /home/ubuntu/daloa \
             && git pull origin main \
             && test -f \"$SQL_FILE\" \
             && set -a && source .env && set +a \
-            && docker exec -i daloa-postgres psql -U \"\$DB_USER\" -d \"\$DB_NAME\" -f \"$SQL_FILE\" \
+            && docker exec -i daloa-postgres psql -U \"\$DB_USER\" -d \"\$DB_NAME\" < \"$SQL_FILE\" \
             && echo MIGRATION_OK"
 
           if [ "$RESTART_NEST" = "true" ]; then


### PR DESCRIPTION
@
## 문제

`db-migrate` 워크플로우 실행 시 실패:
```
StdErr: ... failed to run commands: exit status 1
```

`docker exec -i daloa-postgres psql ... -f "$SQL_FILE"` 에서 `-f`는 **postgres 컨테이너 내부 경로**를 찾는데, SQL 파일은 **호스트(EC2)** 의 `/home/ubuntu/daloa/...`에 있어 파일을 못 찾아 실패.

## 수정

`-f "$SQL_FILE"` → stdin 리다이렉트 `< "$SQL_FILE"`.
`docker exec -i`로 이미 stdin이 컨테이너에 연결돼 있으므로, 호스트의 SQL 파일 내용이 psql로 전달됨.

## 머지 후

site-finder 테이블 생성 마이그레이션 실행:
```
gh workflow run db-migrate.yml -f sql_file=site-finder/migrations/001_create_inven_tables.sql -f restart_nest=true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@