### PR TITLE
feat(admin): 사이트 후보 아이콘 자동 수집 및 선택 UI

### DIFF
--- a/client/app/admin/inven/page.tsx
+++ b/client/app/admin/inven/page.tsx
@@ -127,6 +127,8 @@ function CandidatesTab({ requireMaster }: { requireMaster: (action: string) => b
   // AI 추천 생성 후 모달을 채웠는지 표시 (안내 문구용)
   const [aiFilled, setAiFilled] = useState(false);
   const [suggesting, setSuggesting] = useState(false);
+  // AI가 추천한 아이콘 (og:image 자동 fetch와 별도 보관 → 선택 UI)
+  const [aiIcon, setAiIcon] = useState<string>("");
 
   const load = async () => {
     setLoading(true);
@@ -152,12 +154,18 @@ function CandidatesTab({ requireMaster }: { requireMaster: (action: string) => b
     setAiFilled(false);
     setForm({
       name: c.name || "",
-      href: `https://${c.domain}`,
+      href: c.url,
       category: c.category || "",
       description: c.description || "",
       icon: "",
     });
     setFormError("");
+    // 모달 열리자마자 og:image 자동 fetch (Gemini 없이)
+    apiFetch(`/site-candidates/${c.id}/icon`)
+      .then((res) => {
+        if (res.icon) setForm((p) => ({ ...p, icon: res.icon as string }));
+      })
+      .catch(() => {});
   };
 
   // 모달 안 "✨ AI 추천" → Gemini 호출(클릭 시에만) → 폼 자동 채움
@@ -172,8 +180,8 @@ function CandidatesTab({ requireMaster }: { requireMaster: (action: string) => b
         name: (s.name as string) || p.name,
         category: (s.category as string) || p.category,
         description: (s.description as string) || p.description,
-        icon: (s.icon as string) || p.icon,
       }));
+      if (s.icon) setAiIcon(s.icon as string);
       setAiFilled(true);
     } catch (e) {
       setFormError(e instanceof Error ? e.message : "AI 추천 실패");
@@ -188,6 +196,7 @@ function CandidatesTab({ requireMaster }: { requireMaster: (action: string) => b
     setFormError("");
     setAiFilled(false);
     setSuggesting(false);
+    setAiIcon("");
   };
 
   // 모달 저장 → 후보 승인 API (loa_sites 등록 + status=added)
@@ -361,6 +370,29 @@ function CandidatesTab({ requireMaster }: { requireMaster: (action: string) => b
                         onChange={(e) => setForm((p) => ({ ...p, [field]: e.target.value }))}
                         className="admin-input"
                       />
+                      {field === "icon" && aiIcon && aiIcon !== form.icon && (
+                        <div className="mt-2 flex items-center gap-3">
+                          <span className="text-xs text-[color:var(--admin-text-muted)]">아이콘 선택</span>
+                          {[{ src: form.icon, label: "현재" }, { src: aiIcon, label: "AI" }].map(({ src, label }) => (
+                            src ? (
+                              <button
+                                key={label}
+                                type="button"
+                                onClick={() => setForm((p) => ({ ...p, icon: src }))}
+                                className={`flex flex-col items-center gap-0.5 rounded border px-2 py-1 text-xs transition-colors ${
+                                  form.icon === src
+                                    ? "border-blue-400 bg-blue-50 text-blue-700"
+                                    : "border-[color:var(--admin-border)] text-[color:var(--admin-text-muted)] hover:border-blue-300"
+                                }`}
+                              >
+                                {/* eslint-disable-next-line @next/next/no-img-element */}
+                                <img src={src} alt="" width={20} height={20} className="rounded-sm" />
+                                {label}
+                              </button>
+                            ) : null
+                          ))}
+                        </div>
+                      )}
                     </div>
                   ))}
                 </div>

--- a/client/app/admin/inven/page.tsx
+++ b/client/app/admin/inven/page.tsx
@@ -129,6 +129,10 @@ function CandidatesTab({ requireMaster }: { requireMaster: (action: string) => b
   const [suggesting, setSuggesting] = useState(false);
   // AI가 추천한 아이콘 (og:image 자동 fetch와 별도 보관 → 선택 UI)
   const [aiIcon, setAiIcon] = useState<string>("");
+  // 자동 fetch로 가져온 기본 아이콘 (AI 선택 후에도 복구 가능하도록 보관)
+  const [fetchedIcon, setFetchedIcon] = useState<string>("");
+  // 경쟁 상태 방지: 현재 열린 후보 ID와 응답 대상 ID가 다르면 폼 갱신 무시
+  const [activeFetchId, setActiveFetchId] = useState<number | null>(null);
 
   const load = async () => {
     setLoading(true);
@@ -160,10 +164,18 @@ function CandidatesTab({ requireMaster }: { requireMaster: (action: string) => b
       icon: "",
     });
     setFormError("");
+    setActiveFetchId(c.id);
     // 모달 열리자마자 og:image 자동 fetch (Gemini 없이)
     apiFetch(`/site-candidates/${c.id}/icon`)
       .then((res) => {
-        if (res.icon) setForm((p) => ({ ...p, icon: res.icon as string }));
+        setActiveFetchId((cur) => {
+          if (cur === c.id && res.icon) {
+            const iconUrl = res.icon as string;
+            setForm((p) => ({ ...p, icon: iconUrl }));
+            setFetchedIcon(iconUrl);
+          }
+          return cur;
+        });
       })
       .catch(() => {});
   };
@@ -197,6 +209,8 @@ function CandidatesTab({ requireMaster }: { requireMaster: (action: string) => b
     setAiFilled(false);
     setSuggesting(false);
     setAiIcon("");
+    setFetchedIcon("");
+    setActiveFetchId(null);
   };
 
   // 모달 저장 → 후보 승인 API (loa_sites 등록 + status=added)
@@ -370,10 +384,10 @@ function CandidatesTab({ requireMaster }: { requireMaster: (action: string) => b
                         onChange={(e) => setForm((p) => ({ ...p, [field]: e.target.value }))}
                         className="admin-input"
                       />
-                      {field === "icon" && aiIcon && aiIcon !== form.icon && (
+                      {field === "icon" && aiIcon && aiIcon !== fetchedIcon && (
                         <div className="mt-2 flex items-center gap-3">
                           <span className="text-xs text-[color:var(--admin-text-muted)]">아이콘 선택</span>
-                          {[{ src: form.icon, label: "현재" }, { src: aiIcon, label: "AI" }].map(({ src, label }) => (
+                          {[{ src: fetchedIcon, label: "기본" }, { src: aiIcon, label: "AI" }].map(({ src, label }) => (
                             src ? (
                               <button
                                 key={label}

--- a/client/app/api/admin/inven/site-candidates/[id]/icon/route.ts
+++ b/client/app/api/admin/inven/site-candidates/[id]/icon/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+const NEST_API = process.env.NEST_API_URL ?? "http://localhost:3001";
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const store = await cookies();
+    const token = store.get("admin_token")?.value ?? "";
+
+    const res = await fetch(
+      `${NEST_API}/api/admin/inven/site-candidates/${id}/icon`,
+      {
+        headers: { "x-admin-session": token },
+        cache: "no-store",
+      },
+    );
+    const data = await res.json().catch(() => ({}));
+    return NextResponse.json(data, { status: res.status });
+  } catch {
+    return NextResponse.json({ message: "upstream unavailable" }, { status: 503 });
+  }
+}

--- a/server/src/admin/admin-inven.controller.ts
+++ b/server/src/admin/admin-inven.controller.ts
@@ -92,6 +92,18 @@ export class AdminInvenController {
     return { ok: true };
   }
 
+  /** 사이트 아이콘(og:image → 파비콘)만 반환한다. Gemini 호출 없음. */
+  @Get('site-candidates/:id/icon')
+  async getCandidateIcon(@Param('id', ParseIntPipe) id: number) {
+    const cand = await this.invenRepo.getSiteCandidateById(id);
+    if (!cand) throw new NotFoundException('후보를 찾을 수 없습니다');
+    const icon = await this.suggestService.fetchIcon({
+      url: cand.url,
+      domain: cand.domain,
+    });
+    return { icon };
+  }
+
   /**
    * 추천 후보에 대해 Gemini로 name/category/description/icon을 생성한다.
    * 버튼 클릭 시에만 호출됨(자동 실행 없음) — 토큰 보호. master 전용.

--- a/server/src/admin/site-suggest.service.ts
+++ b/server/src/admin/site-suggest.service.ts
@@ -74,6 +74,15 @@ export class SiteSuggestService {
     });
   }
 
+  /** og:image 또는 파비콘 URL만 반환한다 (Gemini 호출 없음). */
+  async fetchIcon(input: { url: string; domain: string }): Promise<string> {
+    const meta = await this.fetchMeta(input.url);
+    return (
+      meta.ogImage ||
+      `https://www.google.com/s2/favicons?domain=${input.domain}&sz=64`
+    );
+  }
+
   /** 사이트 메타를 fetch해 Gemini로 추천 필드를 생성한다. */
   async suggest(input: {
     url: string;


### PR DESCRIPTION
## Summary

- 사이트 후보 모달 오픈 시 og:image 자동 fetch (Gemini 없이)
- href 필드를 도메인 루트 대신 실제 수집 URL로 채우도록 수정
- AI 추천 아이콘과 기본 아이콘 선택 UI 추가 (기본↔AI 토글)
- 경쟁 상태 방지 및 토글 버그 수정 (fetchedIcon, activeFetchId)

🤖 Generated with [Claude Code](https://claude.com/claude-code)