### PR TITLE
fix(admin): 모니터링 분포 0% 숨김 + 일별 그래프 오늘(KST) 표시

### DIFF
--- a/client/app/admin/monitoring/page.tsx
+++ b/client/app/admin/monitoring/page.tsx
@@ -85,7 +85,10 @@ function toFixedHundred<T extends { count: number }>(
     remainder -= 1;
     cursor += 1;
   }
-  return raw.map((r, idx) => ({ ...r.item, pct: pct[idx] }));
+  // 반올림 결과 0%인 항목은 숨김(0.x% 같은 미미한 값이 0%로 표시되는 노이즈 제거)
+  return raw
+    .map((r, idx) => ({ ...r.item, pct: pct[idx] }))
+    .filter((item) => item.pct > 0);
 }
 
 let monitoringCache: Dashboard | null = null;

--- a/server/src/admin/repositories/monitoring.repository.ts
+++ b/server/src/admin/repositories/monitoring.repository.ts
@@ -352,7 +352,8 @@ export class MonitoringRepository {
              INTERVAL '1 day'
            ) AS d(day)
       LEFT JOIN apm_site_clicks c
-        ON (c.created_at AT TIME ZONE 'Asia/Seoul')::date = d.day
+        ON c.created_at >= d.day AT TIME ZONE 'Asia/Seoul'
+       AND c.created_at < (d.day + INTERVAL '1 day') AT TIME ZONE 'Asia/Seoul'
       GROUP BY d.day
       ORDER BY d.day ASC
     `;
@@ -371,7 +372,8 @@ export class MonitoringRepository {
              INTERVAL '1 day'
            ) AS d(day)
       LEFT JOIN apm_youtube_clicks c
-        ON (c.created_at AT TIME ZONE 'Asia/Seoul')::date = d.day
+        ON c.created_at >= d.day AT TIME ZONE 'Asia/Seoul'
+       AND c.created_at < (d.day + INTERVAL '1 day') AT TIME ZONE 'Asia/Seoul'
       GROUP BY d.day
       ORDER BY d.day ASC
     `;

--- a/server/src/admin/repositories/monitoring.repository.ts
+++ b/server/src/admin/repositories/monitoring.repository.ts
@@ -227,7 +227,7 @@ export class MonitoringRepository {
         ${input.countryCode},
         ${input.osName},
         ${input.browserName},
-        CURRENT_DATE,
+        (NOW() AT TIME ZONE 'Asia/Seoul')::date,
         NOW()
       )
       ON CONFLICT (path, device_type, country_code, os_name, browser_name, visit_day)
@@ -322,14 +322,15 @@ export class MonitoringRepository {
 
   async findPageVisitSeriesDays(days: number) {
     // visit_day(방문 날짜)별 visits 합 = 그날 실제 방문 횟수. generate_series로 빈 날도 0.
+    // 일자 경계는 한국시간(Asia/Seoul) 기준 — DB 서버 타임존(프로덕션=UTC)과 무관하게 '오늘'까지 표시.
     return this.prisma.$queryRaw<
       Array<{ bucket: string; count: bigint | number }>
     >`
       SELECT TO_CHAR(d.day, 'MM-DD') AS bucket,
              COALESCE(SUM(p.visits), 0) AS count
       FROM generate_series(
-             (CURRENT_DATE - ((${days}::int - 1) * INTERVAL '1 day'))::date,
-             CURRENT_DATE,
+             ((NOW() AT TIME ZONE 'Asia/Seoul')::date - ((${days}::int - 1) * INTERVAL '1 day'))::date,
+             (NOW() AT TIME ZONE 'Asia/Seoul')::date,
              INTERVAL '1 day'
            ) AS d(day)
       LEFT JOIN apm_page_visits p ON p.visit_day = d.day
@@ -339,36 +340,38 @@ export class MonitoringRepository {
   }
 
   async findSiteClickSeriesDays(days: number) {
-    // 데이터 없는 날도 0으로 채우기 (generate_series + LEFT JOIN)
+    // 데이터 없는 날도 0으로 채우기 (generate_series + LEFT JOIN). 일자 경계는 한국시간 기준.
     return this.prisma.$queryRaw<
       Array<{ bucket: string; count: bigint | number }>
     >`
       SELECT TO_CHAR(d.day, 'MM-DD') AS bucket,
              COUNT(c.id) AS count
       FROM generate_series(
-             (CURRENT_DATE - ((${days}::int - 1) * INTERVAL '1 day'))::date,
-             CURRENT_DATE,
+             ((NOW() AT TIME ZONE 'Asia/Seoul')::date - ((${days}::int - 1) * INTERVAL '1 day'))::date,
+             (NOW() AT TIME ZONE 'Asia/Seoul')::date,
              INTERVAL '1 day'
            ) AS d(day)
-      LEFT JOIN apm_site_clicks c ON DATE(c.created_at) = d.day
+      LEFT JOIN apm_site_clicks c
+        ON (c.created_at AT TIME ZONE 'Asia/Seoul')::date = d.day
       GROUP BY d.day
       ORDER BY d.day ASC
     `;
   }
 
   async findYoutubeClickSeriesDays(days: number) {
-    // 데이터 없는 날도 0으로 채우기 (generate_series + LEFT JOIN)
+    // 데이터 없는 날도 0으로 채우기 (generate_series + LEFT JOIN). 일자 경계는 한국시간 기준.
     return this.prisma.$queryRaw<
       Array<{ bucket: string; count: bigint | number }>
     >`
       SELECT TO_CHAR(d.day, 'MM-DD') AS bucket,
              COUNT(c.id) AS count
       FROM generate_series(
-             (CURRENT_DATE - ((${days}::int - 1) * INTERVAL '1 day'))::date,
-             CURRENT_DATE,
+             ((NOW() AT TIME ZONE 'Asia/Seoul')::date - ((${days}::int - 1) * INTERVAL '1 day'))::date,
+             (NOW() AT TIME ZONE 'Asia/Seoul')::date,
              INTERVAL '1 day'
            ) AS d(day)
-      LEFT JOIN apm_youtube_clicks c ON DATE(c.created_at) = d.day
+      LEFT JOIN apm_youtube_clicks c
+        ON (c.created_at AT TIME ZONE 'Asia/Seoul')::date = d.day
       GROUP BY d.day
       ORDER BY d.day ASC
     `;


### PR DESCRIPTION
## 요약

- **분포 차트 0% 숨김**: 반올림 후 0%가 된 항목 제외 (국가/OS/브라우저/디바이스/사이트)
- **일별 그래프 오늘(KST) 표시**: 일자 경계를 `Asia/Seoul` 기준으로 명시 → 프로덕션(UTC DB)에서도 KST 자정~오전 9시에 오늘 버킷이 보임
- **성능**: 클릭 시리즈 JOIN을 sargable 범위 조건으로 (created_at 인덱스 활용)

상세: #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)