### PR TITLE
fix(seo): sitemap trailing slash로 canonical 일치

### DIFF
--- a/client/app/sitemap.ts
+++ b/client/app/sitemap.ts
@@ -3,7 +3,7 @@ import type { MetadataRoute } from "next";
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
-      url: "https://www.daloa.kr",
+      url: "https://www.daloa.kr/",
       lastModified: new Date(),
       changeFrequency: "daily",
       priority: 1,


### PR DESCRIPTION
## 요약
sitemap URL에 trailing slash 추가 — canonical(`https://www.daloa.kr/`)과 일치.

- `https://www.daloa.kr` → `https://www.daloa.kr/`

상세: #261

> #260(SEO)이 #261(슬래시)보다 먼저 main에 머지되어, 슬래시 수정만 별도로 main에 반영하는 PR입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
