### PR TITLE
chore(rebrand): 배포 경로·compose 프로젝트명·nginx 라벨 daloa→lomoa 정리

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -40,7 +40,7 @@ jobs:
 
           # Script to run on the remote EC2 host.
           # SQL 파일은 호스트(EC2)에 있으므로 -f(컨테이너 내부 경로) 대신 stdin으로 전달
-          remote_script="cd /home/ubuntu/daloa \
+          remote_script="cd /home/ubuntu/lomoa \
             && git pull origin main \
             && test -f \"$SQL_FILE\" \
             && set -a && source .env && set +a \

--- a/.github/workflows/diag-nest.yml
+++ b/.github/workflows/diag-nest.yml
@@ -34,7 +34,7 @@ jobs:
             --document-name "AWS-RunShellScript" \
             --instance-ids "$EC2_INSTANCE_ID" \
             --comment "diag-nest" \
-            --parameters "commands=[\"sudo -u ubuntu -H bash -lc 'cd /home/ubuntu/daloa && echo === CONTAINER STATUS === && docker compose ps && echo === NEST LOGS === && docker compose logs --tail=$TAIL nest'\"]" \
+            --parameters "commands=[\"sudo -u ubuntu -H bash -lc 'cd /home/ubuntu/lomoa && echo === CONTAINER STATUS === && docker compose ps && echo === NEST LOGS === && docker compose logs --tail=$TAIL nest'\"]" \
             --query 'Command.CommandId' \
             --output text)
 

--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -69,7 +69,7 @@ jobs:
           ECR_PASSWORD=$(aws ecr get-login-password --region ${AWS_REGION})
 
           remote_script="set -e
-          cd /home/ubuntu/daloa
+          cd /home/ubuntu/lomoa
           git reset --hard HEAD
           git pull origin main
           grep -q '^NEXT_REVALIDATE_URL=' .env || echo 'NEXT_REVALIDATE_URL=https://www.lomoa.kr/api/revalidate' >> .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+name: lomoa
+
 services:
   postgres:
     image: postgres:16-alpine

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -7,16 +7,18 @@ limit_req_zone $binary_remote_addr zone=api_per_ip:10m rate=120r/m;
 # HTTP → HTTPS 리다이렉트
 server {
     listen 80;
-    server_name api.daloa.kr api.lomoa.kr;
+    server_name api.lomoa.kr api.daloa.kr;
     return 301 https://$host$request_uri;
 }
 
-# HTTPS: api.daloa.kr → NestJS
+# HTTPS: api.lomoa.kr (구 api.daloa.kr, 폐기 예정) → NestJS
 server {
     listen 443 ssl;
-    server_name api.daloa.kr api.lomoa.kr;
+    server_name api.lomoa.kr api.daloa.kr;
     client_max_body_size 50M;
 
+    # 인증서 디렉터리명은 api.daloa.kr이지만 SAN에 api.lomoa.kr 포함 → lomoa 접속도 정상.
+    # daloa 폐기 시 lomoa 단독 인증서 재발급 후 경로 교체할 것.
     ssl_certificate     /etc/letsencrypt/live/api.daloa.kr/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/api.daloa.kr/privkey.pem;
 


### PR DESCRIPTION
## 개요
daloa→lomoa 리브랜딩의 인프라/배포 잔재 정리. 코드 변경은 작지만, **운영 인프라 마이그레이션과 짝을 이루는 변경**이라 아래 맥락이 중요합니다.

## 코드 변경 (이 PR)
- **워크플로 EC2 배포 경로** `/home/ubuntu/daloa` → `/home/ubuntu/lomoa` (`main-post-merge`, `db-migrate`, `diag-nest`)
- **docker-compose `name: lomoa`** 추가 → 프로젝트명을 폴더명과 무관하게 고정 (볼륨 prefix 사고 방지)
- **nginx** `server_name` lomoa 우선 정렬 + 인증서 경로 의존성 주석

## 머지 전 이미 완료한 운영 작업
- ECR `lomoa-nest` 생성, `daloa-nest` 삭제
- GitHub Secret `ECR_REPOSITORY` → `lomoa-nest`, `AWS_ROLE_TO_ASSUME` → 신규 OIDC 역할
- IAM: `lomoa-ec2-ssm-role`(인스턴스), `lomoa-github-actions-deploy-role`(OIDC) 생성·적용
- **EC2 폴더 rename + DB 볼륨 마이그레이션** (`daloa_*` → `lomoa_*`, 데이터 39,143행 보존 검증 완료)
- 두 도메인(api.lomoa.kr / api.daloa.kr) 정상 응답 확인 (인증서 SAN 양쪽 포함)

## 머지 시 동작
머지 → `main-post-merge` 자동 배포: `cd lomoa` → 이미지 빌드 → **`lomoa-nest`로 push/pull** (ECR·OIDC 체인 최종 검증).

## 머지 후 정리 (별도)
- 옛 IAM 역할 2개 삭제 (`daloa-ec2-ssm-role`, `daloa-github-actions-deploy-role`)
- 옛 볼륨 삭제 (`daloa_postgres_data`, `daloa_redis_data`) — 롤백용 보존 중

🤖 Generated with [Claude Code](https://claude.com/claude-code)
