### PR TITLE
perf(mainPage): 유튜브 LCP 썸네일 우선 로드 + 나머지 lazy

### DIFF
--- a/client/components/youtube/YoutubeList.tsx
+++ b/client/components/youtube/YoutubeList.tsx
@@ -477,6 +477,10 @@ export default function YoutubeList({
                           <img
                             src={v.thumbnailUrl}
                             alt=""
+                            // 첫 썸네일(LCP 후보)은 우선 로드, 보이는 2개만 eager·나머지는 lazy
+                            // → LCP 단축 + 초기 이미지 대역폭 절감(8장 → 보이는 만큼만)
+                            loading={idx < 2 ? "eager" : "lazy"}
+                            fetchPriority={idx === 0 ? "high" : undefined}
                             className="h-28 w-full rounded-lg object-cover"
                           />
                           <span className="absolute bottom-1 right-1 rounded bg-black/70 px-1 py-0.5 text-[10px] font-bold text-white leading-none">

--- a/client/components/youtube/YoutubeList.tsx
+++ b/client/components/youtube/YoutubeList.tsx
@@ -477,9 +477,9 @@ export default function YoutubeList({
                           <img
                             src={v.thumbnailUrl}
                             alt=""
-                            // 첫 썸네일(LCP 후보)은 우선 로드, 보이는 2개만 eager·나머지는 lazy
-                            // → LCP 단축 + 초기 이미지 대역폭 절감(8장 → 보이는 만큼만)
-                            loading={idx < 2 ? "eager" : "lazy"}
+                            // 첫 썸네일(LCP 후보)은 우선 로드. 데스크톱(sm:w-52)에서 한 번에
+                            // 보이는 ~4개까지 eager(pop-in 방지), 화면 밖은 lazy로 대역폭 절감.
+                            loading={idx < 4 ? "eager" : "lazy"}
                             fetchPriority={idx === 0 ? "high" : undefined}
                             className="h-28 w-full rounded-lg object-cover"
                           />


### PR DESCRIPTION
PageSpeed Insights "LCP 요청 탐색"에서 LCP 이미지(유튜브 첫 썸네일)에 `fetchpriority=high`가 없다고 지적 → 적용.

- 첫 썸네일(idx 0): `fetchPriority="high"` → LCP 이미지 우선 로드
- 보이는 2개만 `loading="eager"`, 나머지는 `loading="lazy"` → 초기엔 보이는 썸네일만 받아 이미지 대역폭 절감(초기 8장 → 보이는 만큼)

## 검증
- 타입체크(React 19 fetchPriority 허용)·린트·테스트(youtube 11/11)·`next build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)