### PR TITLE
feat(admin): 사이트 추가 모달에 Gemini AI 추천

### DIFF
--- a/client/app/admin/inven/page.tsx
+++ b/client/app/admin/inven/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { buildGuestNotice, useAdminRole } from "@/lib/admin-role";
 
 // ── 타입 ──────────────────────────────────────────────────────────────────────
@@ -18,19 +18,6 @@ interface SiteCandidate {
   created_at: string;
 }
 
-interface PipelineStatus {
-  running: boolean;
-  step: string;
-  stepIndex: number;
-  totalSteps: number;
-  percent: number;
-  message: string;
-  error: string | null;
-  startedAt: string | null;
-  finishedAt: string | null;
-  targetDate: string | null;
-}
-
 // ── 유틸 ──────────────────────────────────────────────────────────────────────
 
 async function apiFetch(path: string, opts?: RequestInit) {
@@ -42,8 +29,7 @@ async function apiFetch(path: string, opts?: RequestInit) {
 // ── 컴포넌트 ──────────────────────────────────────────────────────────────────
 
 export default function AdminInvenPage() {
-  const [tab, setTab] = useState<"candidates" | "pipeline">("candidates");
-  // 게스트 권한 안내 (제목 아래 고정 표시) — 탭 전환 시 초기화
+  // 게스트 권한 안내 (제목 아래 고정 표시)
   const [accessNotice, setAccessNotice] = useState("");
   const role = useAdminRole();
   const isGuest = role === "guest";
@@ -53,16 +39,6 @@ export default function AdminInvenPage() {
     if (!isGuest) return true;
     setAccessNotice(buildGuestNotice(action));
     return false;
-  };
-
-  const switchTab = (t: "candidates" | "pipeline") => {
-    setAccessNotice("");
-    setTab(t);
-  };
-
-  const TAB_LABELS = {
-    candidates: "🔎 추천 사이트",
-    pipeline:   "⚙️ 수집 실행",
   };
 
   return (
@@ -78,27 +54,7 @@ export default function AdminInvenPage() {
         </pre>
       )}
 
-      {/* 탭 */}
-      <div className="flex gap-2 border-b border-[color:var(--admin-border)] pb-0">
-        {(Object.keys(TAB_LABELS) as Array<keyof typeof TAB_LABELS>).map((t) => (
-          <button
-            key={t}
-            onClick={() => switchTab(t)}
-            className={`px-4 py-2 text-sm rounded-t-lg transition-colors ${
-              tab === t
-                ? "bg-white border border-b-white border-[color:var(--admin-border)] -mb-px font-medium"
-                : "text-[color:var(--admin-muted)] hover:text-[color:var(--admin-fg)]"
-            }`}
-          >
-            {TAB_LABELS[t]}
-          </button>
-        ))}
-      </div>
-
-      <div className="pt-2">
-        {tab === "candidates" && <CandidatesTab requireMaster={requireMaster} />}
-        {tab === "pipeline" && <PipelineTab requireMaster={requireMaster} />}
-      </div>
+      <CandidatesTab requireMaster={requireMaster} />
     </div>
   );
 }
@@ -157,6 +113,9 @@ function CandidatesTab({ requireMaster }: { requireMaster: (action: string) => b
   const [form, setForm] = useState<SiteForm>(EMPTY_SITE_FORM);
   const [saving, setSaving] = useState(false);
   const [formError, setFormError] = useState("");
+  // AI 추천 생성 후 모달을 채웠는지 표시 (안내 문구용)
+  const [aiFilled, setAiFilled] = useState(false);
+  const [suggesting, setSuggesting] = useState(false);
 
   const load = async () => {
     setLoading(true);
@@ -179,6 +138,7 @@ function CandidatesTab({ requireMaster }: { requireMaster: (action: string) => b
   const openAddModal = (c: SiteCandidate) => {
     if (!requireMaster("사이트 추가")) return;
     setAddTarget(c);
+    setAiFilled(false);
     setForm({
       name: c.name || "",
       href: `https://${c.domain}`,
@@ -189,10 +149,34 @@ function CandidatesTab({ requireMaster }: { requireMaster: (action: string) => b
     setFormError("");
   };
 
+  // 모달 안 "✨ AI 추천" → Gemini 호출(클릭 시에만) → 폼 자동 채움
+  const runAiSuggest = async () => {
+    if (!addTarget) return;
+    setSuggesting(true);
+    setFormError("");
+    try {
+      const s = await apiFetch(`/site-candidates/${addTarget.id}/suggest`, { method: "POST" });
+      setForm((p) => ({
+        ...p,
+        name: (s.name as string) || p.name,
+        category: (s.category as string) || p.category,
+        description: (s.description as string) || p.description,
+        icon: (s.icon as string) || p.icon,
+      }));
+      setAiFilled(true);
+    } catch (e) {
+      setFormError(e instanceof Error ? e.message : "AI 추천 실패");
+    } finally {
+      setSuggesting(false);
+    }
+  };
+
   const closeAddModal = () => {
     setAddTarget(null);
     setForm(EMPTY_SITE_FORM);
     setFormError("");
+    setAiFilled(false);
+    setSuggesting(false);
   };
 
   // 모달 저장 → 후보 승인 API (loa_sites 등록 + status=added)
@@ -260,7 +244,7 @@ function CandidatesTab({ requireMaster }: { requireMaster: (action: string) => b
         <div className="admin-card p-6 text-center">
           <p className="admin-page-subtitle">검토할 추천 사이트가 없습니다.</p>
           <p className="text-xs text-[color:var(--admin-muted)] mt-2">
-            「⚙️ 수집 실행」 탭에서 크롤링을 돌리면 새 사이트 후보가 모입니다.
+            수집이 돌면 인벤에서 언급된 새 사이트 후보가 여기에 모입니다.
           </p>
         </div>
       )}
@@ -300,7 +284,7 @@ function CandidatesTab({ requireMaster }: { requireMaster: (action: string) => b
                   setConfirmTarget(c);
                 }}
                 disabled={busyId === c.id}
-                className="admin-btn admin-btn-secondary text-xs px-3 py-1"
+                className="admin-btn admin-btn-secondary text-xs px-3 py-1 whitespace-nowrap"
               >
                 블랙리스트 등록
               </button>
@@ -329,14 +313,29 @@ function CandidatesTab({ requireMaster }: { requireMaster: (action: string) => b
               <h2 className="text-base font-semibold text-[color:var(--admin-text)]">
                 새 사이트 추가 · {addTarget.domain}
               </h2>
-              <button
-                onClick={closeAddModal}
-                disabled={saving}
-                className="text-[color:var(--admin-text-subtle)] hover:text-[color:var(--admin-text)] text-lg leading-none"
-              >
-                ✕
-              </button>
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={runAiSuggest}
+                  disabled={saving || suggesting}
+                  className="admin-btn admin-btn-secondary text-xs px-3 py-1 whitespace-nowrap"
+                  title="Gemini로 이름·카테고리·설명·아이콘을 추천받아 폼을 채웁니다"
+                >
+                  {suggesting ? "AI 추천 중..." : "✨ AI 추천"}
+                </button>
+                <button
+                  onClick={closeAddModal}
+                  disabled={saving}
+                  className="text-[color:var(--admin-text-subtle)] hover:text-[color:var(--admin-text)] text-lg leading-none"
+                >
+                  ✕
+                </button>
+              </div>
             </div>
+            {aiFilled && (
+              <p className="mb-4 rounded border border-blue-200 bg-blue-50 px-3 py-1.5 text-xs text-blue-700">
+                ✨ AI가 추천한 값으로 채웠습니다. 검토 후 수정해서 저장하세요.
+              </p>
+            )}
             <div className="flex gap-6">
               {/* 폼 */}
               <div className="flex-1 min-w-0">
@@ -422,155 +421,6 @@ function CandidatesTab({ requireMaster }: { requireMaster: (action: string) => b
           </div>
         </div>
       )}
-    </div>
-  );
-}
-
-// ── 수집 실행(파이프라인) 탭 ──────────────────────────────────────────────────
-
-const STEP_LABELS: Record<string, string> = {
-  crawl:   "크롤링",
-  save:    "DB 저장",
-  suggest: "사이트 추천",
-  done:    "완료",
-  error:   "오류",
-};
-
-function PipelineTab({ requireMaster }: { requireMaster: (action: string) => boolean }) {
-  const [status, setStatus] = useState<PipelineStatus | null>(null);
-  const [loading, setLoading] = useState(false);
-  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  const fetchStatus = async () => {
-    try {
-      const res = await apiFetch("/pipeline/status");
-      setStatus(res as unknown as PipelineStatus);
-      return res as unknown as PipelineStatus;
-    } catch {
-      return null;
-    }
-  };
-
-  const startPolling = () => {
-    if (pollRef.current) return;
-    pollRef.current = setInterval(async () => {
-      const s = await fetchStatus();
-      if (s && !s.running) stopPolling();
-    }, 2000);
-  };
-
-  const stopPolling = () => {
-    if (pollRef.current) {
-      clearInterval(pollRef.current);
-      pollRef.current = null;
-    }
-  };
-
-  useEffect(() => {
-    fetchStatus().then((s) => {
-      if (s?.running) startPolling();
-    });
-    return () => stopPolling();
-  }, []);
-
-  const handleRun = async () => {
-    if (!requireMaster("수집 실행")) return;
-    setLoading(true);
-    try {
-      await apiFetch("/pipeline/run", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({}),
-      });
-      await fetchStatus();
-      startPolling();
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const isRunning = status?.running ?? false;
-  const percent = status?.percent ?? 0;
-  const stepLabel = status?.step ? (STEP_LABELS[status.step] ?? status.step) : "";
-
-  return (
-    <div className="space-y-4 max-w-lg">
-      {/* 실행 버튼 */}
-      <div className="admin-card p-5 space-y-4">
-        <div>
-          <p className="text-sm font-medium">수동 수집 실행</p>
-          <p className="text-xs text-[color:var(--admin-muted)] mt-1">
-            어제 날짜 기준으로 크롤 → DB 저장 → 사이트 추출을 순서대로 실행합니다.
-          </p>
-        </div>
-
-        <button
-          onClick={handleRun}
-          disabled={isRunning || loading}
-          className="admin-btn admin-btn-primary w-full"
-        >
-          {isRunning ? "실행 중..." : "▶ 수집 시작"}
-        </button>
-
-        {(isRunning || (status && status.percent > 0)) && (
-          <div className="space-y-2">
-            <div className="flex justify-between text-xs">
-              <span className="text-[color:var(--admin-muted)]">
-                {stepLabel}
-                {status?.targetDate && ` (${status.targetDate})`}
-              </span>
-              <span className="font-medium">{percent}%</span>
-            </div>
-            <div className="w-full bg-gray-100 rounded-full h-2">
-              <div
-                className={`h-2 rounded-full transition-all duration-500 ${
-                  status?.step === "error" ? "bg-red-500" : "bg-blue-500"
-                }`}
-                style={{ width: `${percent}%` }}
-              />
-            </div>
-            <p className="text-xs text-[color:var(--admin-muted)]">{status?.message}</p>
-          </div>
-        )}
-
-        {status?.step === "done" && !isRunning && (
-          <p className="text-xs text-green-600 font-medium">
-            ✓ {status.finishedAt ? new Date(status.finishedAt).toLocaleString("ko-KR") : ""} 완료
-            — 「추천 사이트」 탭에서 결과를 확인하세요.
-          </p>
-        )}
-        {status?.error && <p className="text-xs text-red-500">오류: {status.error}</p>}
-      </div>
-
-      {/* 단계 안내 */}
-      <div className="admin-card p-4">
-        <p className="text-xs font-medium mb-2 text-[color:var(--admin-muted)]">실행 단계</p>
-        <div className="space-y-1">
-          {[
-            { key: "crawl",   label: "크롤링",      desc: "인벤 게시판 본문 + 댓글 수집" },
-            { key: "save",    label: "DB 저장",     desc: "수집 결과를 inven_posts에 저장" },
-            { key: "suggest", label: "사이트 추출", desc: "URL 추출 → 기존/daloa/인벤 제외 → 후보 저장" },
-          ].map((s) => {
-            const order = ["crawl", "save", "suggest"];
-            const idx = order.indexOf(s.key);
-            const done = status?.stepIndex !== undefined && idx < status.stepIndex;
-            const active = status?.step === s.key && isRunning;
-            return (
-              <div key={s.key} className="flex items-start gap-2 text-xs">
-                <span
-                  className={`shrink-0 mt-0.5 w-2 h-2 rounded-full ${
-                    active ? "bg-blue-500" : done ? "bg-green-400" : "bg-gray-200"
-                  }`}
-                />
-                <span>
-                  <span className="font-medium">{s.label}</span>
-                  <span className="text-[color:var(--admin-muted)]"> — {s.desc}</span>
-                </span>
-              </div>
-            );
-          })}
-        </div>
-      </div>
     </div>
   );
 }

--- a/client/app/admin/inven/page.tsx
+++ b/client/app/admin/inven/page.tsx
@@ -22,7 +22,18 @@ interface SiteCandidate {
 
 async function apiFetch(path: string, opts?: RequestInit) {
   const res = await fetch(`/api/admin/inven${path}`, opts);
-  if (!res.ok) throw new Error(await res.text());
+  if (!res.ok) {
+    const text = await res.text();
+    // 백엔드 에러 본문이 JSON이면 message만 추출해 사용자에게 노출
+    let msg = text;
+    try {
+      const j = JSON.parse(text) as { message?: unknown };
+      if (typeof j?.message === "string") msg = j.message;
+    } catch {
+      // JSON 아니면 원문 그대로
+    }
+    throw new Error(msg);
+  }
   return res.json() as Promise<Record<string, unknown>>;
 }
 

--- a/client/app/api/admin/inven/site-candidates/[id]/suggest/route.ts
+++ b/client/app/api/admin/inven/site-candidates/[id]/suggest/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+const NEST_API = process.env.NEST_API_URL ?? "http://localhost:3001";
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const store = await cookies();
+    const token = store.get("admin_token")?.value ?? "";
+
+    const res = await fetch(
+      `${NEST_API}/api/admin/inven/site-candidates/${id}/suggest`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "x-admin-session": token },
+        cache: "no-store",
+      },
+    );
+    const data = await res.json().catch(() => ({}));
+    return NextResponse.json(data, { status: res.status });
+  } catch {
+    return NextResponse.json({ message: "upstream unavailable" }, { status: 503 });
+  }
+}

--- a/server/src/admin/admin-inven.controller.ts
+++ b/server/src/admin/admin-inven.controller.ts
@@ -12,6 +12,7 @@ import {
 import { AdminGuard, AdminWriteGuard } from './admin.guard';
 import { AdminInvenRepository } from './repositories/admin-inven.repository';
 import { AdminInvenPipelineService } from './admin-inven-pipeline.service';
+import { SiteSuggestService } from './site-suggest.service';
 import { SitesRepository } from '../sites/sites.repository';
 import { SitesService } from '../sites/sites.service';
 
@@ -21,6 +22,7 @@ export class AdminInvenController {
   constructor(
     private readonly invenRepo: AdminInvenRepository,
     private readonly pipeline: AdminInvenPipelineService,
+    private readonly suggestService: SiteSuggestService,
     private readonly sitesRepo: SitesRepository,
     private readonly sitesService: SitesService,
   ) {}
@@ -88,6 +90,18 @@ export class AdminInvenController {
     await this.invenRepo.updateCandidateStatus(id, 'rejected');
     await this.invenRepo.addToBlacklist(cand.domain, '관리자 거부');
     return { ok: true };
+  }
+
+  /**
+   * 추천 후보에 대해 Gemini로 name/category/description/icon을 생성한다.
+   * 버튼 클릭 시에만 호출됨(자동 실행 없음) — 토큰 보호. master 전용.
+   */
+  @Post('site-candidates/:id/suggest')
+  @UseGuards(AdminWriteGuard)
+  async suggestCandidate(@Param('id', ParseIntPipe) id: number) {
+    const cand = await this.invenRepo.getSiteCandidateById(id);
+    if (!cand) throw new NotFoundException('후보를 찾을 수 없습니다');
+    return this.suggestService.suggest({ url: cand.url, domain: cand.domain });
   }
 
   /** 게시글 목록 (인기순) — 디버그/확인용 */

--- a/server/src/admin/admin.module.ts
+++ b/server/src/admin/admin.module.ts
@@ -20,6 +20,7 @@ import { AdminInvenRepository } from './repositories/admin-inven.repository';
 import { AdminInvenCronService } from './admin-inven-cron.service';
 import { AdminInvenPipelineService } from './admin-inven-pipeline.service';
 import { SiteExtractorService } from './site-extractor.service';
+import { SiteSuggestService } from './site-suggest.service';
 
 @Module({
   imports: [StreamersModule, SitesModule],
@@ -46,6 +47,7 @@ import { SiteExtractorService } from './site-extractor.service';
     AdminInvenCronService,
     AdminInvenPipelineService,
     SiteExtractorService,
+    SiteSuggestService,
   ],
   exports: [AdminAuthService],
 })

--- a/server/src/admin/site-suggest.service.spec.ts
+++ b/server/src/admin/site-suggest.service.spec.ts
@@ -1,0 +1,20 @@
+import { ConfigService } from '@nestjs/config';
+import { SiteSuggestService } from './site-suggest.service';
+
+// 토큰 보호 검증: GEMINI_API_KEY가 없으면 실제 Gemini·네트워크 호출 없이 즉시 예외여야 함.
+// (자동 실행이 없고 모달 버튼 클릭 시에만 호출되므로 별도 비활성 플래그는 두지 않음)
+describe('SiteSuggestService', () => {
+  const makeService = (cfg: Record<string, string>) => {
+    const config = {
+      get: (k: string) => cfg[k],
+    } as unknown as ConfigService;
+    return new SiteSuggestService(config);
+  };
+
+  const input = { url: 'https://example.kr', domain: 'example.kr' };
+
+  it('GEMINI_API_KEY 없으면 호출 없이 예외', async () => {
+    const svc = makeService({});
+    await expect(svc.suggest(input)).rejects.toThrow(/GEMINI_API_KEY/);
+  });
+});

--- a/server/src/admin/site-suggest.service.ts
+++ b/server/src/admin/site-suggest.service.ts
@@ -1,0 +1,141 @@
+import {
+  Injectable,
+  Logger,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import axios from 'axios';
+import * as cheerio from 'cheerio';
+
+export interface SiteSuggestion {
+  name: string;
+  category: string;
+  description: string;
+  icon: string;
+}
+
+// 사이트 관리에서 쓰는 카테고리와 결을 맞춘 추천 범위
+const CATEGORIES = ['정보', '커뮤니티', '거래', '방송', '공략', '도구', '기타'];
+
+interface SiteMeta {
+  title: string;
+  description: string;
+  ogImage: string;
+}
+
+/**
+ * 추천 후보(사이트)에 대해 Gemini로 name/category/description/icon을 생성한다.
+ * 자동 실행 없음 — 관리자가 모달에서 버튼을 누를 때만 호출되므로 토큰은 그때만 소모된다.
+ * (GEMINI_API_KEY가 없으면 비활성.)
+ */
+@Injectable()
+export class SiteSuggestService {
+  private readonly logger = new Logger(SiteSuggestService.name);
+  private readonly genAI: GoogleGenerativeAI | null;
+
+  constructor(private readonly config: ConfigService) {
+    const apiKey = this.config.get<string>('GEMINI_API_KEY');
+    this.genAI = apiKey ? new GoogleGenerativeAI(apiKey) : null;
+    if (!apiKey) {
+      this.logger.warn('GEMINI_API_KEY 미설정 — 사이트 AI 추천 비활성화');
+    }
+  }
+
+  /** 사이트 메타를 fetch해 Gemini로 추천 필드를 생성한다. */
+  async suggest(input: { url: string; domain: string }): Promise<SiteSuggestion> {
+    if (!this.genAI) {
+      throw new ServiceUnavailableException(
+        'GEMINI_API_KEY가 설정되지 않았습니다',
+      );
+    }
+
+    const meta = await this.fetchMeta(input.url);
+
+    const model = this.genAI.getGenerativeModel({
+      model: 'gemini-2.5-flash',
+      generationConfig: { responseMimeType: 'application/json' },
+    });
+
+    const prompt = [
+      '너는 로스트아크(게임) 관련 웹사이트를 분류하는 도우미야.',
+      '아래 사이트 정보를 보고 한국어로 추천해서 JSON 객체만 출력해.',
+      '- name: 사이트의 간결한 이름 (한국어 또는 영문)',
+      `- category: 반드시 다음 중 하나 — ${CATEGORIES.join(', ')}`,
+      '- description: 어떤 사이트인지 30자 이내 한 문장',
+      '- icon: 사이트 대표 로고/og:image의 절대 URL. 확실하지 않으면 빈 문자열 ""',
+      'JSON 키는 name, category, description, icon 네 개만.',
+      '',
+      `도메인: ${input.domain}`,
+      `URL: ${input.url}`,
+      meta.title ? `페이지 제목: ${meta.title}` : '',
+      meta.description ? `메타 설명: ${meta.description}` : '',
+      meta.ogImage ? `og:image: ${meta.ogImage}` : '',
+    ]
+      .filter(Boolean)
+      .join('\n');
+
+    let raw: string;
+    try {
+      const result = await model.generateContent(prompt);
+      raw = result.response.text();
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : '알 수 없는 오류';
+      throw new ServiceUnavailableException(`Gemini 호출 실패: ${msg}`);
+    }
+
+    const parsed = this.parse(raw);
+    // icon fallback: Gemini → og:image → google favicon
+    const icon =
+      parsed.icon?.trim() ||
+      meta.ogImage ||
+      `https://www.google.com/s2/favicons?domain=${input.domain}&sz=64`;
+
+    return {
+      name: parsed.name?.trim() || input.domain,
+      category: parsed.category?.trim() || '기타',
+      description: parsed.description?.trim() || '',
+      icon,
+    };
+  }
+
+  private parse(raw: string): Partial<SiteSuggestion> {
+    try {
+      const cleaned = raw.replace(/```json\s*|\s*```/g, '').trim();
+      return JSON.parse(cleaned) as Partial<SiteSuggestion>;
+    } catch {
+      this.logger.warn(`Gemini JSON 파싱 실패: ${raw.slice(0, 120)}`);
+      return {};
+    }
+  }
+
+  /** 사이트 메타(title/description/og:image) 추출. 실패해도 빈 값 반환(추천은 진행). */
+  private async fetchMeta(url: string): Promise<SiteMeta> {
+    try {
+      const res = await axios.get<string>(url, {
+        timeout: 8000,
+        maxContentLength: 3 * 1024 * 1024,
+        headers: {
+          'User-Agent':
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36',
+          'Accept-Language': 'ko-KR,ko;q=0.9',
+        },
+      });
+      const $ = cheerio.load(res.data);
+      const title =
+        $('title').first().text().trim() ||
+        $('meta[property="og:title"]').attr('content')?.trim() ||
+        '';
+      const description =
+        $('meta[name="description"]').attr('content')?.trim() ||
+        $('meta[property="og:description"]').attr('content')?.trim() ||
+        '';
+      const ogImage =
+        $('meta[property="og:image"]').attr('content')?.trim() || '';
+      return { title, description, ogImage };
+    } catch {
+      this.logger.debug(`사이트 메타 추출 실패 — 도메인만으로 추천: ${url}`);
+      return { title: '', description: '', ogImage: '' };
+    }
+  }
+}

--- a/server/src/admin/site-suggest.service.ts
+++ b/server/src/admin/site-suggest.service.ts
@@ -4,7 +4,7 @@ import {
   ServiceUnavailableException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { GoogleGenerativeAI } from '@google/generative-ai';
+import { GoogleGenerativeAI, SchemaType } from '@google/generative-ai';
 import axios from 'axios';
 import * as cheerio from 'cheerio';
 
@@ -54,7 +54,20 @@ export class SiteSuggestService {
 
     const model = this.genAI.getGenerativeModel({
       model: 'gemini-2.5-flash',
-      generationConfig: { responseMimeType: 'application/json' },
+      generationConfig: {
+        responseMimeType: 'application/json',
+        // 키·타입을 강제하고 category는 enum으로 제한 → 파싱 오류·잘못된 카테고리 차단
+        responseSchema: {
+          type: SchemaType.OBJECT,
+          properties: {
+            name: { type: SchemaType.STRING },
+            category: { type: SchemaType.STRING, enum: CATEGORIES, format: 'enum' },
+            description: { type: SchemaType.STRING },
+            icon: { type: SchemaType.STRING },
+          },
+          required: ['name', 'category', 'description', 'icon'],
+        },
+      },
     });
 
     const prompt = [
@@ -102,19 +115,30 @@ export class SiteSuggestService {
   private parse(raw: string): Partial<SiteSuggestion> {
     try {
       const cleaned = raw.replace(/```json\s*|\s*```/g, '').trim();
-      return JSON.parse(cleaned) as Partial<SiteSuggestion>;
+      const obj: unknown = JSON.parse(cleaned);
+      // null·배열·원시값 방어 — 순수 객체일 때만 사용
+      if (obj && typeof obj === 'object' && !Array.isArray(obj)) {
+        return obj as Partial<SiteSuggestion>;
+      }
+      return {};
     } catch {
       this.logger.warn(`Gemini JSON 파싱 실패: ${raw.slice(0, 120)}`);
       return {};
     }
   }
 
-  /** 사이트 메타(title/description/og:image) 추출. 실패해도 빈 값 반환(추천은 진행). */
+  /** 사이트 메타(title/description/og:image) 추출. 실패/위험 URL이면 빈 값 반환(추천은 진행). */
   private async fetchMeta(url: string): Promise<SiteMeta> {
+    // SSRF 방어: 크롤된 미검증 URL이므로 내부망/메타데이터 요청 차단
+    if (!this.isSafeUrl(url)) {
+      this.logger.warn(`안전하지 않은 URL — 메타 fetch 스킵: ${url}`);
+      return { title: '', description: '', ogImage: '' };
+    }
     try {
       const res = await axios.get<string>(url, {
         timeout: 8000,
         maxContentLength: 3 * 1024 * 1024,
+        maxRedirects: 2,
         headers: {
           'User-Agent':
             'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36',
@@ -130,12 +154,51 @@ export class SiteSuggestService {
         $('meta[name="description"]').attr('content')?.trim() ||
         $('meta[property="og:description"]').attr('content')?.trim() ||
         '';
-      const ogImage =
+      let ogImage =
         $('meta[property="og:image"]').attr('content')?.trim() || '';
+      // 상대 경로(/logo.png 등)는 대상 사이트 기준 절대 URL로 변환
+      if (ogImage) {
+        try {
+          ogImage = new URL(ogImage, url).href;
+        } catch {
+          ogImage = '';
+        }
+      }
       return { title, description, ogImage };
     } catch {
       this.logger.debug(`사이트 메타 추출 실패 — 도메인만으로 추천: ${url}`);
       return { title: '', description: '', ogImage: '' };
     }
+  }
+
+  /** http(s) + 공인 호스트만 허용 (루프백·사설·링크로컬 IP 차단). */
+  private isSafeUrl(raw: string): boolean {
+    let u: URL;
+    try {
+      u = new URL(raw);
+    } catch {
+      return false;
+    }
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') return false;
+
+    const host = u.hostname.toLowerCase().replace(/^\[|\]$/g, '');
+    if (host === 'localhost' || host.endsWith('.localhost')) return false;
+
+    // IPv4 리터럴 사설/예약 대역
+    const m = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+    if (m) {
+      const a = Number(m[1]);
+      const b = Number(m[2]);
+      if (a === 0 || a === 10 || a === 127) return false;
+      if (a === 169 && b === 254) return false; // 링크로컬(AWS 메타데이터 169.254.169.254)
+      if (a === 172 && b >= 16 && b <= 31) return false;
+      if (a === 192 && b === 168) return false;
+      if (a === 100 && b >= 64 && b <= 127) return false; // CGNAT
+    }
+
+    // IPv6 루프백/ULA/링크로컬
+    if (host === '::1' || /^f[cde]/.test(host)) return false;
+
+    return true;
   }
 }


### PR DESCRIPTION
@
## 개요
추천 후보를 사이트로 추가할 때, 모달 안에서 **AI 추천 버튼**을 누르면 Gemini가 name/category/description/icon을 생성해 폼을 자동으로 채웁니다. 관리자가 검토·수정 후 저장합니다.

## 변경
**서버**
- `SiteSuggestService`: 사이트 URL의 메타(title/description/og:image)를 fetch해 컨텍스트로 제공 → Gemini(gemini-2.5-flash)가 JSON으로 추천. icon은 Gemini→og:image→google favicon fallback. `GEMINI_API_KEY` 없으면 비활성
- `POST /api/admin/inven/site-candidates/:id/suggest` (AdminWriteGuard) — **모달 버튼 클릭 시에만 호출**(자동 실행 없음 → 토큰은 그때만 소모)
- spec: key 없을 때 실제 호출 없이 예외

**클라이언트**
- 사이트 추가 모달 헤더에 `✨ AI 추천` 버튼 → 클릭 시 폼 자동 채움 + "AI가 채웠습니다" 안내
- `⚙️ 수집 실행` 탭 제거 (서버 파이프라인/크론은 유지)
- suggest 프록시 라우트 추가

## 비고
- 별도 비활성 플래그는 두지 않음 — 버튼 클릭 시에만 도므로 로컬/CI 자동 토큰 소모가 없음
- 검증은 로컬 + CI에서 확인 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@