### PR TITLE
docs(readme): 기술 스택 정확화 및 불필요 섹션 정리

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,23 +9,15 @@
 
 - Docker
 - TypeScript: 타입 안정성으로 런타임 에러 사전 방지
-- Next.js: SSR (Vercel 배포)
+- Next.js: 메인 페이지 ISR, 관리자 CSR (Vercel 배포)
 - NestJS: 백엔드 API 서버
 - PostgreSQL: 주 데이터베이스
 - Prisma 7: ORM (driver adapter 방식)
 - Redis: 캐시로 속도 개선
 - Nginx: 리버스 프록시
+- Sentry: 에러·성능 모니터링 (프론트·백엔드)
 - AWS EC2 + GitHub Actions: 서버 배포 자동화
-
-## 개선한 점들
-
-| 항목           | Before | After   | 개선율 |
-| -------------- | ------ | ------- | ------ |
-| 초기 로딩 시간 | 4.2s   | 1.1s    | 73% ↓  |
-| DB 응답 시간   | 500ms  | 50ms    | 90% ↓  |
-| 동시 요청 처리 | 50 QPS | 500 QPS | 10배 ↑ |
-
-→ 상세 기록: [docs/performance.md](docs/performance.md)
+- Claude Code: AI 페어 프로그래밍
 
 ## 시스템 흐름:
 
@@ -34,12 +26,3 @@
 </a>
 
 원본 크기로 보기: [docs/architecture.svg](https://raw.githubusercontent.com/haihire/lomoa/main/docs/architecture.svg)
-
-## 브랜치 보호 목록
-
-- main
-- fix/admin
-- feat/admin
-- fix/mainPage
-- feat/mainPage
-- ci/cd


### PR DESCRIPTION
@
## 개요
README 기술 스택을 실제 코드 기준으로 정확화하고, 유지보수가 어려운 섹션을 정리했습니다.

## 변경 사항
- **Next.js 렌더링 방식 정정**: `SSR` → `메인 페이지 ISR, 관리자 CSR`
  - 메인은 서버 컴포넌트 + `next: { revalidate }`(ISR), 관리자는 전부 `"use client"`(CSR). 순수 per-request SSR은 사용 안 함
- **Sentry** 추가: 프론트(`@sentry/nextjs`)·백엔드(`@sentry/nestjs`) 모두 적용 중
- **Claude Code** 추가
- **개선한 점들**(성능 표) 섹션 제거
- **브랜치 보호 목록** 섹션 제거

## 베이스
- `etc` (상위 브랜치) 대상 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@