### PR TITLE
fix(seo): sitemap URL trailing slash로 canonical과 일치

### DIFF
--- a/client/app/sitemap.ts
+++ b/client/app/sitemap.ts
@@ -3,7 +3,7 @@ import type { MetadataRoute } from "next";
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
-      url: "https://www.daloa.kr",
+      url: "https://www.daloa.kr/",
       lastModified: new Date(),
       changeFrequency: "daily",
       priority: 1,


### PR DESCRIPTION
## 개요
sitemap URL을 canonical과 정확히 일치(리뷰 반영).

## 변경
- `https://www.daloa.kr` → `https://www.daloa.kr/` (trailing slash)
- 이유: `alternates.canonical: "/"` + metadataBase가 canonical을 `https://www.daloa.kr/`(slash 포함)로 생성 → sitemap도 동일하게 맞춰 불일치 제거.

## 참고
루트 도메인은 slash 유무를 구글이 동일 취급해 실질 영향은 미미하나, 완전 일치로 정리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
