### PR TITLE
feat(admin): 사이트 관리 UI 개편 + 클릭/방문 통계 개선

### DIFF
--- a/client/app/admin/monitoring/page.tsx
+++ b/client/app/admin/monitoring/page.tsx
@@ -1,7 +1,15 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
 
 interface ContainerStat {
   name: string;
@@ -45,12 +53,22 @@ type Dashboard = {
   };
   siteClickSeries: { minute: string; count: number }[];
   youtubeClickSeries: { minute: string; count: number }[];
-  sectionSeries: { minute: string; label: string; avgDurationMs: number; count: number }[];
+  sectionSeries: {
+    minute: string;
+    label: string;
+    avgDurationMs: number;
+    count: number;
+  }[];
   pageVisits: { path: string; device_type: string; count: number }[];
   countryVisits: { countryCode: string; count: number }[];
   osVisits: { osName: string; count: number }[];
   browserVisits: { browserName: string; count: number }[];
-  siteClicks: { siteName: string; siteHref: string; siteCategory: string; clickCount: number }[];
+  siteClicks: {
+    siteName: string;
+    siteHref: string;
+    siteCategory: string;
+    clickCount: number;
+  }[];
   pageVisitSeries?: { day: string; count: number }[];
   youtubeClickTotal?: number;
 };
