### PR TITLE
feat(streamers): 인기 영상을 DB 누적 7일 창에서 서빙

### DIFF
--- a/db/migrations/004_youtube_published_at_timestamptz.sql
+++ b/db/migrations/004_youtube_published_at_timestamptz.sql
@@ -1,0 +1,23 @@
+-- youtube_view_snapshots.published_at 를 DATE → TIMESTAMPTZ 로 승격 (멱등)
+-- 이유: 최근 7일 영상 피드를 DB 누적분에서 서빙하면서 게시 시각 정밀도가 필요해짐.
+--       DATE(날짜만)면 같은 날 영상 정렬이 뒤섞이고 timeAgo("N시간 전")가 자정 기준으로 어긋남.
+-- 기존 행: 자정(00:00) 시각으로 승격되며, 이후 갱신분부터 전체 시각이 저장됨.
+-- 실행: gh workflow run db-migrate.yml -f sql_file=db/migrations/004_youtube_published_at_timestamptz.sql
+
+SET search_path TO lost_ark, public;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'lost_ark'
+      AND table_name = 'youtube_view_snapshots'
+      AND column_name = 'published_at'
+      AND data_type = 'date'
+  ) THEN
+    ALTER TABLE youtube_view_snapshots
+      ALTER COLUMN published_at TYPE timestamptz
+      USING published_at::timestamptz;
+  END IF;
+END $$;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -217,7 +217,7 @@ model youtube_view_snapshots {
   title         String   @default("")
   channel_title String   @default("")
   thumbnail_url String   @default("")
-  published_at  DateTime @db.Date
+  published_at  DateTime @db.Timestamptz(6)
   duration      String   @default("")
   view_count    BigInt   @default(0)
   recorded_date DateTime @db.Date

--- a/server/src/streamers/streamers.repository.ts
+++ b/server/src/streamers/streamers.repository.ts
@@ -32,6 +32,56 @@ export class StreamersRepository {
     }
   }
 
