### PR TITLE
chore(ci): GitHub Actions Node 24 대응 (버전업 + FORCE 플래그 + auto-delete 보호목록)

### DIFF
--- a/.github/workflows/auto-delete-branch.yml
+++ b/.github/workflows/auto-delete-branch.yml
@@ -17,7 +17,7 @@ jobs:
           HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
           REPO: ${{ github.repository }}
         run: |
-          parent_branches="main ci/cd feat/admin feat/mainPage fix/admin fix/mainPage"
+          parent_branches="main admin mainPage etc"
           for branch in $parent_branches; do
             if [ "$HEAD_BRANCH" = "$branch" ]; then
               echo "$HEAD_BRANCH is a parent branch, skipping deletion."

--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -15,6 +15,10 @@ on:
         required: false
         default: "true"
 
+# configure-aws-credentials@v5가 아직 Node 20 런타임이라 강제로 Node 24에서 실행 (2026-06-16 deprecation 대응)
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/diag-nest.yml
+++ b/.github/workflows/diag-nest.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/diag-nest.yml
+++ b/.github/workflows/diag-nest.yml
@@ -9,6 +9,10 @@ on:
         required: false
         default: "100"
 
+# configure-aws-credentials@v5가 아직 Node 20 런타임이라 강제로 Node 24에서 실행 (2026-06-16 deprecation 대응)
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/drawio-export.yml
+++ b/.github/workflows/drawio-export.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -33,7 +33,7 @@ jobs:
           xmllint --format docs/architecture.svg --output docs/architecture.svg
 
       - name: Create Pull Request with SVG
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "chore: update architecture.svg"
           title: "chore: update architecture.svg"

--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm
@@ -35,7 +35,7 @@ jobs:
         run: npm run build
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -8,6 +8,10 @@ on:
       - 'client/**'
   workflow_dispatch:
 
+# configure-aws-credentials@v5가 아직 Node 20 런타임이라 강제로 Node 24에서 실행 (2026-06-16 deprecation 대응)
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -15,10 +15,10 @@ jobs:
         working-directory: server
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm
@@ -41,10 +41,10 @@ jobs:
         working-directory: client
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm
@@ -84,10 +84,10 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -16,8 +16,8 @@ jobs:
       server: ${{ steps.filter.outputs.server }}
       client: ${{ steps.filter.outputs.client }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -35,10 +35,10 @@ jobs:
       run:
         working-directory: server
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm
@@ -79,10 +79,10 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm
@@ -136,10 +136,10 @@ jobs:
       DISABLE_CLASS_SUMMARY: "true"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm
@@ -169,10 +169,10 @@ jobs:
       run:
         working-directory: client
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/server-e2e.yml
+++ b/.github/workflows/server-e2e.yml
@@ -46,10 +46,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm


### PR DESCRIPTION
## 개요
2026-06-16 Node 20 런타임 deprecation 대응. `etc` 상위 브랜치에 모인 CI 워크플로 정리를 main에 반영.

## 변경
1. **액션 버전업**: checkout v4→v5, setup-node v4→v5, configure-aws-credentials v4→v5, dorny/paths-filter v3→v4, peter-evans/create-pull-request v6→v8
2. **FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 플래그** (db-migrate, diag-nest, main-post-merge): configure-aws-credentials@v5가 아직 Node 20 런타임이라 강제 Node 24 실행
3. **auto-delete 보호목록** → `main admin mainPage etc` (구 컨벤션 ci/cd·feat/*·fix/* 제거)

## 변경 없음
- amazon-ecr-login@v2 (이미 Node24), drawio-export-action@v2 (Docker), node-version:20 (앱 빌드용)

## 검증 완료
- pr-ci: 초록, Node20 경고 0 (checkout/setup-node/paths-filter)
- diag-nest: 초록, Node20 경고 0 (configure-aws-credentials@v5 + FORCE 플래그, OIDC 정상)

## 머지 후 주의
auto-delete 보호목록 수정본이 아직 main에 없어, 이 PR 머지 시 head=`etc`가 자동 삭제될 수 있음. 그 시점 etc==main이라 손실 없음 → 머지 후 etc 재생성으로 복구.

🤖 Generated with [Claude Code](https://claude.com/claude-code)