### PR TITLE
refactor(class-summary): Redis 해시/일일카운터 제거

### DIFF
--- a/server/src/class-summary/class-summary.service.ts
+++ b/server/src/class-summary/class-summary.service.ts
@@ -1,9 +1,6 @@
-﻿import { Injectable, Inject, Logger, OnModuleInit } from '@nestjs/common';
+﻿import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Cron } from '@nestjs/schedule';
-import type { Redis } from 'ioredis';
-import { createHash } from 'crypto';
-import { REDIS_CLIENT } from '../redis/redis.module';
 import axios from 'axios';
 import * as cheerio from 'cheerio';
 import { GoogleGenerativeAI } from '@google/generative-ai';
@@ -51,9 +48,6 @@ const CRAWL_PAGES = 3;
 // 직업 간 처리 간격 (70초 — 무료 티어 RPM 여유 확보)
 const STAGGER_DELAY_MS = 70_000;
 
-// Redis 키: 직업별 크롤링 제목 해시
-const hashKey = (className: string) => `class-summary:hash:${className}`;
-
 @Injectable()
 export class ClassSummaryService implements OnModuleInit {
   private readonly logger = new Logger(ClassSummaryService.name);
@@ -63,7 +57,6 @@ export class ClassSummaryService implements OnModuleInit {
 
   constructor(
     private readonly classSummaryRepo: ClassSummaryRepository,
-    @Inject(REDIS_CLIENT) private readonly redis: Redis,
     private readonly config: ConfigService,
   ) {
     this.disabled = isClassSummaryDisabled(config);
@@ -140,7 +133,7 @@ export class ClassSummaryService implements OnModuleInit {
     }
   }
 
-  /** 단일 직업: 크롤링 → 해시 비교 → 변경 시에만 Gemini 호출. true=Gemini 호출함 */
+  /** 단일 직업: 크롤링 → Gemini 호출. true=Gemini 호출함 */
   private async processClass(className: string): Promise<boolean> {
     const titles = await this.crawlTitles(className);
     if (titles.length === 0) {
@@ -148,27 +141,11 @@ export class ClassSummaryService implements OnModuleInit {
       return false;
     }
 
-    const currentHash = createHash('md5')
-      .update(titles.join('\n'))
-      .digest('hex');
-
-    // DB에 데이터가 있는 경우에만 해시 비교로 스킵
-    if (await this.classSummaryRepo.exists(className)) {
-      const prevHash = await this.redis.get(hashKey(className));
-      if (prevHash === currentHash) {
-        this.logger.debug(`[${className}] 변경 없음 — Gemini 스킵`);
-        return false;
-      }
-    }
-
     const summary = await this.summarize(className, titles);
-    if (!summary) return true; // Gemini 호출은 했으므로 true
+    if (!summary) return true;
 
     await this.classSummaryRepo.upsert(className, summary);
-
-    await this.redis.set(hashKey(className), currentHash, 'EX', 25 * 60 * 60);
-
-    this.logger.log(`[${className}] 새 글 감지 → 한줄평 업데이트 완료`);
+    this.logger.log(`[${className}] 한줄평 업데이트 완료`);
     return true;
   }
 
@@ -214,18 +191,6 @@ export class ClassSummaryService implements OnModuleInit {
   ): Promise<string | null> {
     if (!this.genAI) return null;
 
-    // 일일 한도 체크 (무료 티어: 20회/일 → 안전 마진 18회)
-    const MAX_DAILY_CALLS = 18;
-    const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
-    const dailyKey = `gemini:daily-count:${today}`;
-    const currentCount = parseInt((await this.redis.get(dailyKey)) ?? '0', 10);
-    if (currentCount >= MAX_DAILY_CALLS) {
-      this.logger.warn(
-        `[${className}] 오늘 Gemini 일일 한도(${MAX_DAILY_CALLS}회) 도달 — 스킵`,
-      );
-      return null;
-    }
-
     const model = this.genAI.getGenerativeModel({
       model: 'gemini-2.5-flash',
     });
@@ -241,9 +206,6 @@ export class ClassSummaryService implements OnModuleInit {
       try {
         const result = await model.generateContent(prompt);
         const text = result.response.text().trim().replace(/\n.*/s, '');
-        // 성공 시 카운터 증가, TTL 25시간
-        await this.redis.incr(dailyKey);
-        await this.redis.expire(dailyKey, 25 * 60 * 60);
         return text;
       } catch (e: unknown) {
         const msg = toErrorMessage(e);


### PR DESCRIPTION
## Summary
- `class-summary:hash:{className}` 키 (크롤링 제목 해시 비교) 제거
- `gemini:daily-count:{date}` 키 (일일 18회 한도 카운터) 제거
- Redis 주입(`@Inject(REDIS_CLIENT)`) 및 관련 import(`ioredis`, `crypto`) 제거

## 변경 이유
해시 비교·일일카운터 불필요 — 매 시간 크롤링 후 Gemini 직접 호출로 단순화

## Test plan
- [ ] `npm run build` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)