### PR TITLE
fix(nginx): server_name에 api.lomoa.kr 추가

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -7,14 +7,14 @@ limit_req_zone $binary_remote_addr zone=api_per_ip:10m rate=120r/m;
 # HTTP → HTTPS 리다이렉트
 server {
     listen 80;
-    server_name api.daloa.kr;
+    server_name api.daloa.kr api.lomoa.kr;
     return 301 https://$host$request_uri;
 }
 
 # HTTPS: api.daloa.kr → NestJS
 server {
     listen 443 ssl;
-    server_name api.daloa.kr;
+    server_name api.daloa.kr api.lomoa.kr;
     client_max_body_size 50M;
 
     ssl_certificate     /etc/letsencrypt/live/api.daloa.kr/fullchain.pem;


### PR DESCRIPTION
## 개요
nginx `server_name`에 `api.lomoa.kr` 추가 (API 서브도메인 이전).

## 변경
- HTTP(80)·HTTPS(443) server 블록 `server_name`: `api.daloa.kr` → `api.daloa.kr api.lomoa.kr`
- 인증서는 기존 `api.daloa.kr` letsencrypt 인증서를 **SAN 확장**(`--expand`)해 두 도메인 커버 (cert 경로 동일)

## 상태
- **EC2에는 이미 직접 적용 + nginx reload 완료** (api.lomoa.kr HTTPS 200 확인). 이 PR은 repo 일관성/미래 배포 대비.
- api.daloa.kr는 전환기 동안 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
