### PR TITLE
fix(admin): 입력 텍스트 드래그 중 모달이 닫히는 문제 수정 (admin → main)

### DIFF
--- a/client/app/admin/inven/page.tsx
+++ b/client/app/admin/inven/page.tsx
@@ -131,8 +131,9 @@ function CandidatesTab({ requireMaster }: { requireMaster: (action: string) => b
   const [aiIcon, setAiIcon] = useState<string>("");
   // 자동 fetch로 가져온 기본 아이콘 (AI 선택 후에도 복구 가능하도록 보관)
   const [fetchedIcon, setFetchedIcon] = useState<string>("");
-  // 경쟁 상태 방지: 현재 열린 후보 ID와 응답 대상 ID가 다르면 폼 갱신 무시
-  const [activeFetchId, setActiveFetchId] = useState<number | null>(null);
+  // 경쟁 상태 방지: 현재 열린 후보 ID와 응답 대상 ID가 다르면 폼 갱신 무시.
+  // 값은 setter의 함수형 업데이트(cur) 안에서만 읽으므로 값 바인딩은 생략.
+  const [, setActiveFetchId] = useState<number | null>(null);
 
   const load = async () => {
     setLoading(true);

--- a/client/app/admin/inven/page.tsx
+++ b/client/app/admin/inven/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { buildGuestNotice, useAdminRole } from "@/lib/admin-role";
 
 // ── 타입 ──────────────────────────────────────────────────────────────────────
@@ -150,6 +150,11 @@ function CandidatesTab({ requireMaster }: { requireMaster: (action: string) => b
   useEffect(() => {
     load();
   }, []);
+
+  // 백드롭 클릭으로 모달을 닫되, "프레스를 백드롭에서 시작"한 경우에만 닫는다.
+  // (입력칸 텍스트를 드래그 선택하다 마우스를 백드롭에서 떼면 click 타깃이
+  //  오버레이가 되어 의도치 않게 닫히는 문제 방지)
+  const overlayPressOnSelf = useRef(false);
 
   // "+ 사이트 추가" → 모달 열고 후보 정보로 폼 채우기 (URL은 도메인 루트)
   const openAddModal = (c: SiteCandidate) => {
@@ -338,8 +343,19 @@ function CandidatesTab({ requireMaster }: { requireMaster: (action: string) => b
       {addTarget && (
         <div
           className="admin-modal-overlay"
+          onMouseDown={(e) => {
+            overlayPressOnSelf.current = e.target === e.currentTarget;
+          }}
           onClick={(e) => {
-            if (!saving && e.target === e.currentTarget) closeAddModal();
+            // mousedown·click 모두 오버레이 자신에서 일어난 진짜 백드롭 클릭만 닫기
+            if (
+              !saving &&
+              e.target === e.currentTarget &&
+              overlayPressOnSelf.current
+            ) {
+              closeAddModal();
+            }
+            overlayPressOnSelf.current = false;
           }}
         >
           <div className="admin-modal w-full max-w-2xl p-6">
@@ -445,8 +461,14 @@ function CandidatesTab({ requireMaster }: { requireMaster: (action: string) => b
       {confirmTarget && (
         <div
           className="admin-modal-overlay"
+          onMouseDown={(e) => {
+            overlayPressOnSelf.current = e.target === e.currentTarget;
+          }}
           onClick={(e) => {
-            if (e.target === e.currentTarget) setConfirmTarget(null);
+            if (e.target === e.currentTarget && overlayPressOnSelf.current) {
+              setConfirmTarget(null);
+            }
+            overlayPressOnSelf.current = false;
           }}
         >
           <div className="admin-modal max-w-md w-[90%] p-5 space-y-4">

--- a/client/app/admin/inven/page.tsx
+++ b/client/app/admin/inven/page.tsx
@@ -155,7 +155,9 @@ function CandidatesTab({ requireMaster }: { requireMaster: (action: string) => b
   // 백드롭 클릭으로 모달을 닫되, "프레스를 백드롭에서 시작"한 경우에만 닫는다.
   // (입력칸 텍스트를 드래그 선택하다 마우스를 백드롭에서 떼면 click 타깃이
   //  오버레이가 되어 의도치 않게 닫히는 문제 방지)
-  const overlayPressOnSelf = useRef(false);
+  // 모달별로 ref를 분리해 서로 영향을 주지 않게 한다.
+  const addOverlayPressOnSelf = useRef(false);
+  const confirmOverlayPressOnSelf = useRef(false);
 
   // "+ 사이트 추가" → 모달 열고 후보 정보로 폼 채우기 (URL은 도메인 루트)
   const openAddModal = (c: SiteCandidate) => {
@@ -345,18 +347,18 @@ function CandidatesTab({ requireMaster }: { requireMaster: (action: string) => b
         <div
           className="admin-modal-overlay"
           onMouseDown={(e) => {
-            overlayPressOnSelf.current = e.target === e.currentTarget;
+            addOverlayPressOnSelf.current = e.target === e.currentTarget;
           }}
           onClick={(e) => {
             // mousedown·click 모두 오버레이 자신에서 일어난 진짜 백드롭 클릭만 닫기
             if (
               !saving &&
               e.target === e.currentTarget &&
-              overlayPressOnSelf.current
+              addOverlayPressOnSelf.current
             ) {
               closeAddModal();
             }
-            overlayPressOnSelf.current = false;
+            addOverlayPressOnSelf.current = false;
           }}
         >
           <div className="admin-modal w-full max-w-2xl p-6">
@@ -463,13 +465,13 @@ function CandidatesTab({ requireMaster }: { requireMaster: (action: string) => b
         <div
           className="admin-modal-overlay"
           onMouseDown={(e) => {
-            overlayPressOnSelf.current = e.target === e.currentTarget;
+            confirmOverlayPressOnSelf.current = e.target === e.currentTarget;
           }}
           onClick={(e) => {
-            if (e.target === e.currentTarget && overlayPressOnSelf.current) {
+            if (e.target === e.currentTarget && confirmOverlayPressOnSelf.current) {
               setConfirmTarget(null);
             }
-            overlayPressOnSelf.current = false;
+            confirmOverlayPressOnSelf.current = false;
           }}
         >
           <div className="admin-modal max-w-md w-[90%] p-5 space-y-4">

--- a/client/app/admin/sites/page.tsx
+++ b/client/app/admin/sites/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   Area,
   AreaChart,
@@ -110,6 +110,11 @@ export default function AdminSitesPage() {
   const [busyMessage, setBusyMessage] = useState<string | null>(null);
   const role = useAdminRole();
   const isGuest = role === "guest";
+
+  // 백드롭 클릭으로 모달을 닫되, "프레스를 백드롭에서 시작"한 경우에만 닫는다.
+  // (입력칸 텍스트를 드래그 선택하다 마우스를 백드롭에서 떼면 click 타깃이
+  //  오버레이가 되어 의도치 않게 닫히는 문제 방지)
+  const overlayPressOnSelf = useRef(false);
 
   // 추가/수정 폼
   const [showForm, setShowForm] = useState(false);
@@ -478,8 +483,19 @@ export default function AdminSitesPage() {
       {showForm && (
         <div
           className="admin-modal-overlay"
+          onMouseDown={(e) => {
+            overlayPressOnSelf.current = e.target === e.currentTarget;
+          }}
           onClick={(e) => {
-            if (!isProcessing && e.target === e.currentTarget) cancelEdit();
+            // mousedown·click 모두 오버레이 자신에서 일어난 진짜 백드롭 클릭만 닫기
+            if (
+              !isProcessing &&
+              e.target === e.currentTarget &&
+              overlayPressOnSelf.current
+            ) {
+              cancelEdit();
+            }
+            overlayPressOnSelf.current = false;
           }}
         >
           <div className="admin-modal w-full max-w-2xl p-6">

--- a/client/app/api/admin/inven/pipeline/status/route.ts
+++ b/client/app/api/admin/inven/pipeline/status/route.ts
@@ -1,9 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 
 const NEST_API = process.env.NEST_API_URL ?? "http://localhost:3001";
 
-export async function GET(_req: NextRequest) {
+export async function GET() {
   try {
     const store = await cookies();
     const token = store.get("admin_token")?.value ?? "";


### PR DESCRIPTION
admin 브랜치에 머지된 모달 백드롭 닫힘 버그 수정을 main으로 승격합니다.
(포함 PR: #283)

## 증상
admin **사이트 추천 → 사이트 추가** 모달에서 description 등 입력칸 텍스트를 **드래그로 선택하다 마우스를 모달 바깥(백드롭)에서 떼면 모달이 닫혀버림.**

## 원인
백드롭 닫기 핸들러가 `click`의 `e.target === e.currentTarget`만 검사. 드래그 선택은 mousedown=입력칸 / mouseup=백드롭으로 끝나는데, 이때 `click` target이 공통 조상인 오버레이가 되어 닫힘 조건이 참이 됨.

## 수정
`onMouseDown`으로 **프레스가 백드롭 자신에서 시작됐는지** 기록하고, `onClick`에서 **mousedown·click 둘 다 백드롭일 때만** 닫도록 변경.
- `client/app/admin/inven/page.tsx` — 사이트 추가 모달 + 블랙리스트 확인 모달 (모달별 ref 분리)
- `client/app/admin/sites/page.tsx` — 추가/수정 모달

## 그 외
- eslint no-unused-vars 경고 정리(`activeFetchId`, `_req`)
- 코드 리뷰 반영: CandidatesTab 두 모달의 백드롭 ref 분리

## 검증
- `npm run lint` 경고·에러 0
- 입력칸 안 편집은 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)