### PR TITLE
feat(rebrand): 다로아 → 로모아 + lomoa.kr 전환

### DIFF
--- a/client/app/admin/login/page.tsx
+++ b/client/app/admin/login/page.tsx
@@ -44,7 +44,7 @@ export default function AdminLoginPage() {
       <div className="admin-card w-full max-w-sm p-8">
         <div className="mb-6">
           <h1 className="admin-page-title">
-            다로아 <span className="text-blue-600">Admin</span>
+            로모아 <span className="text-blue-600">Admin</span>
           </h1>
           <p className="admin-page-subtitle mt-1">관리자 로그인</p>
         </div>

--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -16,16 +16,16 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://www.daloa.kr"),
-  title: "다로아 | 로스트아크 사이트 모음",
+  metadataBase: new URL("https://www.lomoa.kr"),
+  title: "로모아 | 로스트아크 사이트 모음",
   description:
     "로스트아크 유용한 사이트 모음, 캐릭터 특성 빌드 분포를 한 번에 확인하세요.",
   openGraph: {
-    title: "다로아 | 로스트아크 사이트 모음",
+    title: "로모아 | 로스트아크 사이트 모음",
     description:
       "로스트아크 유용한 사이트 모음, 캐릭터 특성 빌드 분포를 한 번에 확인하세요.",
-    url: "https://www.daloa.kr",
-    siteName: "다로아",
+    url: "https://www.lomoa.kr",
+    siteName: "로모아",
     locale: "ko_KR",
     type: "website",
     images: [
@@ -33,13 +33,13 @@ export const metadata: Metadata = {
         url: "/icon.png",
         width: 512,
         height: 512,
-        alt: "다로아 대표 아이콘",
+        alt: "로모아 대표 아이콘",
       },
     ],
   },
   twitter: {
     card: "summary_large_image",
-    title: "다로아 | 로스트아크 사이트 모음",
+    title: "로모아 | 로스트아크 사이트 모음",
     description:
       "로스트아크 유용한 사이트 모음, 캐릭터 특성 빌드 분포를 한 번에 확인하세요.",
     images: ["/icon.png"],

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -76,7 +76,7 @@ export default async function Home() {
           <main className="flex flex-col gap-2">
             <header className="fade-in text-center">
               <h1 className="text-lg font-bold tracking-tight text-slate-900 dark:text-slate-100 sm:text-xl">
-                다로아 - 로아 사이트 모음
+                로모아 - 로아 사이트 모음
               </h1>
             </header>
 

--- a/client/app/robots.ts
+++ b/client/app/robots.ts
@@ -2,7 +2,7 @@ import type { MetadataRoute } from "next";
 
 export default function robots(): MetadataRoute.Robots {
   return {
-    host: "https://www.daloa.kr",
+    host: "https://www.lomoa.kr",
     rules: [
       {
         userAgent: "Mediapartners-Google",
@@ -24,6 +24,6 @@ export default function robots(): MetadataRoute.Robots {
         ],
       },
     ],
-    sitemap: "https://www.daloa.kr/sitemap.xml",
+    sitemap: "https://www.lomoa.kr/sitemap.xml",
   };
 }

--- a/client/app/sitemap.ts
+++ b/client/app/sitemap.ts
@@ -3,7 +3,7 @@ import type { MetadataRoute } from "next";
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
-      url: "https://www.daloa.kr/",
+      url: "https://www.lomoa.kr/",
       lastModified: new Date(),
       changeFrequency: "daily",
       priority: 1,

--- a/server/src/admin/site-extractor.service.ts
+++ b/server/src/admin/site-extractor.service.ts
@@ -39,6 +39,8 @@ const EXCLUDE_DOMAINS = new Set([
   'lostark.inven.co.kr',
   'daloa.kr',
   'www.daloa.kr',
+  'lomoa.kr',
+  'www.lomoa.kr',
   'youtube.com',
   'youtu.be',
   'm.youtube.com',


### PR DESCRIPTION
## 요약
브랜드명 **다로아 → 로모아**, 도메인 **daloa.kr → lomoa.kr** 전환.

- 타이틀·h1·OG·siteName·admin 로그인: 다로아 → 로모아
- metadataBase·OG url·sitemap·robots → www.lomoa.kr
- site-extractor 자기도메인에 lomoa.kr 추가

상세: #263

## 배포 후 주의
- API는 아직 `api.daloa.kr` 사용(안 끊김). 이후 api.lomoa.kr 이전 예정.
- daloa.kr/lomoa.kr 둘 다 같은 사이트 서빙, canonical은 lomoa.kr.
- 별도 단계: 서버 CORS env, 구도메인 301, Search Console 새 속성.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