+  /**
+   * 게시일이 최근 `days`일 이내인 영상을 video_id 기준 1건씩(최신 스냅샷의 조회수)
+   * 게시일 내림차순으로 반환한다.
+   *
+   * youtube_view_snapshots 는 (video_id, recorded_date) 당 1행이라 같은 영상이
+   * 여러 날짜로 누적된다. DISTINCT ON 으로 가장 최근에 기록된 행만 골라
+   * 최신 조회수를 쓴다. 7일 창 밖으로 밀려나 더는 갱신되지 않는 영상도
+   * 게시일이 7일 이내면 그대로 노출된다(= 누적 서빙).
+   */
+  async findRecentVideos(days: number): Promise<YoutubeVideoItem[]> {
+    const rows = await this.prisma.$queryRaw<
+      Array<{
+        video_id: string;
+        title: string;
+        channel_title: string;
+        thumbnail_url: string;
+        published_at: Date;
+        duration: string;
+        view_count: bigint;
+      }>
+    >`
+      SELECT DISTINCT ON (video_id)
+        video_id,
+        title,
+        channel_title,
+        thumbnail_url,
+        published_at,
+        duration,
+        view_count
+      FROM youtube_view_snapshots
+      WHERE published_at >= NOW() - (${days}::int * INTERVAL '1 day')
+      ORDER BY video_id, recorded_date DESC
+    `;
+
+    return rows
+      .map((r) => ({
+        videoId: r.video_id,
+        title: r.title,
+        channelTitle: r.channel_title,
+        thumbnailUrl: r.thumbnail_url,
+        publishedAt: r.published_at.toISOString(),
+        duration: r.duration,
+        viewCount: Number(r.view_count),
+      }))
+      .sort(
+        (a, b) =>
+          new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime(),
+      );
+  }
+
   async findViewHistory(
     days: number,
   ): Promise<{ date: string; avg: number }[]> {

--- a/server/src/streamers/streamers.service.spec.ts
+++ b/server/src/streamers/streamers.service.spec.ts
@@ -11,6 +11,7 @@ function createService(options?: {
   localDisable?: string;
   cache?: { items: YoutubeVideoItem[]; nextPageToken: string | null };
   popularCache?: { items: YoutubeVideoItem[] };
+  dbVideos?: YoutubeVideoItem[];
 }) {
   const redis: MockRedis = {
     get: jest.fn((key: string) => {
@@ -43,10 +44,11 @@ function createService(options?: {
 
   const db = {
     query: jest.fn().mockResolvedValue([[], []]),
+    findRecentVideos: jest.fn().mockResolvedValue(options?.dbVideos ?? []),
   };
 
   const service = new StreamersService(redis as never, db as never, config);
-  return { service, redis };
+  return { service, redis, db };
 }
 
 describe('StreamersService', () => {
@@ -100,8 +102,8 @@ describe('StreamersService', () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it('LOCAL_DISABLE_QUOTA_APIS=true고 인기 영상 캐시가 없으면 빈 인기 목록을 반환한다', async () => {
-    const { service } = createService({ localDisable: 'true' });
+  it('인기 영상 캐시가 없고 DB도 비어 있으면 빈 인기 목록을 반환한다', async () => {
+    const { service } = createService();
     const fetchSpy = jest.spyOn(service as never, 'fetchFromYouTube');
 
     const result = await service.searchPopularVideos();
@@ -112,6 +114,46 @@ describe('StreamersService', () => {
       hasMore: false,
       total: 0,
     });
+    // 서빙 경로는 DB만 사용하며 YouTube API를 호출하지 않는다.
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('인기 영상 캐시가 없으면 DB 누적분(최근 7일)에서 서빙한다', async () => {
+    const dbVideos: YoutubeVideoItem[] = [
+      {
+        videoId: 'old7',
+        title: '7일 전 영상',
+        channelTitle: '채널',
+        thumbnailUrl: 'https://example.com/old.jpg',
+        publishedAt: '2026-06-03T00:00:00Z',
+        duration: '12:00',
+        viewCount: 5000,
+      },
+      {
+        videoId: 'today1',
+        title: '오늘 영상',
+        channelTitle: '채널',
+        thumbnailUrl: 'https://example.com/new.jpg',
+        publishedAt: '2026-06-10T00:00:00Z',
+        duration: '08:00',
+        viewCount: 3000,
+      },
+    ];
+    const { service, db, redis } = createService({ dbVideos });
+    const fetchSpy = jest.spyOn(service as never, 'fetchFromYouTube');
+
+    const result = await service.searchPopularVideos();
+
+    expect(db.findRecentVideos).toHaveBeenCalledWith(7);
+    expect(result.items).toEqual(dbVideos);
+    expect(result.total).toBe(2);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    // DB 조회 결과를 Redis 읽기 캐시에 저장한다.
+    expect(redis.set).toHaveBeenCalledWith(
+      'youtube:popular:first',
+      JSON.stringify({ items: dbVideos }),
+      'EX',
+      expect.any(Number),
+    );
   });
 });

--- a/server/src/streamers/streamers.service.ts
+++ b/server/src/streamers/streamers.service.ts
@@ -12,12 +12,12 @@ const POPULAR_CACHE_KEY = 'youtube:popular:first';
 const CACHE_TTL = 4 * 60 * 60; // 4시간 (Cron 3시간 갱신 + 여유)
 const QUOTA_KEY = 'youtube:quota_exceeded';
 const LOCK_VIDEOS_KEY = 'youtube:lock:videos';
-const LOCK_POPULAR_KEY = 'youtube:lock:popular';
 const LOCK_TTL = 60; // 락 최대 60초 유지
 const MAX_RESULTS = 20;
 const POPULAR_MAX_RESULTS = 50;
 const POPULAR_MAX_LIMIT = 50;
 const POPULAR_MAX_PAGES = 8;
+const POPULAR_WINDOW_DAYS = 7; // 인기 영상 노출 창(게시일 기준 최근 7일)
 
 export interface PopularResponse {
   items: YoutubeVideoItem[];
@@ -270,15 +270,17 @@ export class StreamersService implements OnModuleInit {
         (a, b) =>
           new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime(),
       );
-      await this.youtubeRedis.set(
-        POPULAR_CACHE_KEY,
-        JSON.stringify({ items: uniqueItems }),
-        'EX',
-        CACHE_TTL,
-      );
-      this.logger.log(`YouTube 인기 영상 ${uniqueItems.length}건 캐시 저장`);
-      // 조회수 스냅샷 저장
+      // 1) 새로 가져온 영상을 DB에 누적 저장(메타데이터 + 조회수 스냅샷)
       await this.snapshotViewCounts(uniqueItems);
+      // 2) 서빙 캐시는 DB의 최근 7일 누적분으로 재구성한다.
+      //    YouTube 검색이 도달하지 못해 이번에 안 잡힌 영상도 게시일이
+      //    7일 이내면 DB에 남아 있어 계속 노출된다(= 누적 서빙).
+      const recent =
+        await this.streamersRepo.findRecentVideos(POPULAR_WINDOW_DAYS);
+      await this.cachePopular(recent);
+      this.logger.log(
+        `YouTube 인기 영상 ${recent.length}건 캐시 저장 (DB 누적 ${POPULAR_WINDOW_DAYS}일)`,
+      );
     } catch (err: unknown) {
       const apiErr = toYoutubeApiError(err);
       const status = apiErr.response?.status;
@@ -403,12 +405,16 @@ export class StreamersService implements OnModuleInit {
 
   /**
    * GET /api/streamers/popular
-   * offset/limit 미지정 시 전체 목록, 지정 시 캐시된 목록을 분할 반환
+   * 게시일 기준 최근 7일 영상을 DB 누적분에서 서빙한다.
+   * Redis 캐시는 DB 조회 결과를 담는 읽기 캐시일 뿐이며, YouTube API는
+   * 호출하지 않는다(갱신은 refresh() 크론이 전담).
+   * offset/limit 미지정 시 전체 목록, 지정 시 분할 반환.
    */
   async searchPopularVideos(offset = 0, limit = 0): Promise<PopularResponse> {
     const safeOffset = Math.max(0, offset);
     const safeLimit = Math.min(Math.max(0, limit), POPULAR_MAX_LIMIT);
 
+    // 1. Redis 읽기 캐시 (DB 누적분을 캐싱한 결과)
     try {
       const cached = await this.youtubeRedis.get(POPULAR_CACHE_KEY);
       if (cached) {
@@ -421,66 +427,27 @@ export class StreamersService implements OnModuleInit {
       );
     }
 
-    if (this.youtubeRedisReadOnly) {
-      this.logger.log(
-        'YOUTUBE_REDIS_READONLY 활성화 — 인기 영상 캐시 미스 시 빈 결과 반환',
-      );
-      return { items: [], nextOffset: null, hasMore: false, total: 0 };
-    }
-
-    if (this.quotaApisDisabled) {
-      this.logger.log(
-        'LOCAL_DISABLE_QUOTA_APIS 활성화 — 인기 영상 API 호출 없이 빈 결과 반환',
-      );
-      return { items: [], nextOffset: null, hasMore: false, total: 0 };
-    }
-
+    // 2. 캐시 미스 → DB에서 최근 7일 누적분 조회 후 캐싱
+    let items: YoutubeVideoItem[];
     try {
-      const blocked = await this.youtubeRedis.get(QUOTA_KEY);
-      if (blocked) {
-        return { items: [], nextOffset: null, hasMore: false, total: 0 };
-      }
-    } catch (error: unknown) {
-      this.logger.debug(
-        `할당량 플래그 조회 실패(무시): ${toErrorMessage(error)}`,
-      );
-    }
-
-    // 분산 락 — 동시 요청 중 첫 번째만 API 호출 (Thundering Herd 방지)
-    const popularLock = await this.youtubeRedis
-      .set(LOCK_POPULAR_KEY, '1', 'EX', LOCK_TTL, 'NX')
-      .catch(() => null);
-    if (!popularLock) {
-      this.logger.debug('YouTube popular 락 대기 중 — 빈 결과 반환');
-      return { items: [], nextOffset: null, hasMore: false, total: 0 };
-    }
-
-    let popular: { items: YoutubeVideoItem[] };
-    try {
-      const allItems: YoutubeVideoItem[] = [];
-      let pageToken: string | undefined;
-      for (let page = 0; page < POPULAR_MAX_PAGES; page++) {
-        const result = await this.fetchFromYouTube(pageToken, 'date', true);
-        allItems.push(...result.items);
-        if (!result.nextPageToken) break;
-        pageToken = result.nextPageToken;
-      }
-      const uniqueItems = dedupByVideoId(allItems);
-      uniqueItems.sort(
-        (a, b) =>
-          new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime(),
-      );
-      popular = { items: uniqueItems };
+      items = await this.streamersRepo.findRecentVideos(POPULAR_WINDOW_DAYS);
     } catch (err: unknown) {
-      this.logger.error(`searchPopularVideos 실패: ${toErrorMessage(err)}`);
-      await this.youtubeRedis.del(LOCK_POPULAR_KEY).catch(() => {});
+      this.logger.error(`popular DB 조회 실패: ${toErrorMessage(err)}`);
       return { items: [], nextOffset: null, hasMore: false, total: 0 };
     }
 
+    await this.cachePopular(items);
+    return this.slicePopular(items, safeOffset, safeLimit);
+  }
+
+  /** DB의 최근 7일 영상 목록을 popular 읽기 캐시에 저장 */
+  private async cachePopular(items: YoutubeVideoItem[]): Promise<void> {
+    // 로컬 dev가 공유 EC2 Redis를 읽기 전용으로 붙는 경우 쓰기 금지
+    if (this.youtubeRedisReadOnly) return;
     try {
       await this.youtubeRedis.set(
         POPULAR_CACHE_KEY,
-        JSON.stringify(popular),
+        JSON.stringify({ items }),
         'EX',
         CACHE_TTL,
       );
@@ -488,11 +455,7 @@ export class StreamersService implements OnModuleInit {
       this.logger.debug(
         `popular 캐시 저장 실패(무시): ${toErrorMessage(error)}`,
       );
-    } finally {
-      await this.youtubeRedis.del(LOCK_POPULAR_KEY).catch(() => {});
     }
-
-    return this.slicePopular(popular.items, safeOffset, safeLimit);
   }
 
   private slicePopular(


### PR DESCRIPTION
@
## 문제
`/api/streamers/popular`이 Redis 단일 스냅샷(YouTube 그 순간 검색, 4h TTL)만 서빙했음. 최신순 페이지 예산(8p×50)이 하루치에서 소진돼서 **7일 전 영상은 안 뜨고 1일 전까지만** 노출됨. 원래 의도(DB에 누적해 7일간 꾸준히 표시, 7일 지나면 탈락)가 서빙 경로에 연결돼 있지 않았음.

## 변경
- **`searchPopularVideos`**: 서빙 소스를 DB 누적분으로 전환. Redis는 읽기 캐시로만. YouTube API 호출/락/할당량 분기 제거(갱신은 `refresh` 크론 전담).
- **`StreamersRepository.findRecentVideos(days)`**: `DISTINCT ON(video_id)`로 영상당 최신 스냅샷을 골라 `published_at` 최근 7일분을 게시일 내림차순 반환. 7일 창 밖으로 밀려나 더는 안 잡히는 영상도 게시일이 7일 이내면 노출(= 누적 서빙).
- **`refresh`**: 가져온 영상을 DB 스냅샷 저장 후, 서빙 캐시를 DB 7일 누적분으로 재구성. `cachePopular`는 READONLY(로컬 dev) 시 공유 Redis 쓰기 금지.
- **`published_at` DATE → timestamptz** 승격(정렬/시간표시 정밀도): prisma 스키마 + `db/migrations/004`(멱등).

## 배포 순서 주의
db-migrate 워크플로가 `git pull origin main` 기준이라, 마이그레이션 SQL이 **main에 머지된 뒤** 실행 가능:
1. main 반영 후 `gh workflow run db-migrate.yml -f sql_file=db/migrations/004_youtube_published_at_timestamptz.sql -f restart_nest=false`
2. `MIGRATION_OK` 확인 → 코드 배포(nest 재시작)

콜드스타트: DB 7일치가 다 차려면 크론이 며칠 돌아야 하지만, 이미 매일 스냅샷이 쌓여 와서 상당 부분 즉시 노출됨.

## 테스트
- 서버 유닛 테스트 5/5 통과, tsc/eslint green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@