### PR TITLE
ci(deploy): 배포 후 EC2 옛 nest 이미지 자동 정리

### DIFF
--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -81,6 +81,7 @@ jobs:
           docker pull ${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}
           docker compose up -d
           docker restart daloa-nginx
+          docker images '${ECR_REGISTRY}/${ECR_REPOSITORY}' --format '{{.Tag}} {{.ID}}' | grep -v '${IMAGE_TAG}' | awk '{print \$2}' | xargs -r docker rmi -f || true
           docker image prune -f"
 
           encoded=$(printf '%s' "$remote_script" | base64 -w0)


### PR DESCRIPTION
## 문제

EC2에 옛 배포 이미지(`daloa-nest:<sha>`)가 계속 쌓임. 배포 스크립트의 `docker image prune -f`는 **dangling(태그 없는) 이미지만** 지워서, 태그가 달린 옛 버전은 정리 안 됨. (실제로 EC2에 5개까지 쌓여 수동 삭제함)

> ECR lifecycle(클라우드)과 EC2 호스트 이미지는 별개. lifecycle은 EC2를 정리하지 못함.

## 수정

`docker compose up -d` 이후, **현재 배포 태그를 제외한** `daloa-nest` 이미지를 삭제하는 단계 추가:
- `docker images` 목록에서 현재 IMAGE_TAG를 `grep -v`로 제외 → `docker rmi -f`
- `|| true`로 실패해도 배포 중단 안 됨
- 결과: EC2엔 현재 실행 버전 1개만 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)
