### PR TITLE
docs: README 정리 및 아키텍처 다이어그램 Next.js 16 갱신

### DIFF
--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -62,7 +62,7 @@
                   <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 188px; height: 1px; padding-top: 320px; margin-left: 191px;">
                       <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                        <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; "><b>Next.js 15</b><br/>App Router / SSR+ISR</div>
+                        <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; "><b>Next.js 16</b><br/>App Router / SSR+ISR</div>
                       </div>
                     </div>
                   </foreignObject>


### PR DESCRIPTION
@
## 개요
- 아키텍처 다이어그램(`docs/architecture.svg`)의 Vercel 노드 라벨을 `Next.js 15` → `Next.js 16`으로 갱신 (실제 `client` 의존성 `next@16.2.2` 반영)
- README 기술 스택 정확화 및 불필요 섹션 정리 (기존 커밋)

## 검증
- `docker-compose.yml`(postgres:16 / redis:7), `server`(Prisma 7, NestJS 11), `client`(Next 16) 기준으로 다이어그램 나머지 요소 일치 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@