### PR TITLE
perf(mainPage): 홈을 정적 ISR로 전환해 TTFB 단축

### DIFF
--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -13,8 +13,9 @@ export const metadata: Metadata = {
 };
 
 // 홈을 정적 ISR로 서빙 → 서울 엣지 CDN에서 캐시된 HTML 제공(TTFB 대폭 단축).
-// 1시간마다 백그라운드 재검증. 이 시점에만 아래 섹션 fetch/텔레메트리가 실행됨.
-export const revalidate = 3600;
+// 5분마다 백그라운드 재검증. 이 시점에만 아래 섹션 fetch/텔레메트리가 실행됨.
+// (내부 stat-builds fetch가 revalidate:300 → 라우트 재검증 주기는 그 최솟값인 300초로 수렴)
+export const revalidate = 300;
 
 const API = process.env.NEST_API_URL ?? "http://localhost:3001";
 
@@ -66,7 +67,7 @@ export default async function Home() {
   ]);
 
   // 응답 종료 후 섹션별 서버 타이밍을 비동기로 기록(렌더/캐싱에 영향 없음).
-  // 정적 ISR이므로 재검증 렌더 시점(시간당 1회)에만 실행된다.
+  // 정적 ISR이므로 재검증 렌더 시점(5분당 1회)에만 실행된다.
   after(async () => {
     await Promise.all(
       [sitesRes, statRes, summaryRes].map((res) =>

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react";
+import { after } from "next/server";
 import StatBuildList from "@/components/characters/StatBuildList";
 import ClassSummaryList from "@/components/class-summary/ClassSummaryList";
 import SiteList from "@/components/sites/SiteList";
@@ -10,6 +11,10 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   alternates: { canonical: "/" },
 };
+
+// 홈을 정적 ISR로 서빙 → 서울 엣지 CDN에서 캐시된 HTML 제공(TTFB 대폭 단축).
+// 1시간마다 백그라운드 재검증. 이 시점에만 아래 섹션 fetch/텔레메트리가 실행됨.
+export const revalidate = 3600;
 
 const API = process.env.NEST_API_URL ?? "http://localhost:3001";
 
@@ -40,12 +45,9 @@ async function timedFetch<T>(label: string, url: string, revalidate: number) {
     .then<T>((r) => r.json())
     .catch(() => [] as T);
   const durationMs = Date.now() - started;
-  void recordServerTiming({
-    name: label,
-    path: url,
-    durationMs,
-  });
-  return { data, durationMs };
+  // 텔레메트리는 호출처에서 after()로 모아 보냄(렌더 경로 밖). 여기서 직접 보내면
+  // no-store fetch가 렌더 중 실행돼 라우트가 dynamic으로 떨어지고 정적 ISR이 깨진다.
+  return { data, durationMs, name: label, path: url };
 }
 
 export default async function Home() {
@@ -62,6 +64,20 @@ export default async function Home() {
       3600,
     ),
   ]);
+
+  // 응답 종료 후 섹션별 서버 타이밍을 비동기로 기록(렌더/캐싱에 영향 없음).
+  // 정적 ISR이므로 재검증 렌더 시점(시간당 1회)에만 실행된다.
+  after(async () => {
+    await Promise.all(
+      [sitesRes, statRes, summaryRes].map((res) =>
+        recordServerTiming({
+          name: res.name,
+          path: res.path,
+          durationMs: res.durationMs,
+        }),
+      ),
+    );
+  });
 
   const sites = sitesRes.data;
   const statBuilds = statRes.data;


### PR DESCRIPTION
## 배경
홈(`/`)이 진입 시 1.1~1.3초 소요(네이버 0.66초 대비 느림). 원인 진단:

- 홈이 **매 요청마다 dynamic 렌더** → 서울 EC2로 fetch 4회 왕복 후 렌더
- prerender-manifest에 `/` 부재로 dynamic 확정
- 범인: [page.tsx](client/app/page.tsx)의 `recordServerTiming` 안 `cache: "no-store"` 텔레메트리 fetch가 렌더 중 실행되며 라우트를 dynamic으로 강등

## 변경
- `export const revalidate` 추가 → **정적 ISR** 활성화 (서울 엣지 CDN에서 캐시 HTML 서빙)
- `recordServerTiming` 호출을 `after()`(next/server)로 이동 → 렌더 경로에서 분리. dynamic 태깅 해제 + 섹션 타이밍은 재검증 렌더 시점에 계속 기록
- 함수 리전(icn1) 변경 불필요 → Pro/유료 미사용, 추가 비용 $0

## 검증
- `next build` 결과 `/` 가 **ƒ(Dynamic) → ○(Static)** 으로 전환 확인
- Revalidate 5m (내부 stat-builds fetch의 300s가 최솟값으로 적용)
- 타입체크·빌드 통과

## 기대 효과
한국 사용자가 서울 엣지 정적 HTML을 즉시 수신 → TTFB 100ms 안쪽 기대, 네이버보다 빨라질 여지.

## 트레이드오프
per-request 섹션 텔레메트리 해상도는 재검증 주기(약 5분당 1회)로 낮아짐. 사이트 동작엔 영향 없고 어드민 모니터링 통계 밀도만 감소.

🤖 Generated with [Claude Code](https://claude.com/claude-code)