### PR TITLE
feat(admin): 메인페이지 로딩 속도 측정·추적 (RUM + 합성 프로브)

### DIFF
--- a/client/app/admin/monitoring/page.tsx
+++ b/client/app/admin/monitoring/page.tsx
@@ -5,11 +5,30 @@ import {
   Area,
   AreaChart,
   CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
   ResponsiveContainer,
   Tooltip,
   XAxis,
   YAxis,
 } from "recharts";
+
+interface PageLoadPoint {
+  bucket: string;
+  ttfb: number | null;
+  dcl: number | null;
+  lcp: number | null;
+  load: number | null;
+  count: number;
+}
+
+const PAGE_LOAD_METRICS = [
+  { key: "load", label: "전체 로딩", color: "#2563eb" },
+  { key: "lcp", label: "LCP", color: "#16a34a" },
+  { key: "dcl", label: "DCL", color: "#7c3aed" },
+  { key: "ttfb", label: "TTFB", color: "#f59e0b" },
+] as const;
 
 type Dashboard = {
   summary: {
@@ -105,6 +124,12 @@ export default function MonitoringPage() {
   const [sectionTab, setSectionTab] = useState<
     "sites" | "stat-builds" | "youtube"
   >("sites");
+  const [pageLoadSource, setPageLoadSource] = useState<"rum" | "synthetic">(
+    "rum",
+  );
+  const [pageLoadDays, setPageLoadDays] = useState<1 | 7 | 30>(7);
+  const [pageLoadSeries, setPageLoadSeries] = useState<PageLoadPoint[]>([]);
+  const [pageLoadLoading, setPageLoadLoading] = useState(true);
   const hasLoadedRef = useRef(false);
   const prevVisitCountRef = useRef(0);
 
@@ -183,6 +208,37 @@ export default function MonitoringPage() {
       alive = false;
     };
   }, [pageVisitDays]);
+
+  useEffect(() => {
+    let alive = true;
+    setPageLoadLoading(true);
+    async function loadPageLoad() {
+      try {
+        const res = await fetch(
+          `/api/admin/monitoring/page-load-series?source=${pageLoadSource}&days=${pageLoadDays}`,
+          { cache: "no-store" },
+        );
+        if (!alive || !res.ok) return;
+        const series = (await res.json()) as PageLoadPoint[];
+        setPageLoadSeries(Array.isArray(series) ? series : []);
+      } catch {
+        // keep previous
+      } finally {
+        if (alive) setPageLoadLoading(false);
+      }
+    }
+    void loadPageLoad();
+    return () => {
+      alive = false;
+    };
+  }, [pageLoadSource, pageLoadDays]);
+
+  const pageLoadLatest = useMemo(() => {
+    for (let i = pageLoadSeries.length - 1; i >= 0; i -= 1) {
+      if ((pageLoadSeries[i].count ?? 0) > 0) return pageLoadSeries[i];
+    }
+    return null;
+  }, [pageLoadSeries]);
 
   const siteClickTotal = useMemo(
     () => data.siteClicks.reduce((sum, item) => sum + item.clickCount, 0),
@@ -304,6 +360,106 @@ export default function MonitoringPage() {
       )}
 
       <div className="grid grid-cols-1 gap-4">
+        <div className="admin-card p-3">
+          <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+            <div className="flex items-center gap-2">
+              <p className="text-sm font-semibold">메인페이지 로딩 속도 추이</p>
+              {pageLoadLatest && (
+                <span className="text-xs text-[color:var(--admin-text-muted)]">
+                  최근 전체로딩{" "}
+                  <span className="font-semibold text-[color:var(--admin-text)]">
+                    {pageLoadLatest.load ?? "-"}ms
+                  </span>
+                  {pageLoadLatest.lcp != null && ` · LCP ${pageLoadLatest.lcp}ms`}
+                </span>
+              )}
+            </div>
+            <div className="flex items-center gap-2">
+              <div className="flex items-center gap-1 rounded-md bg-slate-100 p-0.5">
+                {(
+                  [
+                    { key: "rum", label: "실사용자" },
+                    { key: "synthetic", label: "합성" },
+                  ] as const
+                ).map((s) => (
+                  <button
+                    key={s.key}
+                    type="button"
+                    onClick={() => setPageLoadSource(s.key)}
+                    className={`rounded px-2 py-1 text-xs ${pageLoadSource === s.key ? "bg-white font-semibold text-[color:var(--admin-text)]" : "text-[color:var(--admin-text-muted)]"}`}
+                  >
+                    {s.label}
+                  </button>
+                ))}
+              </div>
+              <div className="flex gap-1">
+                {([1, 7, 30] as const).map((d) => (
+                  <button
+                    key={d}
+                    type="button"
+                    onClick={() => setPageLoadDays(d)}
+                    className={`admin-btn admin-btn-sm ${pageLoadDays === d ? "admin-btn-primary" : "admin-btn-secondary"}`}
+                  >
+                    {d}일
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+          {pageLoadSource === "synthetic" && (
+            <p className="mb-2 text-[11px] text-[color:var(--admin-text-subtle)]">
+              합성은 서버가 10분마다 메인 HTML 문서를 받아 측정 (TTFB·문서완료만,
+              JS/자원/렌더 제외)
+            </p>
+          )}
+          <div className="h-48">
+            {pageLoadLoading ? (
+              <div className="grid h-full place-items-center text-sm text-[color:var(--admin-text-muted)]">
+                불러오는 중...
+              </div>
+            ) : pageLoadSeries.every((p) => (p.count ?? 0) === 0) ? (
+              <div className="grid h-full place-items-center text-sm text-[color:var(--admin-text-muted)]">
+                데이터 없음 (수집 시작 후 표시됩니다)
+              </div>
+            ) : (
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart
+                  data={pageLoadSeries}
+                  onMouseEnter={() => setActiveChart("page-load")}
+                  onMouseLeave={() => setActiveChart(null)}
+                >
+                  <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                  <XAxis
+                    dataKey="bucket"
+                    tick={{ fontSize: 9, fill: "#6b7280" }}
+                  />
+                  <YAxis tick={{ fontSize: 10, fill: "#6b7280" }} unit="ms" />
+                  <Tooltip
+                    active={activeChart === "page-load"}
+                    formatter={(v, name) => [v == null ? "-" : `${v}ms`, name]}
+                    wrapperStyle={{ pointerEvents: "none" }}
+                  />
+                  <Legend wrapperStyle={{ fontSize: 11 }} />
+                  {PAGE_LOAD_METRICS.filter(
+                    (m) => pageLoadSource === "rum" || m.key === "ttfb" || m.key === "load",
+                  ).map((m) => (
+                    <Line
+                      key={m.key}
+                      type="monotone"
+                      dataKey={m.key}
+                      name={m.label}
+                      stroke={m.color}
+                      dot={false}
+                      strokeWidth={2}
+                      connectNulls
+                    />
+                  ))}
+                </LineChart>
+              </ResponsiveContainer>
+            )}
+          </div>
+        </div>
+
         <div className="grid auto-rows-min content-start grid-cols-1 gap-4 xl:grid-cols-2">
           <div className="admin-card p-3">
             <div className="mb-2 flex items-center justify-between">

--- a/client/app/api/admin/monitoring/page-load-series/route.ts
+++ b/client/app/api/admin/monitoring/page-load-series/route.ts
@@ -1,0 +1,21 @@
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+
+const NEST_API = process.env.NEST_API_URL ?? "http://localhost:3001";
+
+export async function GET(req: NextRequest) {
+  const store = await cookies();
+  const token = store.get("admin_token")?.value ?? "";
+  const source = req.nextUrl.searchParams.get("source") ?? "rum";
+  const days = req.nextUrl.searchParams.get("days") ?? "7";
+  try {
+    const res = await fetch(
+      `${NEST_API}/api/admin/monitoring/page-load-series?source=${encodeURIComponent(source)}&days=${encodeURIComponent(days)}`,
+      { headers: { "x-admin-session": token }, cache: "no-store" },
+    );
+    const data = await res.json().catch(() => []);
+    return NextResponse.json(data, { status: res.status });
+  } catch {
+    return NextResponse.json([], { status: 503 });
+  }
+}

--- a/client/app/api/telemetry/route.ts
+++ b/client/app/api/telemetry/route.ts
@@ -62,6 +62,8 @@ export async function POST(req: NextRequest) {
           ? "/api/telemetry/site-click"
           : body?.type === "youtube-click"
             ? "/api/telemetry/youtube-click"
+            : body?.type === "page-load"
+              ? "/api/telemetry/page-load"
         : null;
 
   if (!endpoint) {

--- a/client/components/MonitoringBeacon.tsx
+++ b/client/components/MonitoringBeacon.tsx
@@ -74,38 +74,43 @@ export default function MonitoringBeacon() {
     }
 
     let sent = false;
-    const report = () => {
+    const ms = (v: number) => (v > 0 ? Math.round(v) : null);
+    const report = (isUnloading = false) => {
       if (sent) return;
       const nav = performance.getEntriesByType("navigation")[0] as
         | PerformanceNavigationTiming
         | undefined;
-      if (!nav || !nav.loadEventEnd) return; // load 완료 전이면 보류
+      if (!nav) return;
+      // load 완료 전이면 보류 — 단, 이탈 시점엔 부분 지표라도 전송(느린 로딩 이탈 추적)
+      if (!nav.loadEventEnd && !isUnloading) return;
       sent = true;
       lcpObserver?.disconnect();
       send({
         type: "page-load",
         path: "/",
         deviceType: classifyDevice(navigator.userAgent ?? ""),
-        ttfb: Math.round(nav.responseStart),
-        dcl: Math.round(nav.domContentLoadedEventEnd),
-        load: Math.round(nav.loadEventEnd),
+        ttfb: ms(nav.responseStart),
+        dcl: ms(nav.domContentLoadedEventEnd),
+        load: ms(nav.loadEventEnd),
         lcp: lcp ? Math.round(lcp) : null,
       });
     };
 
-    const onLoad = () => window.setTimeout(report, 0);
+    const onLoad = () => window.setTimeout(() => report(false), 0);
     if (document.readyState === "complete") {
-      window.setTimeout(report, 0);
+      window.setTimeout(() => report(false), 0);
     } else {
       window.addEventListener("load", onLoad, { once: true });
     }
-    // 탭을 빨리 닫는 경우 대비: 숨김 전 마지막 보고 시도
-    document.addEventListener("visibilitychange", () => {
-      if (document.visibilityState === "hidden") report();
-    });
+    // 이탈(탭 닫기/전환) 시 부분 지표라도 보고
+    const onVisibility = () => {
+      if (document.visibilityState === "hidden") report(true);
+    };
+    document.addEventListener("visibilitychange", onVisibility);
 
     return () => {
       window.removeEventListener("load", onLoad);
+      document.removeEventListener("visibilitychange", onVisibility);
       lcpObserver?.disconnect();
     };
   }, []);

--- a/client/components/MonitoringBeacon.tsx
+++ b/client/components/MonitoringBeacon.tsx
@@ -51,5 +51,64 @@ export default function MonitoringBeacon() {
     });
   }, [pathname]);
 
+  // RUM: 최초 문서 로딩 1회만 측정(메인페이지 한정). SPA 라우팅엔 navigation 엔트리가 없음.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (window.location.pathname !== "/") return;
+    if (!("performance" in window) || !performance.getEntriesByType) return;
+
+    // LCP는 마지막 값이 가장 정확 — observer로 추적하다 보고 시점에 사용
+    let lcp = 0;
+    let lcpObserver: PerformanceObserver | null = null;
+    try {
+      lcpObserver = new PerformanceObserver((list) => {
+        const entries = list.getEntries();
+        const last = entries[entries.length - 1] as
+          | (PerformanceEntry & { renderTime?: number; loadTime?: number })
+          | undefined;
+        if (last) lcp = last.startTime || last.renderTime || last.loadTime || lcp;
+      });
+      lcpObserver.observe({ type: "largest-contentful-paint", buffered: true });
+    } catch {
+      // LCP 미지원 브라우저
+    }
+
+    let sent = false;
+    const report = () => {
+      if (sent) return;
+      const nav = performance.getEntriesByType("navigation")[0] as
+        | PerformanceNavigationTiming
+        | undefined;
+      if (!nav || !nav.loadEventEnd) return; // load 완료 전이면 보류
+      sent = true;
+      lcpObserver?.disconnect();
+      send({
+        type: "page-load",
+        path: "/",
+        deviceType: classifyDevice(navigator.userAgent ?? ""),
+        ttfb: Math.round(nav.responseStart),
+        dcl: Math.round(nav.domContentLoadedEventEnd),
+        load: Math.round(nav.loadEventEnd),
+        lcp: lcp ? Math.round(lcp) : null,
+      });
+    };
+
+    const onLoad = () => window.setTimeout(report, 0);
+    if (document.readyState === "complete") {
+      window.setTimeout(report, 0);
+    } else {
+      window.addEventListener("load", onLoad, { once: true });
+    }
+    // 탭을 빨리 닫는 경우 대비: 숨김 전 마지막 보고 시도
+    document.addEventListener("visibilitychange", () => {
+      if (document.visibilityState === "hidden") report();
+    });
+
+    return () => {
+      window.removeEventListener("load", onLoad);
+      lcpObserver?.disconnect();
+    };
+  }, []);
+
   return null;
 }

