### PR TITLE
feat(site-suggest): 사이트 AI 추천을 Gemini → NVIDIA NIM으로 교체

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -26,6 +26,7 @@
         "cheerio": "^1.2.0",
         "googleapis": "^171.4.0",
         "ioredis": "^5.10.1",
+        "openai": "^6.42.0",
         "pg": "^8.21.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1"
@@ -11236,6 +11237,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.42.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.42.0.tgz",
+      "integrity": "sha512-1WFEt/uXMXOLhYRNkgJWo08Y2YNvNwpVU72K7ibrWgWpNOXd4VojXLbe6SQ4bLiUQ3Y8jz4IiyVkylJCL1DtZg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/optionator": {

--- a/server/package.json
+++ b/server/package.json
@@ -39,6 +39,7 @@
     "cheerio": "^1.2.0",
     "googleapis": "^171.4.0",
     "ioredis": "^5.10.1",
+    "openai": "^6.42.0",
     "pg": "^8.21.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"

--- a/server/src/admin/site-suggest.service.spec.ts
+++ b/server/src/admin/site-suggest.service.spec.ts
@@ -1,7 +1,7 @@
 import { ConfigService } from '@nestjs/config';
 import { SiteSuggestService } from './site-suggest.service';
 
-// 토큰 보호 검증: GEMINI_API_KEY가 없으면 실제 Gemini·네트워크 호출 없이 즉시 예외여야 함.
+// 토큰 보호 검증: NVIDIA_API_KEY가 없으면 실제 AI·네트워크 호출 없이 즉시 예외여야 함.
 // (자동 실행이 없고 모달 버튼 클릭 시에만 호출되므로 별도 비활성 플래그는 두지 않음)
 describe('SiteSuggestService', () => {
   const makeService = (cfg: Record<string, string>) => {
@@ -13,8 +13,8 @@ describe('SiteSuggestService', () => {
 
   const input = { url: 'https://example.kr', domain: 'example.kr' };
 
-  it('GEMINI_API_KEY 없으면 호출 없이 예외', async () => {
+  it('NVIDIA_API_KEY 없으면 호출 없이 예외', async () => {
     const svc = makeService({});
-    await expect(svc.suggest(input)).rejects.toThrow(/GEMINI_API_KEY/);
+    await expect(svc.suggest(input)).rejects.toThrow(/NVIDIA_API_KEY/);
   });
 });

--- a/server/src/admin/site-suggest.service.ts
+++ b/server/src/admin/site-suggest.service.ts
@@ -4,7 +4,7 @@ import {
   ServiceUnavailableException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { GoogleGenerativeAI, SchemaType } from '@google/generative-ai';
+import OpenAI from 'openai';
 import axios from 'axios';
 import * as cheerio from 'cheerio';
 import * as dns from 'dns/promises';
@@ -29,23 +29,32 @@ interface SiteMeta {
 }
 
 /**
- * 추천 후보(사이트)에 대해 Gemini로 name/category/description/icon을 생성한다.
+ * 추천 후보(사이트)에 대해 NVIDIA NIM(OpenAI 호환)으로
+ * name/category/description/icon을 생성한다.
  * 자동 실행 없음 — 관리자가 모달에서 버튼을 누를 때만 호출되므로 토큰은 그때만 소모된다.
- * (GEMINI_API_KEY가 없으면 비활성.)
+ * (NVIDIA_API_KEY가 없으면 비활성.)
  */
 @Injectable()
 export class SiteSuggestService {
   private readonly logger = new Logger(SiteSuggestService.name);
-  private readonly genAI: GoogleGenerativeAI | null;
+  private readonly client: OpenAI | null;
+  private readonly model: string;
   // DNS rebinding 방어: 연결 직전(Time-of-Use) IP를 재검증하는 커스텀 에이전트
   private readonly httpAgent: http.Agent;
   private readonly httpsAgent: https.Agent;
 
   constructor(private readonly config: ConfigService) {
-    const apiKey = this.config.get<string>('GEMINI_API_KEY');
-    this.genAI = apiKey ? new GoogleGenerativeAI(apiKey) : null;
+    const apiKey = this.config.get<string>('NVIDIA_API_KEY');
+    const baseURL =
+      this.config.get<string>('NVIDIA_BASE_URL') ||
+      'https://integrate.api.nvidia.com/v1';
+    // 모델은 .env(NVIDIA_MODEL)로 교체 가능 — 코드 수정 없이 바꾸기 위함
+    this.model =
+      this.config.get<string>('NVIDIA_MODEL') ||
+      'qwen/qwen3-next-80b-a3b-instruct';
+    this.client = apiKey ? new OpenAI({ apiKey, baseURL }) : null;
     if (!apiKey) {
-      this.logger.warn('GEMINI_API_KEY 미설정 — 사이트 AI 추천 비활성화');
+      this.logger.warn('NVIDIA_API_KEY 미설정 — 사이트 AI 추천 비활성화');
     }
 
     // axios가 실제로 연결할 IP를 lookup 단계에서 검사 → isSafeUrl 선검증과
@@ -74,7 +83,7 @@ export class SiteSuggestService {
     });
   }
 
-  /** og:image 또는 파비콘 URL만 반환한다 (Gemini 호출 없음). */
+  /** og:image 또는 파비콘 URL만 반환한다 (AI 호출 없음). */
   async fetchIcon(input: { url: string; domain: string }): Promise<string> {
     const meta = await this.fetchMeta(input.url);
     return (
@@ -83,40 +92,18 @@ export class SiteSuggestService {
     );
   }
 
-  /** 사이트 메타를 fetch해 Gemini로 추천 필드를 생성한다. */
+  /** 사이트 메타를 fetch해 NVIDIA NIM으로 추천 필드를 생성한다. */
   async suggest(input: {
     url: string;
     domain: string;
   }): Promise<SiteSuggestion> {
-    if (!this.genAI) {
+    if (!this.client) {
       throw new ServiceUnavailableException(
-        'GEMINI_API_KEY가 설정되지 않았습니다',
+        'NVIDIA_API_KEY가 설정되지 않았습니다',
       );
     }
 
     const meta = await this.fetchMeta(input.url);
-
-    const model = this.genAI.getGenerativeModel({
-      model: 'gemini-2.5-flash',
-      generationConfig: {
-        responseMimeType: 'application/json',
-        // 키·타입을 강제하고 category는 enum으로 제한 → 파싱 오류·잘못된 카테고리 차단
-        responseSchema: {
-          type: SchemaType.OBJECT,
-          properties: {
-            name: { type: SchemaType.STRING },
-            category: {
-              type: SchemaType.STRING,
-              format: 'enum',
-              enum: CATEGORIES,
-            },
-            description: { type: SchemaType.STRING },
-            icon: { type: SchemaType.STRING },
-          },
-          required: ['name', 'category', 'description', 'icon'],
-        },
-      },
-    });
 
     const prompt = [
       '너는 로스트아크(게임) 관련 웹사이트를 분류하는 도우미야.',
@@ -138,15 +125,31 @@ export class SiteSuggestService {
 
     let raw: string;
     try {
-      const result = await model.generateContent(prompt);
-      raw = result.response.text();
+      // response_format=json_object → 모델이 JSON만 출력 (프롬프트에 "JSON" 명시 필요)
+      const completion = await this.client.chat.completions.create({
+        model: this.model,
+        messages: [{ role: 'user', content: prompt }],
+        temperature: 0.2,
+        response_format: { type: 'json_object' },
+      });
+      raw = completion.choices[0]?.message?.content ?? '';
     } catch (e) {
       const msg = e instanceof Error ? e.message : '알 수 없는 오류';
-      throw new ServiceUnavailableException(`Gemini 호출 실패: ${msg}`);
+      // 429(할당량/속도 제한)는 일시적 — 원본 에러 대신 사용자 안내 메시지로 변환
+      if (/429|quota|rate limit|too many requests/i.test(msg)) {
+        this.logger.warn(`NVIDIA 할당량 초과: ${msg}`);
+        throw new ServiceUnavailableException(
+          'AI 추천 요청이 많아 일시적으로 제한되었습니다. 잠시 후 다시 시도해주세요.',
+        );
+      }
+      this.logger.warn(`NVIDIA 호출 실패: ${msg}`);
+      throw new ServiceUnavailableException(
+        'AI 추천 생성에 실패했습니다. 잠시 후 다시 시도해주세요.',
+      );
     }
 
     const parsed = this.parse(raw);
-    // icon fallback: Gemini → og:image → google favicon
+    // icon fallback: AI → og:image → google favicon
     const icon =
       parsed.icon?.trim() ||
       meta.ogImage ||
@@ -177,7 +180,7 @@ export class SiteSuggestService {
       }
       return {};
     } catch {
-      this.logger.warn(`Gemini JSON 파싱 실패: ${raw.slice(0, 120)}`);
+      this.logger.warn(`NVIDIA JSON 파싱 실패: ${raw.slice(0, 120)}`);
       return {};
     }
   }

--- a/server/src/admin/site-suggest.service.ts
+++ b/server/src/admin/site-suggest.service.ts
@@ -135,8 +135,13 @@ export class SiteSuggestService {
       raw = completion.choices[0]?.message?.content ?? '';
     } catch (e) {
       const msg = e instanceof Error ? e.message : '알 수 없는 오류';
-      // 429(할당량/속도 제한)는 일시적 — 원본 에러 대신 사용자 안내 메시지로 변환
-      if (/429|quota|rate limit|too many requests/i.test(msg)) {
+      // 429(할당량/속도 제한)는 일시적 — 원본 에러 대신 사용자 안내 메시지로 변환.
+      // openai SDK는 HTTP 상태를 e.status로 제공하므로 우선 그것으로 판정하고,
+      // 메시지 정규식은 포맷이 다른 경우를 위한 보조 수단으로 둔다.
+      const isRateLimit =
+        (e instanceof OpenAI.APIError && e.status === 429) ||
+        /429|quota|rate limit|too many requests/i.test(msg);
+      if (isRateLimit) {
         this.logger.warn(`NVIDIA 할당량 초과: ${msg}`);
         throw new ServiceUnavailableException(
           'AI 추천 요청이 많아 일시적으로 제한되었습니다. 잠시 후 다시 시도해주세요.',


### PR DESCRIPTION
## 배경
admin 사이트 추천에서 AI 추천 시 Gemini 무료 등급 **일일 20회(RPD)** 한도를 초과해 `429 Too Many Requests`가 발생했습니다. 한도가 더 여유로운 **NVIDIA NIM(OpenAI 호환)** 으로 전환합니다.

## 변경 내용
- `@google/generative-ai` 호출 제거(이 기능 한정) → `openai` 패키지로 NVIDIA NIM 호출
  - `class-summary`는 여전히 Gemini를 쓰므로 패키지 자체는 유지
- 모델명을 `NVIDIA_MODEL` 환경변수로 분리 → **코드 수정 없이 모델 교체 가능**
  - 기본값: `qwen/qwen3-next-80b-a3b-instruct` (Instruct형, 한국어·JSON·속도 밸런스)
- `responseSchema`(Gemini 전용) → `response_format: json_object` + 기존 후처리(category enum 방어, icon fallback)로 대체
- 429/quota 에러를 사용자 친화 메시지로 변환, 원본 에러는 서버 로그에만 기록
- SSRF/DNS rebinding 방어 로직은 그대로 유지

## 필요 환경변수 (서버 `.env`)
\`\`\`
NVIDIA_API_KEY=...
NVIDIA_BASE_URL=https://integrate.api.nvidia.com/v1
NVIDIA_MODEL=qwen/qwen3-next-80b-a3b-instruct
\`\`\`
> ⚠️ 배포 환경(EC2 등)에도 위 환경변수 추가 필요.

## 검증
- `tsc --noEmit` 통과
- NVIDIA 엔드포인트 실제 호출 2회 성공 — JSON 모드 + 한국어 분류 결과 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)