### PR TITLE
feat(seo): 검색 노출 개선 (타이틀·h1·canonical·sitemap)

### DIFF
--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -17,11 +17,12 @@ const geistMono = Geist_Mono({
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://www.daloa.kr"),
-  title: "다로아 - 로아 사이트 모음",
+  title: "다로아 | 로스트아크 사이트 모음",
+  alternates: { canonical: "/" },
   description:
     "로스트아크 유용한 사이트 모음, 캐릭터 특성 빌드 분포를 한 번에 확인하세요.",
   openGraph: {
-    title: "다로아 - 로아 사이트 모음",
+    title: "다로아 | 로스트아크 사이트 모음",
     description:
       "로스트아크 유용한 사이트 모음, 캐릭터 특성 빌드 분포를 한 번에 확인하세요.",
     url: "https://www.daloa.kr",
@@ -39,7 +40,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "다로아 - 로아 사이트 모음",
+    title: "다로아 | 로스트아크 사이트 모음",
     description:
       "로스트아크 유용한 사이트 모음, 캐릭터 특성 빌드 분포를 한 번에 확인하세요.",
     images: ["/icon.png"],

--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -18,7 +18,6 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   metadataBase: new URL("https://www.daloa.kr"),
   title: "다로아 | 로스트아크 사이트 모음",
-  alternates: { canonical: "/" },
   description:
     "로스트아크 유용한 사이트 모음, 캐릭터 특성 빌드 분포를 한 번에 확인하세요.",
   openGraph: {

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -4,6 +4,12 @@ import ClassSummaryList from "@/components/class-summary/ClassSummaryList";
 import SiteList from "@/components/sites/SiteList";
 import YoutubeSection from "@/components/youtube/YoutubeSection";
 import type { ClassSummary, Site, StatBuildTab } from "@/types";
+import type { Metadata } from "next";
+
+// 홈 전용 canonical (루트 레이아웃에 두면 하위 페이지가 상속받아 색인 병합 문제 → 페이지별 지정)
+export const metadata: Metadata = {
+  alternates: { canonical: "/" },
+};
 
 const API = process.env.NEST_API_URL ?? "http://localhost:3001";
 
@@ -70,7 +76,7 @@ export default async function Home() {
           <main className="flex flex-col gap-2">
             <header className="fade-in text-center">
               <h1 className="text-lg font-bold tracking-tight text-slate-900 dark:text-slate-100 sm:text-xl">
-                로아 사이트 모음
+                다로아 - 로아 사이트 모음
               </h1>
             </header>
 

--- a/client/app/sitemap.ts
+++ b/client/app/sitemap.ts
@@ -3,7 +3,7 @@ import type { MetadataRoute } from "next";
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
-      url: "https://daloa.kr",
+      url: "https://www.daloa.kr",
       lastModified: new Date(),
       changeFrequency: "daily",
       priority: 1,


### PR DESCRIPTION
## 요약
검색 노출/SEO 개선.

- **타이틀**: `다로아 | 로스트아크 사이트 모음` (메인·OG·트위터)
- **홈 h1**: `다로아 - 로아 사이트 모음` (브랜드 추가)
- **canonical**: 홈 페이지에 `https://www.daloa.kr` 지정 (루트 레이아웃 상속 문제 방지)
- **sitemap**: `daloa.kr` → `www.daloa.kr` (308 영구 리다이렉트되는 정식 주소로 통일)

상세 내역 및 리뷰 반영: #259

## 배포 후 운영 작업
- Search Console에서 `https://www.daloa.kr/` 색인 재요청
- sitemap `https://www.daloa.kr/sitemap.xml` 재제출(선택)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
