### PR TITLE
fix(admin): 추천 후보를 도메인 단위로 중복 제거

### DIFF
--- a/db/migrations/003_candidate_domain_unique.sql
+++ b/db/migrations/003_candidate_domain_unique.sql
@@ -1,0 +1,45 @@
+-- 추천 후보(inven_site_candidates)를 도메인 단위로 1행만 유지 (멱등)
+-- 기존: url이 UNIQUE → 같은 도메인이 다른 경로(loalogol.kr/ vs loalogol.kr/package)로
+--       각각 행이 쌓여 추천 목록에 중복 노출.
+-- 변경: domain을 UNIQUE로 → 도메인당 1행. 기존 중복은 병합(언급수 합산, 최단 url 대표).
+-- 실행: gh workflow run db-migrate.yml -f sql_file=db/migrations/003_candidate_domain_unique.sql
+
+SET search_path TO lost_ark, public;
+
+-- 1) 도메인별 대표 행 선정 + 합산 언급수 계산
+--    우선순위: added > rejected > pending → 최단 url → 최소 id
+CREATE TEMP TABLE _cand_dedupe AS
+SELECT
+  id,
+  domain,
+  ROW_NUMBER() OVER (
+    PARTITION BY domain
+    ORDER BY
+      CASE status WHEN 'added' THEN 0 WHEN 'rejected' THEN 1 ELSE 2 END,
+      length(url) ASC,
+      id ASC
+  ) AS rn,
+  SUM(mention_count) OVER (PARTITION BY domain) AS total_mentions
+FROM inven_site_candidates;
+
+-- 2) 대표 행에 도메인 합산 언급수 반영
+UPDATE inven_site_candidates c
+SET mention_count = d.total_mentions
+FROM _cand_dedupe d
+WHERE c.id = d.id
+  AND d.rn = 1
+  AND c.mention_count <> d.total_mentions;
+
+-- 3) 비대표(중복) 행 삭제
+DELETE FROM inven_site_candidates
+WHERE id IN (SELECT id FROM _cand_dedupe WHERE rn > 1);
+
+DROP TABLE _cand_dedupe;
+
+-- 4) url UNIQUE 제약/인덱스 제거 (환경별 이름 차이 대비)
+ALTER TABLE inven_site_candidates DROP CONSTRAINT IF EXISTS inven_site_candidates_url_key;
+DROP INDEX IF EXISTS inven_site_candidates_url_key;
+
+-- 5) domain UNIQUE 인덱스 추가
+CREATE UNIQUE INDEX IF NOT EXISTS inven_site_candidates_domain_key
+  ON inven_site_candidates (domain);

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -191,8 +191,8 @@ model inven_posts {
 
 model inven_site_candidates {
   id             BigInt   @id @default(autoincrement())
-  url            String   @unique
-  domain         String
+  url            String
+  domain         String   @unique
   name           String   @default("")
   description    String   @default("")
   category       String   @default("")

--- a/server/src/admin/repositories/admin-inven.repository.ts
+++ b/server/src/admin/repositories/admin-inven.repository.ts
@@ -125,8 +125,9 @@ export class AdminInvenRepository {
 
   /**
    * 추출된 사이트 후보를 inven_site_candidates에 upsert한다.
-   * 도메인 단위로 1행만 유지 — domain 충돌 시 pending 상태면 대표 url(더 짧은 것)과
-   * 언급 횟수를 갱신 (added/rejected는 건드리지 않음).
+   * 도메인 단위로 1행만 유지 — domain 충돌 시 pending 상태면 대표 url(더 짧은 것)을
+   * 갱신하고 언급 횟수를 누적 합산한다 (added/rejected는 건드리지 않음).
+   * 크롤은 날짜별 증분 배치라, 덮어쓰면 과거 언급수가 사라져 정렬이 왜곡됨.
    */
   async upsertCandidates(drafts: SiteCandidateDraft[]): Promise<number> {
     let saved = 0;
@@ -136,7 +137,7 @@ export class AdminInvenRepository {
           (url, domain, name, description, category, mention_count, sample_post_id, status)
         VALUES (${d.url}, ${d.domain}, '', '', '', ${d.mention_count}, ${d.sample_post_id}, 'pending')
         ON CONFLICT (domain) DO UPDATE SET
-          mention_count = EXCLUDED.mention_count,
+          mention_count = inven_site_candidates.mention_count + EXCLUDED.mention_count,
           url = CASE
             WHEN length(EXCLUDED.url) < length(inven_site_candidates.url)
             THEN EXCLUDED.url ELSE inven_site_candidates.url

--- a/server/src/admin/repositories/admin-inven.repository.ts
+++ b/server/src/admin/repositories/admin-inven.repository.ts
@@ -125,7 +125,8 @@ export class AdminInvenRepository {
 
   /**
    * 추출된 사이트 후보를 inven_site_candidates에 upsert한다.
-   * url 충돌 시 pending 상태면 언급 횟수만 갱신 (added/rejected는 건드리지 않음).
+   * 도메인 단위로 1행만 유지 — domain 충돌 시 pending 상태면 대표 url(더 짧은 것)과
+   * 언급 횟수를 갱신 (added/rejected는 건드리지 않음).
    */
   async upsertCandidates(drafts: SiteCandidateDraft[]): Promise<number> {
     let saved = 0;
@@ -134,8 +135,12 @@ export class AdminInvenRepository {
         INSERT INTO inven_site_candidates
           (url, domain, name, description, category, mention_count, sample_post_id, status)
         VALUES (${d.url}, ${d.domain}, '', '', '', ${d.mention_count}, ${d.sample_post_id}, 'pending')
-        ON CONFLICT (url) DO UPDATE SET
-          mention_count = EXCLUDED.mention_count
+        ON CONFLICT (domain) DO UPDATE SET
+          mention_count = EXCLUDED.mention_count,
+          url = CASE
+            WHEN length(EXCLUDED.url) < length(inven_site_candidates.url)
+            THEN EXCLUDED.url ELSE inven_site_candidates.url
+          END
         WHERE inven_site_candidates.status = 'pending'
       `;
       saved += 1;

--- a/site-finder/migrations/001_create_inven_tables.sql
+++ b/site-finder/migrations/001_create_inven_tables.sql
@@ -23,8 +23,8 @@ CREATE INDEX IF NOT EXISTS idx_inven_posts_crawled       ON inven_posts (crawled
 -- 2) 추출된 사이트 후보 (이름/설명은 관리자가 입력)
 CREATE TABLE IF NOT EXISTS inven_site_candidates (
   id             BIGSERIAL PRIMARY KEY,
-  url            TEXT        NOT NULL UNIQUE,
-  domain         TEXT        NOT NULL,
+  url            TEXT        NOT NULL,
+  domain         TEXT        NOT NULL UNIQUE,
   name           TEXT        NOT NULL DEFAULT '',
   description    TEXT        NOT NULL DEFAULT '',
   category       TEXT        NOT NULL DEFAULT '',


### PR DESCRIPTION
@
## 문제
추천 후보 목록에 같은 도메인이 경로만 다른 채 중복 노출됨 (예: `loalogol.kr/package`와 `loalogol.kr/`).

## 원인
`inven_site_candidates.url`이 UNIQUE, `domain`은 아님. `extract()`는 도메인 단위 집계하지만 저장이 `ON CONFLICT (url)` 기준이라 다른 크롤 배치의 다른 경로가 새 행으로 누적됨.

## 변경
- `schema.prisma`, `site-finder/.../001_*.sql`: `url` UNIQUE → `domain` UNIQUE
- `admin-inven.repository.ts`: `ON CONFLICT (domain)`, 충돌 시 대표 url(최단)·mention_count 갱신
- `db/migrations/003_*.sql` (멱등): 기존 중복 도메인 병합(언급수 합산·최단 url 대표·우선순위 added>rejected>pending) 후 제약 교체

## 동작
`loalogol.kr/` + `loalogol.kr/package` → `loalogol.kr` 1행, 언급수 4, 대표 url `loalogol.kr/`.

## 검증
prisma generate ✅, tsc ✅, 관련 spec 없음. (로컬 DB·docker·psql 부재로 실측 불가 → 표준 SQL + 단일 psql 세션 + 멱등 작성)

## ⚠️ 머지 후 필요
`gh workflow run db-migrate.yml -f sql_file=db/migrations/003_candidate_domain_unique.sql`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@