### PR TITLE
fix(nginx): server_name에 api.lomoa.kr 추가

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -7,14 +7,14 @@ limit_req_zone $binary_remote_addr zone=api_per_ip:10m rate=120r/m;
 # HTTP → HTTPS 리다이렉트
 server {
     listen 80;
-    server_name api.daloa.kr;
+    server_name api.daloa.kr api.lomoa.kr;
     return 301 https://$host$request_uri;
 }
 
 # HTTPS: api.daloa.kr → NestJS
 server {
     listen 443 ssl;
-    server_name api.daloa.kr;
+    server_name api.daloa.kr api.lomoa.kr;
     client_max_body_size 50M;
 
     ssl_certificate     /etc/letsencrypt/live/api.daloa.kr/fullchain.pem;


### PR DESCRIPTION
## 요약
nginx `server_name`에 `api.lomoa.kr` 추가 (API 서브도메인 이전).

- HTTP/HTTPS 블록 `server_name`: `api.daloa.kr api.lomoa.kr`
- 인증서는 기존 cert를 SAN 확장해 두 도메인 커버 (EC2 이미 적용 완료)

상세: #265

> EC2엔 직접 적용·reload 완료. 이 머지는 repo 일관성용(향후 배포 시 nginx 설정 유지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
