### PR TITLE
fix(db): nest search_path에 public 추가 — telemetry enum 에러 해결

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     restart: unless-stopped
     env_file: .env
     environment:
-      DATABASE_URL: postgresql://${DB_USER}:${DB_PASS}@postgres:5432/${DB_NAME}?options=-c%20search_path%3Dlost_ark
+      DATABASE_URL: postgresql://${DB_USER}:${DB_PASS}@postgres:5432/${DB_NAME}?options=-c%20search_path%3Dlost_ark%2Cpublic
       REDIS_HOST: redis
       SITE_FINDER_DIR: /site-finder
     volumes:


### PR DESCRIPTION
@
## 문제
운영 telemetry 500 (카톡 알림): `42704: type "apm_request_timings_scope" does not exist`

apm_* enum 타입이 public 스키마에만 있는데 nest search_path가 lost_ark뿐이라 insert의 enum 캐스팅이 실패.

## 수정
docker-compose nest DATABASE_URL search_path를 `lost_ark` → `lost_ark,public`. 테이블은 lost_ark 우선 유지, enum은 public fallback.

## 검증
로컬에서 telemetry request/site-click/page-visit 모두 201 성공 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@