### PR TITLE
어드민 모니터링·사이트 관리 UI 개선

### DIFF
--- a/client/app/admin/containers/page.tsx
+++ b/client/app/admin/containers/page.tsx
@@ -232,9 +232,6 @@ export default function ContainersPage() {
       <div className="mb-5 flex shrink-0 items-start justify-between gap-4">
         <div>
           <h1 className="admin-page-title">컨테이너 현황</h1>
-          <p className="admin-page-subtitle mt-1">
-            EC2 호스트와 Docker 컨테이너의 상태·자원 사용량을 확인합니다.
-          </p>
         </div>
         <div className="flex shrink-0 flex-col items-end gap-1 pt-1 text-xs text-[color:var(--admin-text-muted)]">
           {cards.length > 0 && (

--- a/client/app/admin/inven/page.tsx
+++ b/client/app/admin/inven/page.tsx
@@ -55,9 +55,6 @@ export default function AdminInvenPage() {
   return (
     <div className="space-y-4">
       <h1 className="admin-page-title">사이트 추천</h1>
-      <p className="admin-page-subtitle">
-        인벤 커뮤니티에서 언급된, 아직 등록되지 않은 사이트를 모아줍니다. 검토 후 직접 추가하세요.
-      </p>
 
       {accessNotice && (
         <pre className="whitespace-pre-wrap rounded border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">

--- a/client/app/admin/monitoring/page.tsx
+++ b/client/app/admin/monitoring/page.tsx
@@ -336,9 +336,6 @@ export default function MonitoringPage() {
       <div className="mb-5 shrink-0 flex items-start justify-between gap-4">
         <div>
           <h1 className="admin-page-title">모니터링</h1>
-          <p className="admin-page-subtitle mt-1">
-            운영 상태와 추세를 빠르게 확인합니다.
-          </p>
         </div>
         <div className="flex shrink-0 items-center pt-1 text-xs text-[color:var(--admin-text-muted)]">
           평균 응답

--- a/client/app/admin/monitoring/page.tsx
+++ b/client/app/admin/monitoring/page.tsx
@@ -124,9 +124,6 @@ export default function MonitoringPage() {
   const [sectionTab, setSectionTab] = useState<
     "sites" | "stat-builds" | "youtube"
   >("sites");
-  const [pageLoadSource, setPageLoadSource] = useState<"rum" | "synthetic">(
-    "rum",
-  );
   const [pageLoadDays, setPageLoadDays] = useState<1 | 7 | 30>(7);
   const [pageLoadSeries, setPageLoadSeries] = useState<PageLoadPoint[]>([]);
   const [pageLoadLoading, setPageLoadLoading] = useState(true);
@@ -215,7 +212,7 @@ export default function MonitoringPage() {
     async function loadPageLoad() {
       try {
         const res = await fetch(
-          `/api/admin/monitoring/page-load-series?source=${pageLoadSource}&days=${pageLoadDays}`,
+          `/api/admin/monitoring/page-load-series?days=${pageLoadDays}`,
           { cache: "no-store" },
         );
         if (!alive || !res.ok) return;
@@ -231,7 +228,7 @@ export default function MonitoringPage() {
     return () => {
       alive = false;
     };
-  }, [pageLoadSource, pageLoadDays]);
+  }, [pageLoadDays]);
 
   const pageLoadLatest = useMemo(() => {
     for (let i = pageLoadSeries.length - 1; i >= 0; i -= 1) {
@@ -364,34 +361,16 @@ export default function MonitoringPage() {
           <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
             <div className="flex items-center gap-2">
               <p className="text-sm font-semibold">메인페이지 로딩 속도 추이</p>
-              {pageLoadLatest && (
+              {pageLoadLatest && pageLoadLatest.load != null && (
                 <span className="text-xs text-[color:var(--admin-text-muted)]">
                   최근 전체로딩{" "}
                   <span className="font-semibold text-[color:var(--admin-text)]">
-                    {pageLoadLatest.load ?? "-"}ms
+                    {(pageLoadLatest.load / 1000).toFixed(1)}초
                   </span>
-                  {pageLoadLatest.lcp != null && ` · LCP ${pageLoadLatest.lcp}ms`}
                 </span>
               )}
             </div>
             <div className="flex items-center gap-2">
-              <div className="flex items-center gap-1 rounded-md bg-slate-100 p-0.5">
-                {(
-                  [
-                    { key: "rum", label: "실사용자" },
-                    { key: "synthetic", label: "합성" },
-                  ] as const
-                ).map((s) => (
-                  <button
-                    key={s.key}
-                    type="button"
-                    onClick={() => setPageLoadSource(s.key)}
-                    className={`rounded px-2 py-1 text-xs ${pageLoadSource === s.key ? "bg-white font-semibold text-[color:var(--admin-text)]" : "text-[color:var(--admin-text-muted)]"}`}
-                  >
-                    {s.label}
-                  </button>
-                ))}
-              </div>
               <div className="flex gap-1">
                 {([1, 7, 30] as const).map((d) => (
                   <button
@@ -406,12 +385,6 @@ export default function MonitoringPage() {
               </div>
             </div>
           </div>
-          {pageLoadSource === "synthetic" && (
-            <p className="mb-2 text-[11px] text-[color:var(--admin-text-subtle)]">
-              합성은 서버가 10분마다 메인 HTML 문서를 받아 측정 (TTFB·문서완료만,
-              JS/자원/렌더 제외)
-            </p>
-          )}
           <div className="h-48">
             {pageLoadLoading ? (
               <div className="grid h-full place-items-center text-sm text-[color:var(--admin-text-muted)]">
@@ -440,9 +413,7 @@ export default function MonitoringPage() {
                     wrapperStyle={{ pointerEvents: "none" }}
                   />
                   <Legend wrapperStyle={{ fontSize: 11 }} />
-                  {PAGE_LOAD_METRICS.filter(
-                    (m) => pageLoadSource === "rum" || m.key === "ttfb" || m.key === "load",
-                  ).map((m) => (
+                  {PAGE_LOAD_METRICS.map((m) => (
                     <Line
                       key={m.key}
                       type="monotone"

--- a/client/app/admin/sites/page.tsx
+++ b/client/app/admin/sites/page.tsx
@@ -445,9 +445,6 @@ export default function AdminSitesPage() {
       <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4 mb-6">
         <div>
           <h1 className="admin-page-title">사이트 관리</h1>
-          <p className="admin-page-subtitle mt-1">
-            등록된 사이트 상태를 관리하고 즉시 반영 여부를 확인합니다.
-          </p>
           {accessNotice && (
             <pre className="mt-3 whitespace-pre-wrap rounded border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
               {accessNotice}

--- a/client/app/admin/sites/page.tsx
+++ b/client/app/admin/sites/page.tsx
@@ -440,9 +440,9 @@ export default function AdminSitesPage() {
   );
 
   return (
-    <div>
+    <div className="flex h-full flex-col">
       {/* 헤더 */}
-      <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4 mb-6">
+      <div className="flex shrink-0 flex-col sm:flex-row sm:items-end sm:justify-between gap-4 mb-6">
         <div>
           <h1 className="admin-page-title">사이트 관리</h1>
           {accessNotice && (
@@ -513,7 +513,7 @@ export default function AdminSitesPage() {
               <div className="flex-1 min-w-0">
                 <div className="grid grid-cols-2 gap-4">
                   {(
-                    ["name", "href", "category", "description", "icon"] as const
+                    ["name", "href", "category", "description"] as const
                   ).map((field) => (
                     <div
                       key={field}
@@ -566,7 +566,7 @@ export default function AdminSitesPage() {
       )}
 
       {error && (
-        <div className="admin-card mb-4 px-4 py-3 border-red-200 bg-red-50">
+        <div className="admin-card mb-4 shrink-0 px-4 py-3 border-red-200 bg-red-50">
           <p className="text-sm text-red-600">{error}</p>
         </div>
       )}
@@ -577,9 +577,9 @@ export default function AdminSitesPage() {
           </p>
         </div>
       ) : (
-        <div className="flex gap-4 items-start">
-        <div className="admin-card overflow-hidden flex-1 min-w-0">
-          <div className="overflow-x-auto">
+        <div className="flex min-h-0 flex-1 items-stretch gap-4">
+        <div className="admin-card overflow-hidden flex-1 min-w-0 flex flex-col">
+          <div className="overflow-auto flex-1">
             <table className="admin-table table-fixed w-full min-w-[860px]">
               <colgroup>
                 <col style={{ width: "15%" }} />
@@ -695,7 +695,7 @@ export default function AdminSitesPage() {
         </div>
 
         {/* 우측: 선택 사이트 7일 클릭 추이 */}
-        <div className="admin-card w-80 shrink-0 p-4 hidden lg:block">
+        <div className="admin-card w-80 shrink-0 self-start p-4 hidden lg:block">
           {!selectedSite ? (
             <p className="text-sm text-[color:var(--admin-text-muted)] text-center py-10">
               사이트를 클릭하면

--- a/client/app/admin/youtube/page.tsx
+++ b/client/app/admin/youtube/page.tsx
@@ -99,7 +99,6 @@ function BarChart({
 
 export default function AdminYoutubePage() {
   const [items, setItems] = useState<YoutubeVideo[]>([]);
-  const [total, setTotal] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
   const [purging, setPurging] = useState(false);
   const [purgeResult, setPurgeResult] = useState<"idle" | "done" | "error">(
@@ -147,7 +146,6 @@ export default function AdminYoutubePage() {
         total: number;
       };
       setItems(data.items ?? []);
-      setTotal(data.total ?? data.items?.length ?? 0);
     } catch {
       setItems([]);
     } finally {
@@ -255,11 +253,6 @@ export default function AdminYoutubePage() {
       <div className="flex items-end justify-between mb-5 shrink-0">
         <div>
           <h1 className="admin-page-title">유튜브 인기 영상</h1>
-          <p className="admin-page-subtitle mt-1">
-            {total !== null
-              ? `총 ${total}개의 인기 영상이 캐시되어 있습니다.`
-              : "캐시된 영상 목록을 확인합니다."}
-          </p>
           {accessNotice && (
             <pre className="mt-3 whitespace-pre-wrap rounded border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
               {accessNotice}

--- a/client/components/sites/SiteList.test.tsx
+++ b/client/components/sites/SiteList.test.tsx
@@ -73,18 +73,23 @@ describe("SiteList", () => {
     expect(screen.getByText("인벤 커뮤니티")).toBeInTheDocument();
   });
 
-  it("icon이 있는 사이트는 img가 렌더링된다", () => {
-    const { container } = render(<SiteList sites={MOCK_SITES} />);
+  it("icon이 지정된 사이트는 해당 icon이 사용된다", () => {
+    const { container } = render(<SiteList sites={[MOCK_SITES[1]]} />);
 
     const img = container.querySelector("img");
     expect(img).not.toBeNull();
     expect(img).toHaveAttribute("src", "https://example.com/icon.png");
   });
 
-  it("icon이 없는 사이트는 img가 없다", () => {
+  it("icon이 없는 사이트는 href 기반 favicon이 표시된다", () => {
     const { container } = render(<SiteList sites={[MOCK_SITES[0]]} />);
 
-    expect(container.querySelector("img")).toBeNull();
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img).toHaveAttribute(
+      "src",
+      "https://www.google.com/s2/favicons?domain=lostark.game.onstove.com&sz=32",
+    );
   });
 
   it("빈 배열이면 아무것도 렌더링되지 않는다", () => {

--- a/client/components/sites/SiteList.tsx
+++ b/client/components/sites/SiteList.tsx
@@ -204,32 +204,39 @@ export default function SiteList({ sites }: Props) {
 
                   <div className="flex items-start justify-between gap-2 pr-5">
                     <div className="flex min-w-0 items-center gap-1.5">
-                      {site.icon && (
-                        // eslint-disable-next-line @next/next/no-img-element
-                        <img
-                          src={site.icon}
-                          alt=""
-                          width={16}
-                          height={16}
-                          className="shrink-0 rounded-sm"
-                          onError={(e) => {
-                            const img = e.target as HTMLImageElement;
-                            const domain = (() => {
-                              try {
-                                return new URL(site.href).hostname;
-                              } catch {
-                                return "";
+                      {(() => {
+                        const domain = (() => {
+                          try {
+                            return new URL(site.href).hostname;
+                          } catch {
+                            return "";
+                          }
+                        })();
+                        const fallback = domain
+                          ? `https://www.google.com/s2/favicons?domain=${domain}&sz=32`
+                          : "";
+                        // icon이 있으면 우선 사용, 없으면 href 기반 favicon으로 표시
+                        const primarySrc = site.icon || fallback;
+                        if (!primarySrc) return null;
+                        return (
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img
+                            src={primarySrc}
+                            alt=""
+                            width={16}
+                            height={16}
+                            className="shrink-0 rounded-sm"
+                            onError={(e) => {
+                              const img = e.target as HTMLImageElement;
+                              if (fallback && img.src !== fallback) {
+                                img.src = fallback;
+                              } else {
+                                img.style.display = "none";
                               }
-                            })();
-                            const fallback = `https://www.google.com/s2/favicons?domain=${domain}&sz=32`;
-                            if (img.src !== fallback && domain) {
-                              img.src = fallback;
-                            } else {
-                              img.style.display = "none";
-                            }
-                          }}
-                        />
-                      )}
+                            }}
+                          />
+                        );
+                      })()}
                       <span className="truncate font-semibold text-slate-900 dark:text-slate-100">
                         {site.name}
                       </span>

--- a/server/src/admin/admin-monitoring.service.ts
+++ b/server/src/admin/admin-monitoring.service.ts
@@ -147,7 +147,8 @@ export class AdminMonitoringService implements OnModuleInit {
   /** source별 페이지 로딩 추이. days에 따라 버킷 크기 자동 선택. */
   async getPageLoadSeries(source: PageLoadSource, days: number) {
     const safeDays = Math.max(1, Math.min(30, Math.trunc(days)));
-    const bucketHours = safeDays <= 1 ? 1 : safeDays <= 7 ? 6 : 24;
+    // 1일: 1시간 단위, 7일/30일: 1일(24시간) 단위
+    const bucketHours = safeDays <= 1 ? 1 : 24;
     const rows = await this.monitoringRepo.findPageLoadSeries(
       source,
       safeDays,

--- a/server/src/admin/repositories/monitoring.repository.ts
+++ b/server/src/admin/repositories/monitoring.repository.ts
@@ -366,6 +366,8 @@ export class MonitoringRepository {
     rangeDays: number,
     bucketHours: number,
   ) {
+    // 시간 단위 버킷(1일 보기)은 시각만, 일 단위 버킷(7/30일 보기)은 날짜만 표기
+    const bucketFormat = bucketHours < 24 ? 'HH24:MI' : 'MM-DD';
     return this.prisma.$queryRaw<PageLoadSeriesRow[]>`
       WITH samples AS (
         SELECT
@@ -385,7 +387,7 @@ export class MonitoringRepository {
                (${bucketHours} * INTERVAL '1 hour')
              ) AS g
       )
-      SELECT TO_CHAR(b.bucket_start, 'MM-DD HH24:MI') AS bucket,
+      SELECT TO_CHAR(b.bucket_start, ${bucketFormat}) AS bucket,
              ROUND(AVG(s.ttfb_ms))::int AS avg_ttfb,
              ROUND(AVG(s.dcl_ms))::int  AS avg_dcl,
              ROUND(AVG(s.lcp_ms))::int  AS avg_lcp,


### PR DESCRIPTION
@
어드민 페이지 UI 개선 모음. (base: `admin`)

## 1. 메인페이지 로딩 추이 축/단위 정리
- X축 라벨에서 시각 제거: 7/30일 보기는 날짜(`MM-DD`), 1일 보기는 시각(`HH:MI`)
- 버킷 단위: 7일 보기 6시간 → 1일 단위 (1일 보기는 1시간 유지)
- 실사용자/합성 토글 제거하고 실사용자(rum) 기준으로 고정
- "최근 전체로딩" 표기를 ms → 초 단위로 변경

## 2. 페이지 제목 아래 설명 소제목 제거
- 좌측 탭 5개(모니터링·컨테이너·사이트 관리·유튜브·사이트 추천)의 제목 하단 설명 문구 제거
- youtube: 소제목에서만 쓰이던 `total` 상태 정리

## 3. 사이트 관리 표 내부 스크롤
- 페이지를 `flex h-full` 레이아웃으로 변경 → 사이트가 많아져도 표 목록만 내부에서 세로 스크롤(헤더·우측 차트 고정)
- 표 헤더는 기존 `sticky` 스타일로 스크롤 중 상단 고정

## 4. 사이트 Icon 입력칸 제거 + favicon 폴백
- 추가/수정 폼에서 Icon 입력칸 제거 (기존 저장된 커스텀 아이콘 값은 보존)
- 메인 SiteList: `icon`이 없으면 href 기반 구글 favicon v2로 표시하도록 폴백 추가 → 미리보기와 실제 화면 동작 일치
- SiteList 테스트를 새 동작에 맞게 갱신

## 검증
- client `tsc --noEmit` 통과
- SiteList 테스트 18개 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@