### PR TITLE
fix(ci): Docker prod install postinstall 충돌로 깨진 배포 핫픽스

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "license": "UNLICENSED",
   "scripts": {
-    "postinstall": "prisma generate",
+    "postinstall": "prisma generate || true",
     "prebuild": "prisma generate",
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",


### PR DESCRIPTION
@
## 긴급
PR #241 머지 후 **main-post-merge 배포가 Docker 빌드에서 실패** 중. 핫픽스.

## 원인
Dockerfile은 `generated`를 EC2 빌드 산출물에서 COPY로 받음(generate 불필요). 그런데 PR #241에서 추가한 `postinstall: prisma generate`가 `npm ci --omit=dev` 단계에서 트리거됨 → 그 시점엔 prisma CLI(devDep, --omit=dev로 제외)도 schema도 없어 `Could not find Prisma Schema`로 빌드 실패.

## 수정
`postinstall: prisma generate || true`
- CI/로컬(prisma 존재): generate 정상 성공 (#240/#241 의도 유지)
- Docker prod install(prisma 부재): graceful skip, generated는 COPY로 충당
- `--ignore-scripts`와 달리 bcrypt 등 네이티브 빌드 스크립트는 그대로 실행
- 빌드 실패는 prebuild(`prisma generate`, ||true 없음)에서 여전히 감지됨

## 검증
임시 폴더에서 `npm ci --omit=dev` 재현 → postinstall이 schema 없이도 exit=0, 311 packages 설치 성공 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@