### PR TITLE
feat(monitoring): 페이지 방문 날짜별 집계 (visit_day)

### DIFF
--- a/db/migrations/002_page_visits_daily.sql
+++ b/db/migrations/002_page_visits_daily.sql
@@ -1,0 +1,25 @@
+-- 페이지 방문을 날짜별로 집계하기 위해 apm_page_visits에 visit_day 추가 (멱등)
+-- 기존: (path,device,country,os,browser) 조합당 행 1개 + 누적 visits → 재방문 시 last_seen_at만 갱신되어
+--       일별 추이가 부정확(과거 방문이 최신일로 몰림).
+-- 변경: visit_day(방문 날짜)를 unique 키에 포함 → 날짜별로 행이 나뉘어 일별 방문수 정확.
+-- 실행: gh workflow run db-migrate.yml -f sql_file=db/migrations/002_page_visits_daily.sql
+
+SET search_path TO lost_ark, public;
+
+-- 1) visit_day 컬럼 추가 (기존 행은 마지막 방문일로 근사)
+ALTER TABLE apm_page_visits
+  ADD COLUMN IF NOT EXISTS visit_day DATE NOT NULL DEFAULT CURRENT_DATE;
+
+UPDATE apm_page_visits
+  SET visit_day = last_seen_at::date
+  WHERE visit_day <> last_seen_at::date;
+
+-- 2) 날짜 없는 기존 unique 제약/인덱스 제거 (환경별 이름 차이 대비해 모두 시도)
+ALTER TABLE apm_page_visits DROP CONSTRAINT IF EXISTS uk_page_device_country_os_browser;
+ALTER TABLE apm_page_visits DROP CONSTRAINT IF EXISTS idx_16508_uk_page_device_country_os_browser;
+DROP INDEX IF EXISTS uk_page_device_country_os_browser;
+DROP INDEX IF EXISTS idx_16508_uk_page_device_country_os_browser;
+
+-- 3) visit_day 포함 unique 인덱스 추가
+CREATE UNIQUE INDEX IF NOT EXISTS uk_page_device_country_os_browser_day
+  ON apm_page_visits (path, device_type, country_code, os_name, browser_name, visit_day);

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -23,13 +23,14 @@ model apm_page_visits {
   user_agent   String
   referrer     String?
   visits       Int      @default(1)
+  visit_day    DateTime @default(now()) @db.Date
   last_seen_at DateTime @default(now()) @db.Timestamptz(6)
   created_at   DateTime @default(now()) @db.Timestamptz(6)
   country_code String   @default("UNKNOWN")
   os_name      String   @default("Unknown")
   browser_name String   @default("Unknown")
 
-  @@unique([path, device_type, country_code, os_name, browser_name], map: "idx_16508_uk_page_device_country_os_browser")
+  @@unique([path, device_type, country_code, os_name, browser_name, visit_day], map: "uk_page_device_country_os_browser_day")
 }
 
 model apm_request_timings {

--- a/server/src/admin/repositories/monitoring.repository.ts
+++ b/server/src/admin/repositories/monitoring.repository.ts
@@ -95,9 +95,10 @@ export class MonitoringRepository {
         os_name VARCHAR(64) NOT NULL DEFAULT 'Unknown',
         browser_name VARCHAR(64) NOT NULL DEFAULT 'Unknown',
         visits INT NOT NULL DEFAULT 1,
+        visit_day DATE NOT NULL DEFAULT CURRENT_DATE,
         last_seen_at TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
         created_at TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        CONSTRAINT uk_page_device_country_os_browser UNIQUE (path, device_type, country_code, os_name, browser_name)
+        CONSTRAINT uk_page_device_country_os_browser_day UNIQUE (path, device_type, country_code, os_name, browser_name, visit_day)
       )
     `;
     await this.prisma.$executeRaw`
@@ -213,9 +214,11 @@ export class MonitoringRepository {
     osName: string;
     browserName: string;
   }) {
+    // visit_day(방문 날짜)를 충돌 키에 포함 → 같은 방문자라도 날짜별로 행이 나뉘어
+    // 일별 방문 추이가 정확해진다 (5/1·5/3 따로 집계).
     await this.prisma.$executeRaw`
       INSERT INTO apm_page_visits
-        (path, device_type, user_agent, referrer, country_code, os_name, browser_name, created_at)
+        (path, device_type, user_agent, referrer, country_code, os_name, browser_name, visit_day, created_at)
       VALUES (
         ${input.path},
         ${input.deviceType}::apm_page_visits_device_type,
@@ -224,16 +227,14 @@ export class MonitoringRepository {
         ${input.countryCode},
         ${input.osName},
         ${input.browserName},
+        CURRENT_DATE,
         NOW()
       )
-      ON CONFLICT (path, device_type, country_code, os_name, browser_name)
+      ON CONFLICT (path, device_type, country_code, os_name, browser_name, visit_day)
       DO UPDATE SET
         visits = apm_page_visits.visits + 1,
         user_agent = EXCLUDED.user_agent,
         referrer = EXCLUDED.referrer,
-        country_code = EXCLUDED.country_code,
-        os_name = EXCLUDED.os_name,
-        browser_name = EXCLUDED.browser_name,
         last_seen_at = NOW()
     `;
   }
@@ -320,8 +321,7 @@ export class MonitoringRepository {
   }
 
   async findPageVisitSeriesDays(days: number) {
-    // apm_page_visits는 (path,device,...)별 누적 카운터(visits)라 행 수가 아닌 visits 합을 세야
-    // 실제 방문 횟수가 됨. generate_series로 데이터 없는 날도 0으로 표시.
+    // visit_day(방문 날짜)별 visits 합 = 그날 실제 방문 횟수. generate_series로 빈 날도 0.
     return this.prisma.$queryRaw<
       Array<{ bucket: string; count: bigint | number }>
     >`
@@ -332,7 +332,7 @@ export class MonitoringRepository {
              CURRENT_DATE,
              INTERVAL '1 day'
            ) AS d(day)
-      LEFT JOIN apm_page_visits p ON DATE(p.last_seen_at) = d.day
+      LEFT JOIN apm_page_visits p ON p.visit_day = d.day
       GROUP BY d.day
       ORDER BY d.day ASC
     `;


### PR DESCRIPTION
@
## 문제
페이지 방문 추이가 부정확. apm_page_visits는 (path,device,country,os,browser) 조합당 행 1개+누적 visits 구조라, 같은 방문자가 다른 날 재방문하면 last_seen_at만 갱신되어 **과거 방문이 최신일로 몰림** (6/6에 221이 몰린 사례).

## 수정
**visit_day(방문 날짜)를 unique 키에 포함** → 날짜별로 행이 나뉘어 일별 방문수가 정확.
- 예: A가 5/1·5/3, B가 5/1·5/2, C가 5/1·5/3 방문 → 5/1=3, 5/2=1, 5/3=2
- recordPageVisit upsert 키에 visit_day 추가, 추이 쿼리도 visit_day 기준
- `db/migrations/002_page_visits_daily.sql` (멱등): visit_day 컬럼 + unique 교체

## 검증
로컬에서 같은 날 3회 방문 → visit_day별 visits=3 확인. lint/build 통과.

## 머지 후
```
gh workflow run db-migrate.yml -f sql_file=db/migrations/002_page_visits_daily.sql
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@