### PR TITLE
perf(mainPage): 홈 정적 ISR 전환 (TTFB 단축)

### DIFF
--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -13,8 +13,9 @@ export const metadata: Metadata = {
 };
 
 // 홈을 정적 ISR로 서빙 → 서울 엣지 CDN에서 캐시된 HTML 제공(TTFB 대폭 단축).
-// 1시간마다 백그라운드 재검증. 이 시점에만 아래 섹션 fetch/텔레메트리가 실행됨.
-export const revalidate = 3600;
+// 5분마다 백그라운드 재검증. 이 시점에만 아래 섹션 fetch/텔레메트리가 실행됨.
+// (내부 stat-builds fetch가 revalidate:300 → 라우트 재검증 주기는 그 최솟값인 300초로 수렴)
+export const revalidate = 300;
 
 const API = process.env.NEST_API_URL ?? "http://localhost:3001";
 
@@ -66,7 +67,7 @@ export default async function Home() {
   ]);
 
   // 응답 종료 후 섹션별 서버 타이밍을 비동기로 기록(렌더/캐싱에 영향 없음).
-  // 정적 ISR이므로 재검증 렌더 시점(시간당 1회)에만 실행된다.
+  // 정적 ISR이므로 재검증 렌더 시점(5분당 1회)에만 실행된다.
   after(async () => {
     await Promise.all(
       [sitesRes, statRes, summaryRes].map((res) =>

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react";
+import { after } from "next/server";
 import StatBuildList from "@/components/characters/StatBuildList";
 import ClassSummaryList from "@/components/class-summary/ClassSummaryList";
 import SiteList from "@/components/sites/SiteList";
@@ -10,6 +11,10 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   alternates: { canonical: "/" },
 };
+
+// 홈을 정적 ISR로 서빙 → 서울 엣지 CDN에서 캐시된 HTML 제공(TTFB 대폭 단축).
+// 1시간마다 백그라운드 재검증. 이 시점에만 아래 섹션 fetch/텔레메트리가 실행됨.
+export const revalidate = 3600;
 
 const API = process.env.NEST_API_URL ?? "http://localhost:3001";
 
@@ -40,12 +45,9 @@ async function timedFetch<T>(label: string, url: string, revalidate: number) {
     .then<T>((r) => r.json())
     .catch(() => [] as T);
   const durationMs = Date.now() - started;
-  void recordServerTiming({
-    name: label,
-    path: url,
-    durationMs,
-  });
-  return { data, durationMs };
+  // 텔레메트리는 호출처에서 after()로 모아 보냄(렌더 경로 밖). 여기서 직접 보내면
+  // no-store fetch가 렌더 중 실행돼 라우트가 dynamic으로 떨어지고 정적 ISR이 깨진다.
+  return { data, durationMs, name: label, path: url };
 }
 
 export default async function Home() {
@@ -62,6 +64,20 @@ export default async function Home() {
       3600,
     ),
   ]);
+
+  // 응답 종료 후 섹션별 서버 타이밍을 비동기로 기록(렌더/캐싱에 영향 없음).
+  // 정적 ISR이므로 재검증 렌더 시점(시간당 1회)에만 실행된다.
+  after(async () => {
+    await Promise.all(
+      [sitesRes, statRes, summaryRes].map((res) =>
+        recordServerTiming({
+          name: res.name,
+          path: res.path,
+          durationMs: res.durationMs,
+        }),
+      ),
+    );
+  });
 
   const sites = sitesRes.data;
   const statBuilds = statRes.data;


### PR DESCRIPTION
`mainPage` → `main` 머지 PR. 홈 페이지 정적 ISR 전환 작업 반영.

## 포함 커밋
- perf(mainPage): 홈을 정적 ISR로 전환해 TTFB 단축 (#287)
- docs(mainPage): revalidate 설정·주석을 실제 동작(300초)에 맞춤 (리뷰 반영)

## 요약
홈(`/`)이 매 요청마다 dynamic 렌더되며 서울 EC2로 fetch 4회 왕복하던 것을 **정적 ISR**로 전환.
서울 엣지 CDN에서 캐시 HTML을 서빙해 TTFB 대폭 단축(기존 1.1~1.3초 → 100ms대 기대).

- `export const revalidate = 300` → 정적 ISR 활성화 (실효 재검증 5분, stat-builds 신선도 기준)
- `recordServerTiming`을 `after()`로 이동 → 렌더 중 no-store fetch가 라우트를 dynamic으로 강등하던 원인 제거. 섹션 타이밍은 재검증 시점에 계속 기록
- 함수 리전(icn1) 변경 불필요 → 추가 비용 $0

## 검증
- `next build`에서 `/` 가 ƒ(Dynamic) → ○(Static) 전환 확인
- 타입체크·빌드 통과, Vercel 프리뷰 Ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)