@@ -104,18 +122,28 @@ let hostCache: HostStats | null = null;
 const containerHistoryCache: Record<string, ContainerHistoryPoint[]> = {};
 
 export default function MonitoringPage() {
-  const [data, setData] = useState<Dashboard>(monitoringCache ?? EMPTY_DASHBOARD);
+  const [data, setData] = useState<Dashboard>(
+    monitoringCache ?? EMPTY_DASHBOARD,
+  );
   const [loading, setLoading] = useState(monitoringCache === null);
   const [liveVisitDelta, setLiveVisitDelta] = useState(0);
   const [deviceTab, setDeviceTab] = useState<"device" | "browser">("device");
   const [activeChart, setActiveChart] = useState<string | null>(null);
   const [pageVisitDays, setPageVisitDays] = useState<7 | 30>(7);
-  const [sectionTab, setSectionTab] = useState<"sites" | "stat-builds" | "youtube">("sites");
-  const [containers, setContainers] = useState<ContainerStat[]>(containersCache ?? []);
+  const [sectionTab, setSectionTab] = useState<
+    "sites" | "stat-builds" | "youtube"
+  >("sites");
+  const [containers, setContainers] = useState<ContainerStat[]>(
+    containersCache ?? [],
+  );
   const [host, setHost] = useState<HostStats | null>(hostCache);
-  const [containersLoading, setContainersLoading] = useState(containersCache === null);
+  const [containersLoading, setContainersLoading] = useState(
+    containersCache === null,
+  );
   const [containerTab, setContainerTab] = useState<string>("전체");
-  const [containerHistory, setContainerHistory] = useState<ContainerHistoryPoint[]>([]);
+  const [containerHistory, setContainerHistory] = useState<
+    ContainerHistoryPoint[]
+  >([]);
   const [historyLoading, setHistoryLoading] = useState(false);
   const hasLoadedRef = useRef(false);
   const prevVisitCountRef = useRef(0);
@@ -125,7 +153,10 @@ export default function MonitoringPage() {
     async function load(initial = false) {
       if (initial && monitoringCache === null) setLoading(true);
       try {
-        const dashboardRes = await fetch("/api/admin/monitoring/dashboard?days=7", { cache: "no-store" });
+        const dashboardRes = await fetch(
+          "/api/admin/monitoring/dashboard?days=7",
+          { cache: "no-store" },
+        );
         if (!alive) return;
 
         const dashboard = dashboardRes.ok
@@ -170,9 +201,13 @@ export default function MonitoringPage() {
     let alive = true;
     async function loadContainers() {
       try {
-        const res = await fetch("/api/admin/monitoring/containers", { cache: "no-store" });
+        const res = await fetch("/api/admin/monitoring/containers", {
+          cache: "no-store",
+        });
         if (!alive || !res.ok) return;
-        const raw = (await res.json()) as ContainerStat[] | { containers: ContainerStat[]; host: HostStats | null };
+        const raw = (await res.json()) as
+          | ContainerStat[]
+          | { containers: ContainerStat[]; host: HostStats | null };
         const parsed = Array.isArray(raw)
           ? { containers: raw, host: null }
           : { containers: raw.containers ?? [], host: raw.host ?? null };
@@ -188,7 +223,10 @@ export default function MonitoringPage() {
     }
     void loadContainers();
     const timer = setInterval(() => void loadContainers(), 10_000);
-    return () => { alive = false; clearInterval(timer); };
+    return () => {
+      alive = false;
+      clearInterval(timer);
+    };
   }, []);
 
   useEffect(() => {
@@ -221,7 +259,9 @@ export default function MonitoringPage() {
       }
     }
     void loadHistory();
-    return () => { alive = false; };
+    return () => {
+      alive = false;
+    };
   }, [containerTab]);
 
   useEffect(() => {
@@ -238,7 +278,8 @@ export default function MonitoringPage() {
           ...prev,
           sectionSeries: dashboard.sectionSeries ?? prev.sectionSeries,
           pageVisitSeries: dashboard.pageVisitSeries ?? prev.pageVisitSeries,
-          youtubeClickTotal: dashboard.youtubeClickTotal ?? prev.youtubeClickTotal,
+          youtubeClickTotal:
+            dashboard.youtubeClickTotal ?? prev.youtubeClickTotal,
         }));
       } catch {
         // Keep existing data if fetch fails.
@@ -250,7 +291,10 @@ export default function MonitoringPage() {
     };
   }, [pageVisitDays]);
 
-  const siteClickTotal = useMemo(() => data.siteClicks.reduce((sum, item) => sum + item.clickCount, 0), [data.siteClicks]);
+  const siteClickTotal = useMemo(
+    () => data.siteClicks.reduce((sum, item) => sum + item.clickCount, 0),
+    [data.siteClicks],
+  );
 
   const deviceSummary = useMemo(() => {
     const summaryCounts = data.summary.deviceCounts;
@@ -259,7 +303,13 @@ export default function MonitoringPage() {
       const desktop = summaryCounts.desktop ?? 0;
       const tablet = summaryCounts.tablet ?? 0;
       const bot = summaryCounts.bot ?? 0;
-      return { total: mobile + desktop + tablet + bot, mobile, desktop, tablet, bot };
+      return {
+        total: mobile + desktop + tablet + bot,
+        mobile,
+        desktop,
+        tablet,
+        bot,
+      };
     }
 
     let mobile = 0;
@@ -272,7 +322,13 @@ export default function MonitoringPage() {
       else if (row.device_type === "tablet") tablet += row.count;
       else if (row.device_type === "bot") bot += row.count;
     }
-    return { total: mobile + desktop + tablet + bot, mobile, desktop, tablet, bot };
+    return {
+      total: mobile + desktop + tablet + bot,
+      mobile,
+      desktop,
+      tablet,
+      bot,
+    };
   }, [data.pageVisits, data.summary.deviceCounts]);
 
   const deviceItems = useMemo(() => {
@@ -290,7 +346,12 @@ export default function MonitoringPage() {
   );
 
   const siteClickShareItems = useMemo(
-    () => toFixedHundred(data.siteClicks.slice(0, 4).map((item) => ({ ...item, count: item.clickCount }))),
+    () =>
+      toFixedHundred(
+        data.siteClicks
+          .slice(0, 4)
+          .map((item) => ({ ...item, count: item.clickCount })),
+      ),
     [data.siteClicks],
   );
 
@@ -305,7 +366,12 @@ export default function MonitoringPage() {
       const name = row.osName.toLowerCase();
       if (name.includes("windows")) counters.Windows += row.count;
       else if (name.includes("linux")) counters["GNU/Linux"] += row.count;
-      else if (name.includes("ios") || name.includes("iphone") || name.includes("ipad")) counters.iOS += row.count;
+      else if (
+        name.includes("ios") ||
+        name.includes("iphone") ||
+        name.includes("ipad")
+      )
+        counters.iOS += row.count;
       else if (name.includes("mac")) counters.Mac += row.count;
     }
     return toFixedHundred([
@@ -316,14 +382,17 @@ export default function MonitoringPage() {
     ]);
   }, [data.osVisits]);
 
-  const normalizeLabel = (value: string) => (value.toUpperCase() === "UNKNOWN" ? "기타" : value);
+  const normalizeLabel = (value: string) =>
+    value.toUpperCase() === "UNKNOWN" ? "기타" : value;
 
   return (
     <div className="flex h-full flex-col">
       <div className="mb-5 shrink-0 flex items-start justify-between gap-4">
         <div>
           <h1 className="admin-page-title">모니터링</h1>
-          <p className="admin-page-subtitle mt-1">운영 상태와 추세를 빠르게 확인합니다.</p>
+          <p className="admin-page-subtitle mt-1">
+            운영 상태와 추세를 빠르게 확인합니다.
+          </p>
         </div>
         <div className="flex shrink-0 items-center pt-1 text-xs text-[color:var(--admin-text-muted)]">
           평균 응답
@@ -346,13 +415,20 @@ export default function MonitoringPage() {
           <div className="mb-2 flex items-center justify-between">
             <p className="text-sm font-semibold">컨테이너 현황</p>
             <div className="flex gap-1">
-              <button type="button" onClick={() => setContainerTab("전체")}
-                className={`admin-btn admin-btn-sm ${containerTab === "전체" ? "admin-btn-primary" : "admin-btn-secondary"}`}>
+              <button
+                type="button"
+                onClick={() => setContainerTab("전체")}
+                className={`admin-btn admin-btn-sm ${containerTab === "전체" ? "admin-btn-primary" : "admin-btn-secondary"}`}
+              >
                 전체
               </button>
               {containers.map((c) => (
-                <button key={c.name} type="button" onClick={() => setContainerTab(c.label)}
-                  className={`admin-btn admin-btn-sm ${containerTab === c.label ? "admin-btn-primary" : "admin-btn-secondary"}`}>
+                <button
+                  key={c.name}
+                  type="button"
+                  onClick={() => setContainerTab(c.label)}
+                  className={`admin-btn admin-btn-sm ${containerTab === c.label ? "admin-btn-primary" : "admin-btn-secondary"}`}
+                >
                   {c.label}
                 </button>
               ))}
@@ -361,38 +437,74 @@ export default function MonitoringPage() {
 
           {containerTab === "전체" ? (
             containersLoading ? (
-              <p className="text-xs text-[color:var(--admin-text-muted)]">불러오는 중...</p>
+              <p className="text-xs text-[color:var(--admin-text-muted)]">
+                불러오는 중...
+              </p>
             ) : containers.length === 0 ? (
-              <p className="text-xs text-[color:var(--admin-text-muted)]">컨테이너 데이터 없음 (EC2 환경에서만 표시됩니다)</p>
+              <p className="text-xs text-[color:var(--admin-text-muted)]">
+                컨테이너 데이터 없음 (EC2 환경에서만 표시됩니다)
+              </p>
             ) : (
               <div className="space-y-3">
                 {host && (
                   <div className="rounded border border-[color:var(--admin-border)] bg-slate-50 p-2.5">
-                    <p className="mb-1.5 text-xs font-semibold text-[color:var(--admin-text)]">EC2 호스트 전체</p>
+                    <p className="mb-1.5 text-xs font-semibold text-[color:var(--admin-text)]">
+                      EC2 호스트 전체
+                    </p>
                     <div className="grid gap-1 text-xs text-[color:var(--admin-text-muted)] sm:grid-cols-3">
-                      <p>CPU <span className="font-medium text-[color:var(--admin-text)]">{host.cpuPercent.toFixed(1)}%</span></p>
                       <p>
-                        메모리 <span className="font-medium text-[color:var(--admin-text)]">{host.memPercent.toFixed(1)}%</span>
-                        <span className="ml-1">({host.memUsedMb}MB / {host.memTotalMb}MB)</span>
+                        CPU{" "}
+                        <span className="font-medium text-[color:var(--admin-text)]">
+                          {host.cpuPercent.toFixed(1)}%
+                        </span>
                       </p>
                       <p>
-                        디스크 <span className="font-medium text-[color:var(--admin-text)]">{host.diskPercent}%</span>
-                        <span className="ml-1">({host.diskUsedGb}GB / {host.diskTotalGb}GB)</span>
+                        메모리{" "}
+                        <span className="font-medium text-[color:var(--admin-text)]">
+                          {host.memPercent.toFixed(1)}%
+                        </span>
+                        <span className="ml-1">
+                          ({host.memUsedMb}MB / {host.memTotalMb}MB)
+                        </span>
+                      </p>
+                      <p>
+                        디스크{" "}
+                        <span className="font-medium text-[color:var(--admin-text)]">
+                          {host.diskPercent}%
+                        </span>
+                        <span className="ml-1">
+                          ({host.diskUsedGb}GB / {host.diskTotalGb}GB)
+                        </span>
                       </p>
                     </div>
                   </div>
                 )}
                 <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
                   {containers.map((c) => (
-                    <div key={c.name} className="rounded border border-[color:var(--admin-border)] p-2.5">
+                    <div
+                      key={c.name}
+                      className="rounded border border-[color:var(--admin-border)] p-2.5"
+                    >
                       <p className="mb-1.5 text-xs font-semibold">{c.label}</p>
                       <div className="space-y-0.5 text-xs text-[color:var(--admin-text-muted)]">
-                        <p>CPU <span className="font-medium text-[color:var(--admin-text)]">{c.cpuPercent.toFixed(1)}%</span></p>
                         <p>
-                          메모리 <span className="font-medium text-[color:var(--admin-text)]">{c.memPercent.toFixed(1)}%</span>
-                          <span className="ml-1">({c.memUsedMb}MB / {c.memTotalMb}MB)</span>
+                          CPU{" "}
+                          <span className="font-medium text-[color:var(--admin-text)]">
+                            {c.cpuPercent.toFixed(1)}%
+                          </span>
                         </p>
-                        <p>NET ↓{c.netInMb}MB · ↑{c.netOutMb}MB</p>
+                        <p>
+                          메모리{" "}
+                          <span className="font-medium text-[color:var(--admin-text)]">
+                            {c.memPercent.toFixed(1)}%
+                          </span>
+                          <span className="ml-1">
+                            ({c.memUsedMb}MB / {c.memTotalMb}MB)
+                          </span>
+                        </p>
+                        <p>
+                          NET ↓{c.netInMb}MB · ↑{c.netOutMb}MB
+                        </p>
                       </div>
                     </div>
                   ))}
@@ -402,44 +514,92 @@ export default function MonitoringPage() {
           ) : (
             <div className="grid gap-3 md:grid-cols-2">
               <div>
-                <p className="mb-1 text-xs text-[color:var(--admin-text-muted)]">CPU % (7일)</p>
+                <p className="mb-1 text-xs text-[color:var(--admin-text-muted)]">
+                  CPU % (7일)
+                </p>
                 <div className="h-28">
                   {historyLoading ? (
-                    <div className="grid h-full place-items-center text-[11px] text-[color:var(--admin-text-muted)]">불러오는 중...</div>
+                    <div className="grid h-full place-items-center text-[11px] text-[color:var(--admin-text-muted)]">
+                      불러오는 중...
+                    </div>
                   ) : containerHistory.length === 0 ? (
-                    <div className="grid h-full place-items-center text-[11px] text-[color:var(--admin-text-muted)]">데이터 없음</div>
+                    <div className="grid h-full place-items-center text-[11px] text-[color:var(--admin-text-muted)]">
+                      데이터 없음
+                    </div>
                   ) : (
                     <ResponsiveContainer width="100%" height="100%">
-                      <AreaChart data={containerHistory}
+                      <AreaChart
+                        data={containerHistory}
                         onMouseEnter={() => setActiveChart("container-cpu")}
-                        onMouseLeave={() => setActiveChart(null)}>
+                        onMouseLeave={() => setActiveChart(null)}
+                      >
                         <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
-                        <XAxis dataKey="bucket" tick={{ fontSize: 9, fill: "#6b7280" }} />
-                        <YAxis tick={{ fontSize: 10, fill: "#6b7280" }} unit="%" />
-                        <Tooltip active={activeChart === "container-cpu"} formatter={(v) => [`${v ?? 0}%`, "CPU"]} wrapperStyle={{ pointerEvents: "none" }} />
-                        <Area type="linear" dataKey="avgCpu" stroke="#2563eb" fill="#bfdbfe" name="CPU %" />
+                        <XAxis
+                          dataKey="bucket"
+                          tick={{ fontSize: 9, fill: "#6b7280" }}
+                        />
+                        <YAxis
+                          tick={{ fontSize: 10, fill: "#6b7280" }}
+                          unit="%"
+                        />
+                        <Tooltip
+                          active={activeChart === "container-cpu"}
+                          formatter={(v) => [`${v ?? 0}%`, "CPU"]}
+                          wrapperStyle={{ pointerEvents: "none" }}
+                        />
+                        <Area
+                          type="linear"
+                          dataKey="avgCpu"
+                          stroke="#2563eb"
+                          fill="#bfdbfe"
+                          name="CPU %"
+                        />
                       </AreaChart>
                     </ResponsiveContainer>
                   )}
                 </div>
               </div>
               <div>
-                <p className="mb-1 text-xs text-[color:var(--admin-text-muted)]">메모리 % (7일)</p>
+                <p className="mb-1 text-xs text-[color:var(--admin-text-muted)]">
+                  메모리 % (7일)
+                </p>
                 <div className="h-28">
                   {historyLoading ? (
-                    <div className="grid h-full place-items-center text-[11px] text-[color:var(--admin-text-muted)]">불러오는 중...</div>
+                    <div className="grid h-full place-items-center text-[11px] text-[color:var(--admin-text-muted)]">
+                      불러오는 중...
+                    </div>
                   ) : containerHistory.length === 0 ? (
-                    <div className="grid h-full place-items-center text-[11px] text-[color:var(--admin-text-muted)]">데이터 없음</div>
+                    <div className="grid h-full place-items-center text-[11px] text-[color:var(--admin-text-muted)]">
+                      데이터 없음
+                    </div>
                   ) : (
                     <ResponsiveContainer width="100%" height="100%">
-                      <AreaChart data={containerHistory}
+                      <AreaChart
+                        data={containerHistory}
                         onMouseEnter={() => setActiveChart("container-mem")}
-                        onMouseLeave={() => setActiveChart(null)}>
+                        onMouseLeave={() => setActiveChart(null)}
+                      >
                         <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
-                        <XAxis dataKey="bucket" tick={{ fontSize: 9, fill: "#6b7280" }} />
-                        <YAxis tick={{ fontSize: 10, fill: "#6b7280" }} unit="%" />
-                        <Tooltip active={activeChart === "container-mem"} formatter={(v) => [`${v ?? 0}%`, "메모리"]} wrapperStyle={{ pointerEvents: "none" }} />
-                        <Area type="linear" dataKey="avgMem" stroke="#7c3aed" fill="#ede9fe" name="메모리 %" />
+                        <XAxis
+                          dataKey="bucket"
+                          tick={{ fontSize: 9, fill: "#6b7280" }}
+                        />
+                        <YAxis
+                          tick={{ fontSize: 10, fill: "#6b7280" }}
+                          unit="%"
+                        />
+                        <Tooltip
+                          active={activeChart === "container-mem"}
+                          formatter={(v) => [`${v ?? 0}%`, "메모리"]}
+                          wrapperStyle={{ pointerEvents: "none" }}
+                        />
+                        <Area
+                          type="linear"
+                          dataKey="avgMem"
+                          stroke="#7c3aed"
+                          fill="#ede9fe"
+                          name="메모리 %"
+                        />
                       </AreaChart>
                     </ResponsiveContainer>
                   )}
@@ -453,25 +613,48 @@ export default function MonitoringPage() {
           <div className="admin-card p-3">
             <div className="mb-2 flex items-center justify-between">
               <p className="text-sm font-semibold">사이트 클릭 타임라인 (일)</p>
-              <span className="text-xs text-[color:var(--admin-text-muted)]">누적 {siteClickTotal.toLocaleString()}회</span>
+              <span className="text-xs text-[color:var(--admin-text-muted)]">
+                누적 {siteClickTotal.toLocaleString()}회
+              </span>
             </div>
             <div className="h-40">
               {loading ? (
-                <div className="grid h-full place-items-center text-sm text-[color:var(--admin-text-muted)]">불러오는 중...</div>
+                <div className="grid h-full place-items-center text-sm text-[color:var(--admin-text-muted)]">
+                  불러오는 중...
+                </div>
               ) : data.siteClickSeries.length === 0 ? (
-                <div className="grid h-full place-items-center text-sm text-[color:var(--admin-text-muted)]">데이터 없음</div>
+                <div className="grid h-full place-items-center text-sm text-[color:var(--admin-text-muted)]">
+                  데이터 없음
+                </div>
               ) : (
-                <ResponsiveContainer width="100%" height="100%" minWidth={220} minHeight={120}>
+                <ResponsiveContainer
+                  width="100%"
+                  height="100%"
+                  minWidth={220}
+                  minHeight={120}
+                >
                   <AreaChart
                     data={data.siteClickSeries}
                     onMouseEnter={() => setActiveChart("site-click")}
                     onMouseLeave={() => setActiveChart(null)}
                   >
                     <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
-                    <XAxis dataKey="minute" tick={{ fontSize: 10, fill: "#6b7280" }} />
+                    <XAxis
+                      dataKey="minute"
+                      tick={{ fontSize: 10, fill: "#6b7280" }}
+                    />
                     <YAxis tick={{ fontSize: 10, fill: "#6b7280" }} />
-                    <Tooltip active={activeChart === "site-click"} wrapperStyle={{ pointerEvents: "none" }} />
-                    <Area type="linear" dataKey="count" stroke="#2563eb" fill="#bfdbfe" name="사이트 클릭" />
+                    <Tooltip
+                      active={activeChart === "site-click"}
+                      wrapperStyle={{ pointerEvents: "none" }}
+                    />
+                    <Area
+                      type="linear"
+                      dataKey="count"
+                      stroke="#2563eb"
+                      fill="#bfdbfe"
+                      name="사이트 클릭"
+                    />
                   </AreaChart>
                 </ResponsiveContainer>
               )}
@@ -481,25 +664,48 @@ export default function MonitoringPage() {
           <div className="admin-card p-3">
             <div className="mb-2 flex items-center justify-between">
               <p className="text-sm font-semibold">유튜브 클릭 타임라인 (일)</p>
-              <span className="text-xs text-[color:var(--admin-text-muted)]">누적 {(data.youtubeClickTotal ?? 0).toLocaleString()}회</span>
+              <span className="text-xs text-[color:var(--admin-text-muted)]">
+                누적 {(data.youtubeClickTotal ?? 0).toLocaleString()}회
+              </span>
             </div>
             <div className="h-40">
               {loading ? (
-                <div className="grid h-full place-items-center text-sm text-[color:var(--admin-text-muted)]">불러오는 중...</div>
+                <div className="grid h-full place-items-center text-sm text-[color:var(--admin-text-muted)]">
+                  불러오는 중...
+                </div>
               ) : data.youtubeClickSeries.length === 0 ? (
-                <div className="grid h-full place-items-center text-sm text-[color:var(--admin-text-muted)]">데이터 없음</div>
+                <div className="grid h-full place-items-center text-sm text-[color:var(--admin-text-muted)]">
+                  데이터 없음
+                </div>
               ) : (
-                <ResponsiveContainer width="100%" height="100%" minWidth={220} minHeight={120}>
+                <ResponsiveContainer
+                  width="100%"
+                  height="100%"
+                  minWidth={220}
+                  minHeight={120}
+                >
                   <AreaChart
                     data={data.youtubeClickSeries}
                     onMouseEnter={() => setActiveChart("youtube-click")}
                     onMouseLeave={() => setActiveChart(null)}
                   >
                     <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
-                    <XAxis dataKey="minute" tick={{ fontSize: 10, fill: "#6b7280" }} />
+                    <XAxis
+                      dataKey="minute"
+                      tick={{ fontSize: 10, fill: "#6b7280" }}
+                    />
                     <YAxis tick={{ fontSize: 10, fill: "#6b7280" }} />
-                    <Tooltip active={activeChart === "youtube-click"} wrapperStyle={{ pointerEvents: "none" }} />
-                    <Area type="linear" dataKey="count" stroke="#ef4444" fill="#fecaca" name="유튜브 클릭" />
+                    <Tooltip
+                      active={activeChart === "youtube-click"}
+                      wrapperStyle={{ pointerEvents: "none" }}
+                    />
+                    <Area
+                      type="linear"
+                      dataKey="count"
+                      stroke="#ef4444"
+                      fill="#fecaca"
+                      name="유튜브 클릭"
+                    />
                   </AreaChart>
                 </ResponsiveContainer>
               )}
@@ -510,11 +716,18 @@ export default function MonitoringPage() {
             <div className="mb-2 flex items-center justify-between">
               <div className="flex items-center gap-2">
                 <p className="text-sm font-semibold">페이지 방문 추이 (일)</p>
-                <span className="text-xs text-[color:var(--admin-text-muted)]">누적 {data.summary.pageVisits.toLocaleString()}회</span>
+                <span className="text-xs text-[color:var(--admin-text-muted)]">
+                  누적 {data.summary.pageVisits.toLocaleString()}회
+                </span>
               </div>
               <div className="flex gap-1">
                 {([7, 30] as const).map((d) => (
-                  <button key={d} type="button" onClick={() => setPageVisitDays(d)} className={`admin-btn admin-btn-sm ${pageVisitDays === d ? "admin-btn-primary" : "admin-btn-secondary"}`}>
+                  <button
+                    key={d}
+                    type="button"
+                    onClick={() => setPageVisitDays(d)}
+                    className={`admin-btn admin-btn-sm ${pageVisitDays === d ? "admin-btn-primary" : "admin-btn-secondary"}`}
+                  >
                     {d}일
                   </button>
                 ))}
@@ -522,21 +735,42 @@ export default function MonitoringPage() {
             </div>
             <div className="h-20">
               {loading ? (
-                <div className="grid h-full place-items-center text-sm text-[color:var(--admin-text-muted)]">불러오는 중...</div>
+                <div className="grid h-full place-items-center text-sm text-[color:var(--admin-text-muted)]">
+                  불러오는 중...
+                </div>
               ) : (data.pageVisitSeries ?? []).length === 0 ? (
-                <div className="grid h-full place-items-center text-sm text-[color:var(--admin-text-muted)]">데이터 없음</div>
+                <div className="grid h-full place-items-center text-sm text-[color:var(--admin-text-muted)]">
+                  데이터 없음
+                </div>
               ) : (
-                <ResponsiveContainer width="100%" height="100%" minWidth={220} minHeight={120}>
+                <ResponsiveContainer
+                  width="100%"
+                  height="100%"
+                  minWidth={220}
+                  minHeight={120}
+                >
                   <AreaChart
                     data={data.pageVisitSeries}
                     onMouseEnter={() => setActiveChart("page-visit")}
                     onMouseLeave={() => setActiveChart(null)}
                   >
                     <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
-                    <XAxis dataKey="day" tick={{ fontSize: 10, fill: "#6b7280" }} />
+                    <XAxis
+                      dataKey="day"
+                      tick={{ fontSize: 10, fill: "#6b7280" }}
+                    />
                     <YAxis tick={{ fontSize: 10, fill: "#6b7280" }} />
-                    <Tooltip active={activeChart === "page-visit"} wrapperStyle={{ pointerEvents: "none" }} />
-                    <Area type="linear" dataKey="count" stroke="#7c3aed" fill="#ede9fe" name="페이지 방문" />
+                    <Tooltip
+                      active={activeChart === "page-visit"}
+                      wrapperStyle={{ pointerEvents: "none" }}
+                    />
+                    <Area
+                      type="linear"
+                      dataKey="count"
+                      stroke="#7c3aed"
+                      fill="#ede9fe"
+                      name="페이지 방문"
+                    />
                   </AreaChart>
                 </ResponsiveContainer>
               )}
@@ -545,45 +779,90 @@ export default function MonitoringPage() {
 
           <div className="admin-card p-3">
             <div className="mb-2 flex items-center justify-between">
-              <p className="text-sm font-semibold">기능별 응답 추이 (10분 자동점검)</p>
+              <p className="text-sm font-semibold">
+                기능별 응답 추이 (10분 자동점검)
+              </p>
               <div className="flex items-center gap-2">
-                <span className="text-xs text-[color:var(--admin-text-muted)]">최근 10일</span>
+                <span className="text-xs text-[color:var(--admin-text-muted)]">
+                  최근 10일
+                </span>
                 <div className="flex gap-1">
-                  {(["sites", "stat-builds", "youtube"] as const).map((name) => (
-                    <button key={name} type="button" onClick={() => setSectionTab(name)}
-                      className={`admin-btn admin-btn-sm ${sectionTab === name ? "admin-btn-primary" : "admin-btn-secondary"}`}>
-                      {name}
-                    </button>
-                  ))}
+                  {(["sites", "stat-builds", "youtube"] as const).map(
+                    (name) => (
+                      <button
+                        key={name}
+                        type="button"
+                        onClick={() => setSectionTab(name)}
+                        className={`admin-btn admin-btn-sm ${sectionTab === name ? "admin-btn-primary" : "admin-btn-secondary"}`}
+                      >
+                        {name}
+                      </button>
+                    ),
+                  )}
                 </div>
               </div>
             </div>
             {(() => {
-              const series = data.sectionSeries.filter((item) => item.label === sectionTab);
-              const latest = series.length > 0 ? series[series.length - 1] : null;
-              const totalCount = series.reduce((sum, item) => sum + item.count, 0);
+              const series = data.sectionSeries.filter(
+                (item) => item.label === sectionTab,
+              );
+              const latest =
+                series.length > 0 ? series[series.length - 1] : null;
+              const totalCount = series.reduce(
+                (sum, item) => sum + item.count,
+                0,
+              );
               return (
                 <>
                   <div className="mb-1 flex justify-end">
                     <span className="text-[11px] text-[color:var(--admin-text-muted)]">
-                      {latest ? `${latest.avgDurationMs}ms · ${totalCount}회` : "데이터 없음"}
+                      {latest
+                        ? `${latest.avgDurationMs}ms · ${totalCount}회`
+                        : "데이터 없음"}
                     </span>
                   </div>
                   <div className="h-28">
                     {series.length === 0 ? (
-                      <div className="grid h-full place-items-center text-[11px] text-[color:var(--admin-text-muted)]">데이터 없음</div>
+                      <div className="grid h-full place-items-center text-[11px] text-[color:var(--admin-text-muted)]">
+                        데이터 없음
+                      </div>
                     ) : (
-                      <ResponsiveContainer width="100%" height="100%" minWidth={120} minHeight={80}>
+                      <ResponsiveContainer
+                        width="100%"
+                        height="100%"
+                        minWidth={120}
+                        minHeight={80}
+                      >
                         <AreaChart
                           data={series}
-                          onMouseEnter={() => setActiveChart(`section-${sectionTab}`)}
+                          onMouseEnter={() =>
+                            setActiveChart(`section-${sectionTab}`)
+                          }
                           onMouseLeave={() => setActiveChart(null)}
                         >
-                          <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
-                          <XAxis dataKey="minute" tick={{ fontSize: 10, fill: "#6b7280" }} />
-                          <YAxis tick={{ fontSize: 10, fill: "#6b7280" }} unit="ms" />
-                          <Tooltip active={activeChart === `section-${sectionTab}`} wrapperStyle={{ pointerEvents: "none" }} />
-                          <Area type="linear" dataKey="avgDurationMs" stroke="#2563eb" fill="#dbeafe" name="평균 응답" />
+                          <CartesianGrid
+                            strokeDasharray="3 3"
+                            stroke="#e5e7eb"
+                          />
+                          <XAxis
+                            dataKey="minute"
+                            tick={{ fontSize: 10, fill: "#6b7280" }}
+                          />
+                          <YAxis
+                            tick={{ fontSize: 10, fill: "#6b7280" }}
+                            unit="ms"
+                          />
+                          <Tooltip
+                            active={activeChart === `section-${sectionTab}`}
+                            wrapperStyle={{ pointerEvents: "none" }}
+                          />
+                          <Area
+                            type="linear"
+                            dataKey="avgDurationMs"
+                            stroke="#2563eb"
+                            fill="#dbeafe"
+                            name="평균 응답"
+                          />
                         </AreaChart>
                       </ResponsiveContainer>
                     )}
@@ -598,15 +877,24 @@ export default function MonitoringPage() {
           <div className="admin-card p-3">
             <div className="mb-2 flex items-center justify-between">
               <p className="text-sm font-semibold">사이트 클릭 상위</p>
-              <span className="text-xs text-[color:var(--admin-text-muted)]">누적</span>
+              <span className="text-xs text-[color:var(--admin-text-muted)]">
+                누적
+              </span>
             </div>
             <div className="space-y-1">
               {siteClickShareItems.length === 0 ? (
-                <div className="text-sm text-[color:var(--admin-text-muted)]">데이터 없음</div>
+                <div className="text-sm text-[color:var(--admin-text-muted)]">
+                  데이터 없음
+                </div>
               ) : (
                 siteClickShareItems.map((item) => (
-                  <div key={`${item.siteHref}-${item.siteCategory}`} className="flex items-center justify-between rounded-md bg-slate-50 px-3 py-1.5">
-                    <p className="truncate text-sm font-medium">{item.siteName}</p>
+                  <div
+                    key={`${item.siteName}-${item.siteHref}-${item.siteCategory}`}
+                    className="flex items-center justify-between rounded-md bg-slate-50 px-3 py-1.5"
+                  >
+                    <p className="truncate text-sm font-medium">
+                      {item.siteName}
+                    </p>
                     <p className="text-sm font-semibold">{item.pct}%</p>
                   </div>
                 ))
@@ -617,31 +905,54 @@ export default function MonitoringPage() {
           <div className="admin-card p-3">
             <div className="mb-2 flex items-center justify-between">
               <div className="flex items-center gap-1 rounded-md bg-slate-100 p-0.5">
-                <button type="button" onClick={() => setDeviceTab("device")} className={`rounded px-2 py-1 text-xs ${deviceTab === "device" ? "bg-white font-semibold text-[color:var(--admin-text)]" : "text-[color:var(--admin-text-muted)]"}`}>
+                <button
+                  type="button"
+                  onClick={() => setDeviceTab("device")}
+                  className={`rounded px-2 py-1 text-xs ${deviceTab === "device" ? "bg-white font-semibold text-[color:var(--admin-text)]" : "text-[color:var(--admin-text-muted)]"}`}
+                >
                   Devices
                 </button>
-                <button type="button" onClick={() => setDeviceTab("browser")} className={`rounded px-2 py-1 text-xs ${deviceTab === "browser" ? "bg-white font-semibold text-[color:var(--admin-text)]" : "text-[color:var(--admin-text-muted)]"}`}>
+                <button
+                  type="button"
+                  onClick={() => setDeviceTab("browser")}
+                  className={`rounded px-2 py-1 text-xs ${deviceTab === "browser" ? "bg-white font-semibold text-[color:var(--admin-text)]" : "text-[color:var(--admin-text-muted)]"}`}
+                >
                   Browsers
                 </button>
               </div>
               {liveVisitDelta > 0 ? (
-                <span className="rounded bg-emerald-100 px-1.5 py-0.5 text-[11px] font-semibold text-emerald-700">+{liveVisitDelta}</span>
+                <span className="rounded bg-emerald-100 px-1.5 py-0.5 text-[11px] font-semibold text-emerald-700">
+                  +{liveVisitDelta}
+                </span>
               ) : null}
             </div>
             <div className="space-y-1">
-              {(deviceTab === "device" ? deviceItems : browserItems).length === 0 ? (
-                <div className="grid h-24 place-items-center text-xs text-[color:var(--admin-text-muted)]">데이터 없음</div>
+              {(deviceTab === "device" ? deviceItems : browserItems).length ===
+              0 ? (
+                <div className="grid h-24 place-items-center text-xs text-[color:var(--admin-text-muted)]">
+                  데이터 없음
+                </div>
               ) : deviceTab === "device" ? (
                 deviceItems.map((item) => (
-                  <div key={item.label} className="flex items-center justify-between rounded-md bg-slate-50 px-3 py-1.5">
-                    <p className="text-sm font-medium">{normalizeLabel(item.label)}</p>
+                  <div
+                    key={item.label}
+                    className="flex items-center justify-between rounded-md bg-slate-50 px-3 py-1.5"
+                  >
+                    <p className="text-sm font-medium">
+                      {normalizeLabel(item.label)}
+                    </p>
                     <p className="text-sm font-semibold">{item.pct}%</p>
                   </div>
                 ))
               ) : (
                 browserItems.map((item) => (
-                  <div key={item.browserName} className="flex items-center justify-between rounded-md bg-slate-50 px-3 py-1.5">
-                    <p className="text-sm font-medium">{normalizeLabel(item.browserName)}</p>
+                  <div
+                    key={item.browserName}
+                    className="flex items-center justify-between rounded-md bg-slate-50 px-3 py-1.5"
+                  >
+                    <p className="text-sm font-medium">
+                      {normalizeLabel(item.browserName)}
+                    </p>
                     <p className="text-sm font-semibold">{item.pct}%</p>
                   </div>
                 ))
@@ -652,15 +963,24 @@ export default function MonitoringPage() {
           <div className="admin-card p-3">
             <div className="mb-2 flex items-center justify-between">
               <p className="text-sm font-semibold">국가 분포</p>
-              <span className="text-xs text-[color:var(--admin-text-muted)]">방문</span>
+              <span className="text-xs text-[color:var(--admin-text-muted)]">
+                방문
+              </span>
             </div>
             <div className="space-y-1">
               {countryShareItems.length === 0 ? (
-                <div className="text-sm text-[color:var(--admin-text-muted)]">데이터 없음</div>
+                <div className="text-sm text-[color:var(--admin-text-muted)]">
+                  데이터 없음
+                </div>
               ) : (
                 countryShareItems.map((item) => (
-                  <div key={item.countryCode} className="flex items-center justify-between rounded-md bg-slate-50 px-3 py-1.5">
-                    <p className="text-sm font-medium">{normalizeLabel(item.countryCode)}</p>
+                  <div
+                    key={item.countryCode}
+                    className="flex items-center justify-between rounded-md bg-slate-50 px-3 py-1.5"
+                  >
+                    <p className="text-sm font-medium">
+                      {normalizeLabel(item.countryCode)}
+                    </p>
                     <p className="text-sm font-semibold">{item.pct}%</p>
                   </div>
                 ))
@@ -671,15 +991,24 @@ export default function MonitoringPage() {
           <div className="admin-card p-3">
             <div className="mb-2 flex items-center justify-between">
               <p className="text-sm font-semibold">운영체제 분포</p>
-              <span className="text-xs text-[color:var(--admin-text-muted)]">방문</span>
+              <span className="text-xs text-[color:var(--admin-text-muted)]">
+                방문
+              </span>
             </div>
             <div className="space-y-1">
               {osShareItems.length === 0 ? (
-                <div className="text-sm text-[color:var(--admin-text-muted)]">데이터 없음</div>
+                <div className="text-sm text-[color:var(--admin-text-muted)]">
+                  데이터 없음
+                </div>
               ) : (
                 osShareItems.map((item) => (
-                  <div key={item.osName} className="flex items-center justify-between rounded-md bg-slate-50 px-3 py-1.5">
-                    <p className="text-sm font-medium">{normalizeLabel(item.osName)}</p>
+                  <div
+                    key={item.osName}
+                    className="flex items-center justify-between rounded-md bg-slate-50 px-3 py-1.5"
+                  >
+                    <p className="text-sm font-medium">
+                      {normalizeLabel(item.osName)}
+                    </p>
                     <p className="text-sm font-semibold">{item.pct}%</p>
                   </div>
                 ))
@@ -688,7 +1017,6 @@ export default function MonitoringPage() {
           </div>
         </div>
       </div>
-
     </div>
   );
 }

--- a/client/app/admin/sites/page.tsx
+++ b/client/app/admin/sites/page.tsx
@@ -126,27 +126,42 @@ export default function AdminSitesPage() {
   const [clickYMax, setClickYMax] = useState(0);
   const [seriesLoading, setSeriesLoading] = useState(false);
 
-  const selectSite = useCallback(async (site: Site) => {
+  const selectSite = useCallback((site: Site) => {
     setSelectedSite(site);
-    setSeriesLoading(true);
-    try {
-      const res = await fetch(
-        `/api/admin/sites/${site.seq}/click-series?days=7`,
-        { cache: "no-store" },
-      );
-      const data = (await res.json()) as {
-        series: { bucket: string; count: number }[];
-        yMax?: number;
-      };
-      setClickSeries(data.series ?? []);
-      setClickYMax(data.yMax ?? 0);
-    } catch {
-      setClickSeries([]);
-      setClickYMax(0);
-    } finally {
-      setSeriesLoading(false);
-    }
   }, []);
+
+  // 선택된 사이트의 7일 클릭 추이를 가져온다.
+  // cleanup으로 이전 요청을 무시해 빠른 연속 클릭 시 경쟁 상태(stale 응답) 방지.
+  useEffect(() => {
+    if (!selectedSite) return;
+    let cancelled = false;
+    const seq = selectedSite.seq;
+    setSeriesLoading(true);
+    (async () => {
+      try {
+        const res = await fetch(`/api/admin/sites/${seq}/click-series?days=7`, {
+          cache: "no-store",
+        });
+        const data = (await res.json()) as {
+          series: { bucket: string; count: number }[];
+          yMax?: number;
+        };
+        if (cancelled) return;
+        setClickSeries(data.series ?? []);
+        setClickYMax(data.yMax ?? 0);
+      } catch {
+        if (!cancelled) {
+          setClickSeries([]);
+          setClickYMax(0);
+        }
+      } finally {
+        if (!cancelled) setSeriesLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedSite]);
 
   function requireMaster(action: string) {
     if (!isGuest) return true;

--- a/client/app/admin/sites/page.tsx
+++ b/client/app/admin/sites/page.tsx
@@ -1,6 +1,15 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
 import { buildGuestNotice, useAdminRole } from "@/lib/admin-role";
 
 interface Site {
@@ -11,6 +20,7 @@ interface Site {
   description: string | null;
   icon: string | null;
   is_active: number;
+  click_count: number;
 }
 
 const EMPTY_FORM = {
@@ -107,6 +117,36 @@ export default function AdminSitesPage() {
   const [editingId, setEditingId] = useState<number | null>(null);
   const [saving, setSaving] = useState(false);
   const [formError, setFormError] = useState("");
+
+  // 선택된 사이트의 7일 클릭 추이 (우측 그래프)
+  const [selectedSite, setSelectedSite] = useState<Site | null>(null);
+  const [clickSeries, setClickSeries] = useState<
+    { bucket: string; count: number }[]
+  >([]);
+  const [clickYMax, setClickYMax] = useState(0);
+  const [seriesLoading, setSeriesLoading] = useState(false);
+
+  const selectSite = useCallback(async (site: Site) => {
+    setSelectedSite(site);
+    setSeriesLoading(true);
+    try {
+      const res = await fetch(
+        `/api/admin/sites/${site.seq}/click-series?days=7`,
+        { cache: "no-store" },
+      );
+      const data = (await res.json()) as {
+        series: { bucket: string; count: number }[];
+        yMax?: number;
+      };
+      setClickSeries(data.series ?? []);
+      setClickYMax(data.yMax ?? 0);
+    } catch {
+      setClickSeries([]);
+      setClickYMax(0);
+    } finally {
+      setSeriesLoading(false);
+    }
+  }, []);
 
   function requireMaster(action: string) {
     if (!isGuest) return true;
@@ -396,9 +436,10 @@ export default function AdminSitesPage() {
   }
 
   const isProcessing = busyMessage !== null;
-  const totalSites = sites.length;
-  const activeSites = sites.filter((site) => site.is_active === 1).length;
-  const inactiveSites = totalSites - activeSites;
+  // 표시용: 클릭수 내림차순 (동점이면 기존 순서 유지)
+  const sortedSites = [...sites].sort(
+    (a, b) => (b.click_count ?? 0) - (a.click_count ?? 0),
+  );
 
   return (
     <div>
@@ -445,24 +486,6 @@ export default function AdminSitesPage() {
           >
             + 사이트 추가
           </button>
-        </div>
-      </div>
-
-      {/* 통계 카드 */}
-      <div className="grid grid-cols-3 gap-4 mb-6">
-        <div className="admin-stat-card">
-          <p className="admin-stat-label">전체 사이트</p>
-          <p className="admin-stat-value mt-1">{totalSites}</p>
-        </div>
-        <div className="admin-stat-card">
-          <p className="admin-stat-label">활성</p>
-          <p className="admin-stat-value mt-1 text-emerald-600">
-            {activeSites}
-          </p>
-        </div>
-        <div className="admin-stat-card">
-          <p className="admin-stat-label">비활성</p>
-          <p className="admin-stat-value mt-1 text-gray-400">{inactiveSites}</p>
         </div>
       </div>
 
@@ -556,41 +579,61 @@ export default function AdminSitesPage() {
           </p>
         </div>
       ) : (
-        <div className="admin-card overflow-hidden">
+        <div className="flex gap-4 items-start">
+        <div className="admin-card overflow-hidden flex-1 min-w-0">
           <div className="overflow-x-auto">
-            <table className="admin-table">
+            <table className="admin-table table-fixed w-full min-w-[860px]">
+              <colgroup>
+                <col style={{ width: "15%" }} />
+                <col style={{ width: "21%" }} />
+                <col style={{ width: "23%" }} />
+                <col style={{ width: "13%" }} />
+                <col style={{ width: "7%" }} />
+                <col style={{ width: "14%" }} />
+                <col style={{ width: "7%" }} />
+              </colgroup>
               <thead>
                 <tr>
-                  <th className="w-12 text-center">#</th>
-                  <th>이름</th>
-                  <th>URL</th>
-                  <th>설명</th>
-                  <th>카테고리</th>
+                  <th className="text-center">이름</th>
+                  <th className="text-center">URL</th>
+                  <th className="text-center">설명</th>
+                  <th className="text-center">카테고리</th>
                   <th className="text-center">활성</th>
                   <th className="text-center">액션</th>
+                  <th className="text-center">인기도</th>
                 </tr>
               </thead>
               <tbody>
-                {sites.map((site, idx) => (
-                  <tr key={site.seq}>
-                    <td className="text-center text-[color:var(--admin-text-subtle)] tabular-nums">
-                      {idx + 1}
-                    </td>
-                    <td className="font-medium">{site.name}</td>
-                    <td>
+                {sortedSites.map((site) => (
+                  <tr
+                    key={site.seq}
+                    onClick={() => selectSite(site)}
+                    className={`cursor-pointer ${
+                      selectedSite?.seq === site.seq
+                        ? "bg-blue-50/70"
+                        : ""
+                    }`}
+                  >
+                    <td className="text-center font-medium truncate">{site.name}</td>
+                    <td className="text-center">
                       <a
                         href={site.href}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="block max-w-xs truncate text-blue-600 hover:text-blue-700 hover:underline"
+                        onClick={(e) => e.stopPropagation()}
+                        className="block truncate text-center text-blue-600 hover:text-blue-700 hover:underline"
+                        title={site.href}
                       >
                         {site.href}
                       </a>
                     </td>
-                    <td className="text-[color:var(--admin-text-muted)] max-w-xs truncate">
+                    <td
+                      className="text-center text-[color:var(--admin-text-muted)] truncate"
+                      title={site.description ?? ""}
+                    >
                       {site.description ?? "-"}
                     </td>
-                    <td>
+                    <td className="text-center">
                       {site.category ? (
                         <span
                           className={`admin-badge ${getCategoryTone(site.category)}`}
@@ -605,7 +648,10 @@ export default function AdminSitesPage() {
                     </td>
                     <td className="text-center">
                       <button
-                        onClick={() => handleToggleActive(site)}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleToggleActive(site);
+                        }}
                         disabled={isProcessing}
                         className={`admin-badge ${
                           site.is_active
@@ -616,29 +662,106 @@ export default function AdminSitesPage() {
                         {site.is_active ? "활성" : "비활성"}
                       </button>
                     </td>
-                    <td>
-                      <div className="flex justify-center gap-2">
+                    <td className="text-center" style={{ paddingLeft: 6, paddingRight: 6 }}>
+                      <div className="flex justify-center gap-1 flex-nowrap">
                         <button
-                          onClick={() => startEdit(site)}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            startEdit(site);
+                          }}
                           disabled={isProcessing}
-                          className="admin-btn admin-btn-sm admin-btn-secondary"
+                          className="admin-btn admin-btn-sm admin-btn-secondary whitespace-nowrap"
                         >
                           수정
                         </button>
                         <button
-                          onClick={() => handleDelete(site.seq)}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleDelete(site.seq);
+                          }}
                           disabled={isProcessing}
-                          className="admin-btn admin-btn-sm admin-btn-danger"
+                          className="admin-btn admin-btn-sm admin-btn-danger whitespace-nowrap"
                         >
                           삭제
                         </button>
                       </div>
+                    </td>
+                    <td className="text-center tabular-nums font-semibold text-blue-600">
+                      {site.click_count.toLocaleString()}
                     </td>
                   </tr>
                 ))}
               </tbody>
             </table>
           </div>
+        </div>
+
+        {/* 우측: 선택 사이트 7일 클릭 추이 */}
+        <div className="admin-card w-80 shrink-0 p-4 hidden lg:block">
+          {!selectedSite ? (
+            <p className="text-sm text-[color:var(--admin-text-muted)] text-center py-10">
+              사이트를 클릭하면
+              <br />
+              최근 7일 클릭 추이를 볼 수 있어요.
+            </p>
+          ) : (
+            <div>
+              {/* 이름(왼쪽) + 총 클릭수(오른쪽 끝) */}
+              <div className="flex items-baseline justify-between gap-2 mb-3">
+                <p className="text-sm font-semibold truncate">
+                  {selectedSite.name}
+                </p>
+                <span className="shrink-0">
+                  <span className="text-lg font-bold text-blue-600 tabular-nums">
+                    {selectedSite.click_count.toLocaleString()}
+                  </span>
+                  <span className="text-xs text-[color:var(--admin-text-muted)] ml-1">
+                    클릭
+                  </span>
+                </span>
+              </div>
+              {seriesLoading ? (
+                <p className="text-xs text-[color:var(--admin-text-muted)] py-10 text-center">
+                  불러오는 중...
+                </p>
+              ) : (
+                <div style={{ width: "100%", height: 180 }}>
+                  <ResponsiveContainer width="100%" height="100%">
+                    <AreaChart data={clickSeries}>
+                      <defs>
+                        <linearGradient id="siteClickFill" x1="0" y1="0" x2="0" y2="1">
+                          <stop offset="0%" stopColor="#3b82f6" stopOpacity={0.3} />
+                          <stop offset="100%" stopColor="#3b82f6" stopOpacity={0} />
+                        </linearGradient>
+                      </defs>
+                      <CartesianGrid strokeDasharray="3 3" stroke="#f1f5f9" />
+                      <XAxis
+                        dataKey="bucket"
+                        interval={0}
+                        tick={{ fontSize: 9, fill: "#6b7280" }}
+                      />
+                      <YAxis
+                        allowDecimals={false}
+                        width={28}
+                        domain={[0, Math.max(clickYMax, 1)]}
+                        tick={{ fontSize: 10, fill: "#6b7280" }}
+                      />
+                      <Tooltip />
+                      <Area
+                        type="monotone"
+                        dataKey="count"
+                        stroke="#3b82f6"
+                        strokeWidth={2}
+                        fill="url(#siteClickFill)"
+                        dot={{ r: 3, fill: "#3b82f6" }}
+                      />
+                    </AreaChart>
+                  </ResponsiveContainer>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
         </div>
       )}
 

--- a/client/app/api/admin/sites/[id]/click-series/route.ts
+++ b/client/app/api/admin/sites/[id]/click-series/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+const NEST_API = process.env.NEST_API_URL ?? "http://localhost:3001";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const store = await cookies();
+    const token = store.get("admin_token")?.value ?? "";
+    const days = req.nextUrl.searchParams.get("days") ?? "7";
+
+    const res = await fetch(
+      `${NEST_API}/api/admin/sites/${id}/click-series?days=${days}`,
+      { headers: { "x-admin-session": token }, cache: "no-store" },
+    );
+    const data = await res.json().catch(() => ({ series: [] }));
+    return NextResponse.json(data, { status: res.status });
+  } catch {
+    return NextResponse.json({ series: [] }, { status: 503 });
+  }
+}

--- a/client/app/globals.css
+++ b/client/app/globals.css
@@ -415,9 +415,13 @@ body {
   color: var(--admin-text-muted);
   font-size: 0.8125rem;
   font-weight: 500;
-  text-align: left;
+  /* 정렬은 각 th의 유틸리티 클래스(text-left/text-center)로 지정 */
   padding: 0.875rem 1rem;
   border-bottom: 1px solid var(--admin-border);
+}
+/* 정렬 클래스를 명시하지 않은 헤더는 기본 왼쪽 정렬 */
+.admin-table thead th:not(.text-center):not(.text-right) {
+  text-align: left;
 }
 .admin-table tbody td {
   padding: 0.75rem 1rem;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     restart: unless-stopped
     env_file: .env
     environment:
-      DATABASE_URL: postgresql://${DB_USER}:${DB_PASS}@postgres:5432/${DB_NAME}
+      DATABASE_URL: postgresql://${DB_USER}:${DB_PASS}@postgres:5432/${DB_NAME}?options=-c%20search_path%3Dlost_ark
       REDIS_HOST: redis
       SITE_FINDER_DIR: /site-finder
     volumes:

--- a/server/src/admin/admin-sites.controller.ts
+++ b/server/src/admin/admin-sites.controller.ts
@@ -9,6 +9,7 @@ import {
   ParseIntPipe,
   Post,
   Put,
+  Query,
   UseGuards,
 } from '@nestjs/common';
 import { SitesRepository } from '../sites/sites.repository';
@@ -26,6 +27,20 @@ export class AdminSitesController {
   @Get()
   async findAll() {
     return this.sitesRepo.findAdminAll();
+  }
+
+  /** 특정 사이트의 최근 N일(기본 7) 일별 클릭 추이 */
+  @Get(':seq/click-series')
+  async clickSeries(
+    @Param('seq', ParseIntPipe) seq: number,
+    @Query('days') days?: string,
+  ) {
+    const n = Math.max(1, Math.min(30, days ? parseInt(days, 10) : 7));
+    const [series, yMax] = await Promise.all([
+      this.sitesRepo.findClickSeries(seq, n),
+      this.sitesRepo.findMaxDailyClicks(n),
+    ]);
+    return { series, yMax };
   }
 
   @Post()

--- a/server/src/admin/admin-sites.controller.ts
+++ b/server/src/admin/admin-sites.controller.ts
@@ -35,7 +35,8 @@ export class AdminSitesController {
     @Param('seq', ParseIntPipe) seq: number,
     @Query('days') days?: string,
   ) {
-    const n = Math.max(1, Math.min(30, days ? parseInt(days, 10) : 7));
+    const parsed = days ? parseInt(days, 10) : 7;
+    const n = Number.isNaN(parsed) ? 7 : Math.max(1, Math.min(30, parsed));
     const [series, yMax] = await Promise.all([
       this.sitesRepo.findClickSeries(seq, n),
       this.sitesRepo.findMaxDailyClicks(n),

--- a/server/src/admin/repositories/monitoring.repository.ts
+++ b/server/src/admin/repositories/monitoring.repository.ts
@@ -320,12 +320,13 @@ export class MonitoringRepository {
   }
 
   async findPageVisitSeriesDays(days: number) {
-    // generate_series로 전체 날짜 축을 만들고 LEFT JOIN → 데이터 없는 날도 0으로 표시
+    // apm_page_visits는 (path,device,...)별 누적 카운터(visits)라 행 수가 아닌 visits 합을 세야
+    // 실제 방문 횟수가 됨. generate_series로 데이터 없는 날도 0으로 표시.
     return this.prisma.$queryRaw<
       Array<{ bucket: string; count: bigint | number }>
     >`
       SELECT TO_CHAR(d.day, 'MM-DD') AS bucket,
-             COUNT(p.id) AS count
+             COALESCE(SUM(p.visits), 0) AS count
       FROM generate_series(
              (CURRENT_DATE - ((${days}::int - 1) * INTERVAL '1 day'))::date,
              CURRENT_DATE,
@@ -448,9 +449,9 @@ export class MonitoringRepository {
 
   async findSiteClicks() {
     return this.prisma.$queryRaw<SiteClickRow[]>`
-      SELECT site_name, site_href, site_category, COUNT(*) AS click_count
+      SELECT MAX(site_name) AS site_name, site_href, site_category, COUNT(*) AS click_count
       FROM apm_site_clicks
-      GROUP BY site_name, site_href, site_category
+      GROUP BY site_href, site_category
       ORDER BY click_count DESC
       LIMIT 20
     `;

--- a/server/src/class-summary/class-summary.repository.ts
+++ b/server/src/class-summary/class-summary.repository.ts
@@ -27,7 +27,11 @@ export class ClassSummaryRepository {
     return row !== null;
   }
 
-  async upsert(className: string, summary: string, titleHash: string): Promise<void> {
+  async upsert(
+    className: string,
+    summary: string,
+    titleHash: string,
+  ): Promise<void> {
     await this.prisma.loa_class_summaries.upsert({
       where: { class_name: className },
       create: {

--- a/server/src/class-summary/class-summary.service.spec.ts
+++ b/server/src/class-summary/class-summary.service.spec.ts
@@ -16,6 +16,8 @@ function createService(localDisable = 'true') {
       const values: Record<string, string | undefined> = {
         GEMINI_API_KEY: 'dummy-key',
         LOCAL_DISABLE_QUOTA_APIS: localDisable,
+        // service는 isClassSummaryDisabled(DISABLE_CLASS_SUMMARY)로 판단
+        DISABLE_CLASS_SUMMARY: localDisable,
       };
       return values[key];
     }),

--- a/server/src/class-summary/class-summary.service.spec.ts
+++ b/server/src/class-summary/class-summary.service.spec.ts
@@ -21,10 +21,7 @@ function createService(localDisable = 'true') {
     }),
   } as unknown as ConfigService;
 
-  const service = new ClassSummaryService(
-    repo as never,
-    config,
-  );
+  const service = new ClassSummaryService(repo as never, config);
   return { service, repo };
 }
 

--- a/server/src/class-summary/class-summary.service.ts
+++ b/server/src/class-summary/class-summary.service.ts
@@ -142,7 +142,9 @@ export class ClassSummaryService implements OnModuleInit {
       return false;
     }
 
-    const currentHash = createHash('md5').update(titles.join('\n')).digest('hex');
+    const currentHash = createHash('md5')
+      .update(titles.join('\n'))
+      .digest('hex');
     const existing = await this.classSummaryRepo.findOne(className);
     if (existing && existing.titleHash === currentHash) {
       this.logger.debug(`[${className}] 변경 없음 — Gemini 스킵`);

--- a/server/src/sites/sites.repository.ts
+++ b/server/src/sites/sites.repository.ts
@@ -12,6 +12,7 @@ export interface SiteRecord {
 
 export interface AdminSiteRecord extends SiteRecord {
   is_active: number;
+  click_count: number;
 }
 
 export interface SiteCheckRecord {
@@ -63,23 +64,36 @@ export class SitesRepository {
   }
 
   async findAdminAll(): Promise<AdminSiteRecord[]> {
-    const rows = await this.prisma.loa_sites.findMany({
-      orderBy: { seq: 'asc' },
-      select: {
-        seq: true,
-        name: true,
-        href: true,
-        category: true,
-        description: true,
-        icon: true,
-        is_active: true,
-      },
-    });
+    // 각 사이트의 클릭수(apm_site_clicks)를 href 기준으로 LEFT JOIN해 함께 반환
+    const rows = await this.prisma.$queryRaw<
+      Array<{
+        seq: bigint;
+        name: string;
+        href: string;
+        category: string | null;
+        description: string | null;
+        icon: string | null;
+        is_active: boolean | null;
+        click_count: bigint;
+      }>
+    >`
+      SELECT s.seq, s.name, s.href, s.category, s.description, s.icon, s.is_active,
+             COUNT(c.id) AS click_count
+      FROM loa_sites s
+      LEFT JOIN apm_site_clicks c ON c.site_href = s.href
+      GROUP BY s.seq, s.name, s.href, s.category, s.description, s.icon, s.is_active
+      ORDER BY s.seq ASC
+    `;
 
     return rows.map((row) => ({
-      ...row,
       seq: Number(row.seq),
+      name: row.name,
+      href: row.href,
+      category: row.category,
+      description: row.description,
+      icon: row.icon,
       is_active: row.is_active ? 1 : 0,
+      click_count: Number(row.click_count),
     }));
   }
 
@@ -91,6 +105,50 @@ export class SitesRepository {
     return row ? { seq: Number(row.seq) } : null;
   }
 
+  /**
+   * 특정 사이트(seq)의 최근 N일 일별 클릭수.
+   * generate_series로 빈 날짜도 0으로 채워서 반환 (오래된→최신 순).
+   */
+  async findClickSeries(
+    seq: number,
+    days: number,
+  ): Promise<Array<{ bucket: string; count: number }>> {
+    const rows = await this.prisma.$queryRaw<
+      Array<{ bucket: string; count: bigint }>
+    >`
+      SELECT TO_CHAR(d.day, 'MM-DD') AS bucket,
+             COUNT(c.id) AS count
+      FROM generate_series(
+             (CURRENT_DATE - ((${days}::int - 1) * INTERVAL '1 day'))::date,
+             CURRENT_DATE,
+             INTERVAL '1 day'
+           ) AS d(day)
+      LEFT JOIN loa_sites s ON s.seq = ${seq}
+      LEFT JOIN apm_site_clicks c
+        ON c.site_href = s.href AND DATE(c.created_at) = d.day
+      GROUP BY d.day
+      ORDER BY d.day ASC
+    `;
+    return rows.map((r) => ({ bucket: r.bucket, count: Number(r.count) }));
+  }
+
+  /**
+   * 최근 N일 동안 "한 사이트가 하루에 받은 최대 클릭수".
+   * 모든 사이트 그래프의 Y축을 이 값으로 통일하면 사이트 간 인기 비교가 가능.
+   */
+  async findMaxDailyClicks(days: number): Promise<number> {
+    const rows = await this.prisma.$queryRaw<Array<{ max_daily: bigint }>>`
+      SELECT COALESCE(MAX(cnt), 0) AS max_daily
+      FROM (
+        SELECT site_href, DATE(created_at) AS d, COUNT(*) AS cnt
+        FROM apm_site_clicks
+        WHERE created_at >= (CURRENT_DATE - ((${days}::int - 1) * INTERVAL '1 day'))
+        GROUP BY site_href, DATE(created_at)
+      ) t
+    `;
+    return Number(rows[0]?.max_daily ?? 0);
+  }
+
   async create(input: SiteCreateInput): Promise<number> {
     const created = await this.prisma.loa_sites.create({
       data: input,
@@ -100,6 +158,18 @@ export class SitesRepository {
   }
 
   async update(seq: number, input: SiteUpdateInput): Promise<void> {
+    if (input.name !== undefined) {
+      const current = await this.prisma.loa_sites.findUnique({
+        where: { seq },
+        select: { href: true },
+      });
+      if (current) {
+        await this.prisma.$executeRaw`
+          UPDATE apm_site_clicks SET site_name = ${input.name}
+          WHERE site_href = ${current.href}
+        `;
+      }
+    }
     await this.prisma.loa_sites.update({
       where: { seq },
       data: input,
@@ -110,6 +180,18 @@ export class SitesRepository {
     seq: number,
     input: Pick<SiteCreateInput, 'name' | 'description'>,
   ): Promise<void> {
+    if (input.name !== undefined) {
+      const current = await this.prisma.loa_sites.findUnique({
+        where: { seq },
+        select: { href: true },
+      });
+      if (current) {
+        await this.prisma.$executeRaw`
+          UPDATE apm_site_clicks SET site_name = ${input.name}
+          WHERE site_href = ${current.href}
+        `;
+      }
+    }
     await this.prisma.loa_sites.update({
       where: { seq },
       data: input,

--- a/server/src/sites/sites.repository.ts
+++ b/server/src/sites/sites.repository.ts
@@ -158,14 +158,18 @@ export class SitesRepository {
   }
 
   async update(seq: number, input: SiteUpdateInput): Promise<void> {
-    if (input.name !== undefined) {
+    // 이름/URL 변경 시 클릭 로그(apm_site_clicks)도 동기화 — 기존 href로 매칭 후 갱신.
+    // href가 바뀌어도 과거 클릭 이력이 새 URL에 그대로 연결되도록 함.
+    if (input.name !== undefined || input.href !== undefined) {
       const current = await this.prisma.loa_sites.findUnique({
         where: { seq },
         select: { href: true },
       });
       if (current) {
         await this.prisma.$executeRaw`
-          UPDATE apm_site_clicks SET site_name = ${input.name}
+          UPDATE apm_site_clicks
+          SET site_name = COALESCE(${input.name ?? null}, site_name),
+              site_href = COALESCE(${input.href ?? null}, site_href)
           WHERE site_href = ${current.href}
         `;
       }


### PR DESCRIPTION
## 요약

관리자 **사이트 관리** UI 개편과 클릭/방문 통계 개선을 main에 반영합니다. (fix/admin에 머지된 내용)

## 주요 변경

- **사이트 관리**: 인기도(클릭수) 컬럼 + 클릭수 내림차순 정렬, 사이트 행 클릭 시 우측 7일 클릭 추이 그래프(Y축 통일·날짜 라벨·dot), 통계바 제거·정렬/컬럼폭 정리, 액션 버튼 한 줄
- **백엔드**: `/sites/:seq/click-series`(gap-fill + 전체 최대) 추가, `findAdminAll` click_count 조인, 이름/URL 변경 시 `apm_site_clicks` 동기화
- **집계 수정**: 페이지 방문 추이 `COUNT → SUM(visits)`, 헤더 정렬 CSS, docker-compose `search_path` 명시
- **버그 수정(리뷰 반영)**: days 파라미터 NaN 방어, 그래프 fetch 경쟁 상태(useEffect+cleanup), class-summary 테스트 mock 키 수정

## 검증
- lint / build / client typecheck 통과, class-summary 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)