--- a/server/src/admin/admin-monitoring.controller.ts
+++ b/server/src/admin/admin-monitoring.controller.ts
@@ -60,6 +60,50 @@ export class AdminMonitoringController {
     return this.dockerStats.getContainerHistory(container ?? 'nest');
   }
 
+  @UseGuards(AdminGuard)
+  @Get('admin/monitoring/page-load-series')
+  pageLoadSeries(
+    @Query('source') source?: string,
+    @Query('days') days?: string,
+  ) {
+    const safeSource = source === 'synthetic' ? 'synthetic' : 'rum';
+    const parsed = Number(days);
+    const rangeDays = Number.isFinite(parsed) ? parsed : 7;
+    return this.monitoring.getPageLoadSeries(safeSource, rangeDays);
+  }
+
+  @Post('telemetry/page-load')
+  pageLoad(
+    @Req() req: Request,
+    @Headers('x-telemetry-token') token: string | undefined,
+    @Body()
+    body: {
+      path?: string;
+      deviceType?: string;
+      ttfb?: number;
+      dcl?: number;
+      lcp?: number;
+      load?: number;
+    },
+  ) {
+    this.assertTelemetryAllowed(req, token);
+    const num = (v: unknown): number | null =>
+      typeof v === 'number' && Number.isFinite(v) ? v : null;
+    // load(또는 최소 ttfb)가 없으면 의미 없는 비콘 — 무시
+    if (num(body.load) === null && num(body.ttfb) === null) {
+      return { ok: false };
+    }
+    return this.monitoring.recordPageLoad({
+      path: typeof body.path === 'string' ? body.path : '/',
+      deviceType:
+        typeof body.deviceType === 'string' ? body.deviceType : 'unknown',
+      ttfb: num(body.ttfb),
+      dcl: num(body.dcl),
+      lcp: num(body.lcp),
+      load: num(body.load),
+    });
+  }
+
   @Post('telemetry/page-visit')
   pageVisit(
     @Req() req: Request,

--- a/server/src/admin/admin-monitoring.service.ts
+++ b/server/src/admin/admin-monitoring.service.ts
@@ -230,6 +230,13 @@ export class AdminMonitoringService implements OnModuleInit {
         Math.round(Number(process.hrtime.bigint() - startedAt) / 1_000_000);
 
       const req = client.get(url, { timeout: 15_000 }, (res) => {
+        const status = res.statusCode ?? 0;
+        // 2xx만 정상 측정 — 3xx/4xx/5xx의 작은 응답이 평균을 왜곡하지 않도록 실패 처리
+        if (status < 200 || status >= 300) {
+          res.resume();
+          req.destroy(new Error(`probe status ${status}`));
+          return;
+        }
         const ttfbMs = elapsed();
         res.on('data', () => undefined); // 본문 소비
         res.on('end', () => resolve({ ttfbMs, loadMs: elapsed() }));

--- a/server/src/admin/admin-monitoring.service.ts
+++ b/server/src/admin/admin-monitoring.service.ts
@@ -1,7 +1,10 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
+import * as http from 'http';
+import * as https from 'https';
 import {
   type DeviceType,
+  type PageLoadSource,
   type VisitRow,
   MonitoringRepository,
 } from './repositories/monitoring.repository';
@@ -117,6 +120,49 @@ export class AdminMonitoringService implements OnModuleInit {
     await this.monitoringRepo.recordYoutubeClick(input);
   }
 
+  /** RUM(실사용자) 페이지 로딩 측정값 기록. 값은 0~600000ms로 클램프, 비정상은 null. */
+  async recordPageLoad(input: {
+    path: string;
+    deviceType: string;
+    ttfb: number | null;
+    dcl: number | null;
+    lcp: number | null;
+    load: number | null;
+  }) {
+    const clamp = (v: number | null): number | null =>
+      typeof v === 'number' && Number.isFinite(v) && v >= 0
+        ? Math.min(600_000, Math.round(v))
+        : null;
+    await this.monitoringRepo.recordPageLoad({
+      source: 'rum',
+      path: input.path.slice(0, 255) || '/',
+      deviceType: input.deviceType.slice(0, 16) || 'unknown',
+      ttfbMs: clamp(input.ttfb),
+      dclMs: clamp(input.dcl),
+      lcpMs: clamp(input.lcp),
+      loadMs: clamp(input.load),
+    });
+  }
+
+  /** source별 페이지 로딩 추이. days에 따라 버킷 크기 자동 선택. */
+  async getPageLoadSeries(source: PageLoadSource, days: number) {
+    const safeDays = Math.max(1, Math.min(30, Math.trunc(days)));
+    const bucketHours = safeDays <= 1 ? 1 : safeDays <= 7 ? 6 : 24;
+    const rows = await this.monitoringRepo.findPageLoadSeries(
+      source,
+      safeDays,
+      bucketHours,
+    );
+    return rows.map((row) => ({
+      bucket: row.bucket,
+      ttfb: row.avg_ttfb ?? null,
+      dcl: row.avg_dcl ?? null,
+      lcp: row.avg_lcp ?? null,
+      load: row.avg_load ?? null,
+      count: Number(row.count),
+    }));
+  }
+
   @Cron('0 */10 * * * *')
   async probeApis() {
     const base =
@@ -153,6 +199,47 @@ export class AdminMonitoringService implements OnModuleInit {
     }
   }
 
+  /** 메인페이지 HTML 문서를 받아 TTFB/문서완료 시간을 합성 측정해 기록(10분). */
+  @Cron('0 */10 * * * *')
+  async probeMainPage() {
+    const url = process.env.MONITORING_MAINPAGE_URL ?? 'https://www.daloa.kr/';
+    try {
+      const { ttfbMs, loadMs } = await this.measureDocument(url);
+      await this.monitoringRepo.recordPageLoad({
+        source: 'synthetic',
+        path: '/',
+        deviceType: 'server',
+        ttfbMs,
+        dclMs: null,
+        lcpMs: null,
+        loadMs,
+      });
+    } catch (err: unknown) {
+      this.logger.warn(`mainpage probe failed: ${toErrorMessage(err)}`);
+    }
+  }
+
+  /** HTML 문서 1건을 받아 TTFB(헤더 수신)·문서 완료 시간을 ms로 측정. */
+  private measureDocument(
+    url: string,
+  ): Promise<{ ttfbMs: number; loadMs: number }> {
+    return new Promise((resolve, reject) => {
+      const client = url.startsWith('https:') ? https : http;
+      const startedAt = process.hrtime.bigint();
+      const elapsed = () =>
+        Math.round(Number(process.hrtime.bigint() - startedAt) / 1_000_000);
+
+      const req = client.get(url, { timeout: 15_000 }, (res) => {
+        const ttfbMs = elapsed();
+        res.on('data', () => undefined); // 본문 소비
+        res.on('end', () => resolve({ ttfbMs, loadMs: elapsed() }));
+        res.on('error', reject);
+      });
+      req.on('timeout', () => req.destroy(new Error('probe timeout')));
+      req.on('error', reject);
+    });
+  }
+
   @Cron('0 0 3 * * *')
   async cleanupMetricRetention() {
     try {
@@ -165,9 +252,14 @@ export class AdminMonitoringService implements OnModuleInit {
         'monitoring_api_probes',
         this.MONITORING_METRIC_RETENTION_DAYS,
       );
+      const deletedPageLoads =
+        await this.monitoringRepo.deleteMetricRowsOlderThan(
+          'apm_page_load_timings',
+          this.MONITORING_METRIC_RETENTION_DAYS,
+        );
 
       this.logger.log(
-        `monitoring retention cleanup completed: requests=${deletedRequests}, probes=${deletedProbes}`,
+        `monitoring retention cleanup completed: requests=${deletedRequests}, probes=${deletedProbes}, pageLoads=${deletedPageLoads}`,
       );
     } catch (err: unknown) {
       this.logger.warn(

--- a/server/src/admin/repositories/monitoring.repository.ts
+++ b/server/src/admin/repositories/monitoring.repository.ts
@@ -40,7 +40,21 @@ export interface SiteClickRow {
   click_count: bigint | number;
 }
 
-type RetentionTable = 'apm_request_timings' | 'monitoring_api_probes';
+type RetentionTable =
+  | 'apm_request_timings'
+  | 'monitoring_api_probes'
+  | 'apm_page_load_timings';
+
+export type PageLoadSource = 'rum' | 'synthetic';
+
+export interface PageLoadSeriesRow {
+  bucket: string;
+  avg_ttfb: number | null;
+  avg_dcl: number | null;
+  avg_lcp: number | null;
+  avg_load: number | null;
+  count: bigint | number;
+}
 
 export type ContainerName = 'nest' | 'nginx' | 'redis' | 'postgres';
 
@@ -146,6 +160,20 @@ export class MonitoringRepository {
         created_at TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP
       )
     `;
+    // 페이지 로딩 속도(RUM: 실사용자 / synthetic: 서버 합성 프로브). 지표는 NULL 허용.
+    await this.prisma.$executeRaw`
+      CREATE TABLE IF NOT EXISTS apm_page_load_timings (
+        id BIGSERIAL PRIMARY KEY,
+        source VARCHAR(16) NOT NULL DEFAULT 'rum',
+        path VARCHAR(255) NOT NULL DEFAULT '/',
+        device_type VARCHAR(16) NOT NULL DEFAULT 'unknown',
+        ttfb_ms INT,
+        dcl_ms INT,
+        lcp_ms INT,
+        load_ms INT,
+        created_at TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP
+      )
+    `;
 
     await this.prisma
       .$executeRaw`CREATE INDEX IF NOT EXISTS idx_apm_request_timings_created_at ON apm_request_timings(created_at)`;
@@ -163,6 +191,10 @@ export class MonitoringRepository {
       .$executeRaw`CREATE INDEX IF NOT EXISTS idx_apm_youtube_clicks_created_at ON apm_youtube_clicks(created_at)`;
     await this.prisma
       .$executeRaw`CREATE INDEX IF NOT EXISTS idx_apm_youtube_clicks_video_id ON apm_youtube_clicks(video_id)`;
+    await this.prisma
+      .$executeRaw`CREATE INDEX IF NOT EXISTS idx_apm_page_load_timings_created_at ON apm_page_load_timings(created_at)`;
+    await this.prisma
+      .$executeRaw`CREATE INDEX IF NOT EXISTS idx_apm_page_load_timings_source_created_at ON apm_page_load_timings(source, created_at)`;
 
     for (const container of Object.keys(DOCKER_TABLE) as ContainerName[]) {
       await this.prisma.$executeRawUnsafe(`
@@ -299,6 +331,70 @@ export class MonitoringRepository {
         ${input.isSuccess},
         NOW()
       )
+    `;
+  }
+
+  /** 페이지 로딩 측정값 1건 저장. 지표는 NULL 허용(소스별로 채워지는 지표가 다름). */
+  async recordPageLoad(input: {
+    source: PageLoadSource;
+    path: string;
+    deviceType: string;
+    ttfbMs: number | null;
+    dclMs: number | null;
+    lcpMs: number | null;
+    loadMs: number | null;
+  }) {
+    await this.prisma.$executeRaw`
+      INSERT INTO apm_page_load_timings
+        (source, path, device_type, ttfb_ms, dcl_ms, lcp_ms, load_ms, created_at)
+      VALUES (
+        ${input.source},
+        ${input.path},
+        ${input.deviceType},
+        ${input.ttfbMs},
+        ${input.dclMs},
+        ${input.lcpMs},
+        ${input.loadMs},
+        NOW()
+      )
+    `;
+  }
+
+  /** source별 시간버킷 평균(ttfb/dcl/lcp/load). 빈 버킷도 채워 반환. */
+  async findPageLoadSeries(
+    source: PageLoadSource,
+    rangeDays: number,
+    bucketHours: number,
+  ) {
+    return this.prisma.$queryRaw<PageLoadSeriesRow[]>`
+      WITH samples AS (
+        SELECT
+          TO_TIMESTAMP(FLOOR(EXTRACT(EPOCH FROM created_at) / (${bucketHours} * 3600)) * (${bucketHours} * 3600)) AS bucket_start,
+          ttfb_ms, dcl_ms, lcp_ms, load_ms
+        FROM apm_page_load_timings
+        WHERE source = ${source}
+          AND created_at >= NOW() - (${rangeDays}::int * INTERVAL '1 day')
+      ),
+      buckets AS (
+        SELECT TO_TIMESTAMP(
+                 FLOOR(EXTRACT(EPOCH FROM g) / (${bucketHours} * 3600)) * (${bucketHours} * 3600)
+               ) AS bucket_start
+        FROM generate_series(
+               NOW() - (${rangeDays}::int * INTERVAL '1 day'),
+               NOW(),
+               (${bucketHours} * INTERVAL '1 hour')
+             ) AS g
+      )
+      SELECT TO_CHAR(b.bucket_start, 'MM-DD HH24:MI') AS bucket,
+             ROUND(AVG(s.ttfb_ms))::int AS avg_ttfb,
+             ROUND(AVG(s.dcl_ms))::int  AS avg_dcl,
+             ROUND(AVG(s.lcp_ms))::int  AS avg_lcp,
+             ROUND(AVG(s.load_ms))::int AS avg_load,
+             COUNT(s.ttfb_ms) AS count
+      FROM buckets b
+      LEFT JOIN samples s ON s.bucket_start = b.bucket_start
+      GROUP BY b.bucket_start
+      ORDER BY b.bucket_start ASC
     `;
   }
 
@@ -544,7 +640,36 @@ export class MonitoringRepository {
         return this.deleteRequestTimingRowsOlderThan(retentionDays, chunkSize);
       case 'monitoring_api_probes':
         return this.deleteApiProbeRowsOlderThan(retentionDays, chunkSize);
+      case 'apm_page_load_timings':
+        return this.deleteRowsOlderThan(
+          'apm_page_load_timings',
+          retentionDays,
+          chunkSize,
+        );
     }
+  }
+
+  private async deleteRowsOlderThan(
+    table: 'apm_page_load_timings',
+    retentionDays: number,
+    chunkSize: number,
+  ) {
+    const deleted = await this.prisma.$queryRawUnsafe<Array<{ id: bigint }>>(
+      `
+      DELETE FROM ${table}
+      WHERE id IN (
+        SELECT id
+        FROM ${table}
+        WHERE created_at < NOW() - ($1::int * INTERVAL '1 day')
+        ORDER BY id ASC
+        LIMIT $2
+      )
+      RETURNING id
+      `,
+      retentionDays,
+      chunkSize,
+    );
+    return deleted.length;
   }
 
   private async findDimensionRows(

--- a/server/src/admin/repositories/monitoring.repository.ts
+++ b/server/src/admin/repositories/monitoring.repository.ts
@@ -390,7 +390,7 @@ export class MonitoringRepository {
              ROUND(AVG(s.dcl_ms))::int  AS avg_dcl,
              ROUND(AVG(s.lcp_ms))::int  AS avg_lcp,
              ROUND(AVG(s.load_ms))::int AS avg_load,
-             COUNT(s.ttfb_ms) AS count
+             COUNT(s.bucket_start) AS count
       FROM buckets b
       LEFT JOIN samples s ON s.bucket_start = b.bucket_start
       GROUP BY b.bucket_start


### PR DESCRIPTION
## 요약

메인페이지 로딩 속도를 DB에 적재해 과거 추이를 추적하고, 모니터링 탭에 시계열 그래프로 표시.

- **RUM**: 방문자 브라우저의 Navigation Timing(load/DCL/TTFB) + LCP를 수집 (이탈 시 부분 지표도)
- **합성 프로브**: 10분 크론이 메인 HTML 응답시간(TTFB·문서완료) 측정 (2xx만 정상 처리)
- 신규 테이블 `apm_page_load_timings` (30일 리텐션), `GET /api/admin/monitoring/page-load-series`
- 모니터링 탭 "메인페이지 로딩 속도 추이" 카드 (실사용자/합성 토글, 1·7·30일)

상세: #255

⚠️ 운영은 배포 후부터 데이터 누적 · 측정 URL은 `MONITORING_MAINPAGE_URL` env로 변경 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)