### PR TITLE
chore(ci): auto-delete-branch DELETE 멱등 처리 (안전망)

### DIFF
--- a/.github/workflows/auto-delete-branch.yml
+++ b/.github/workflows/auto-delete-branch.yml
@@ -25,4 +25,6 @@ jobs:
             fi
           done
           echo "Deleting sub-branch: $HEAD_BRANCH"
-          gh api --method DELETE "repos/$REPO/git/refs/heads/$HEAD_BRANCH"
+          # ref가 이미 없어도(수동 삭제·중복 트리거 등) 워크플로우가 실패하지 않도록 멱등 처리
+          gh api --method DELETE "repos/$REPO/git/refs/heads/$HEAD_BRANCH" \
+            || echo "Branch already deleted or missing: $HEAD_BRANCH"


### PR DESCRIPTION
@
## 배경
`delete_branch_on_merge=false` 전환으로 GitHub 자동삭제와 워크플로우의 중복 삭제(422)는 이미 해소됨. 이 PR은 추가 안전망.

## 변경
auto-delete-branch.yml의 `gh api DELETE`에 `|| echo` 추가 → ref가 이미 없는 예외 상황(수동 삭제·중복 트리거 등)에도 `bash -e`에서 워크플로우가 실패하지 않도록 멱등 처리.

## 검증
`bash -e -c "false || echo ...; echo end"` → exit=0 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@