### PR TITLE
chore(monitoring): 합성 측정 제거 + youtube total 타입 정리

### DIFF
--- a/client/app/admin/youtube/page.tsx
+++ b/client/app/admin/youtube/page.tsx
@@ -143,7 +143,6 @@ export default function AdminYoutubePage() {
       if (!res.ok) throw new Error();
       const data = (await res.json()) as {
         items: YoutubeVideo[];
-        total: number;
       };
       setItems(data.items ?? []);
     } catch {

--- a/client/app/api/admin/monitoring/page-load-series/route.ts
+++ b/client/app/api/admin/monitoring/page-load-series/route.ts
@@ -6,11 +6,10 @@ const NEST_API = process.env.NEST_API_URL ?? "http://localhost:3001";
 export async function GET(req: NextRequest) {
   const store = await cookies();
   const token = store.get("admin_token")?.value ?? "";
-  const source = req.nextUrl.searchParams.get("source") ?? "rum";
   const days = req.nextUrl.searchParams.get("days") ?? "7";
   try {
     const res = await fetch(
-      `${NEST_API}/api/admin/monitoring/page-load-series?source=${encodeURIComponent(source)}&days=${encodeURIComponent(days)}`,
+      `${NEST_API}/api/admin/monitoring/page-load-series?days=${encodeURIComponent(days)}`,
       { headers: { "x-admin-session": token }, cache: "no-store" },
     );
     const data = await res.json().catch(() => []);

--- a/server/src/admin/admin-monitoring.controller.ts
+++ b/server/src/admin/admin-monitoring.controller.ts
@@ -62,14 +62,10 @@ export class AdminMonitoringController {
 
   @UseGuards(AdminGuard)
   @Get('admin/monitoring/page-load-series')
-  pageLoadSeries(
-    @Query('source') source?: string,
-    @Query('days') days?: string,
-  ) {
-    const safeSource = source === 'synthetic' ? 'synthetic' : 'rum';
+  pageLoadSeries(@Query('days') days?: string) {
     const parsed = Number(days);
     const rangeDays = Number.isFinite(parsed) ? parsed : 7;
-    return this.monitoring.getPageLoadSeries(safeSource, rangeDays);
+    return this.monitoring.getPageLoadSeries(rangeDays);
   }
 
   @Post('telemetry/page-load')

--- a/server/src/admin/admin-monitoring.service.ts
+++ b/server/src/admin/admin-monitoring.service.ts
@@ -1,10 +1,7 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
-import * as http from 'http';
-import * as https from 'https';
 import {
   type DeviceType,
-  type PageLoadSource,
   type VisitRow,
   MonitoringRepository,
 } from './repositories/monitoring.repository';
@@ -134,7 +131,6 @@ export class AdminMonitoringService implements OnModuleInit {
         ? Math.min(600_000, Math.round(v))
         : null;
     await this.monitoringRepo.recordPageLoad({
-      source: 'rum',
       path: input.path.slice(0, 255) || '/',
       deviceType: input.deviceType.slice(0, 16) || 'unknown',
       ttfbMs: clamp(input.ttfb),
@@ -144,13 +140,12 @@ export class AdminMonitoringService implements OnModuleInit {
     });
   }
 
-  /** source별 페이지 로딩 추이. days에 따라 버킷 크기 자동 선택. */
-  async getPageLoadSeries(source: PageLoadSource, days: number) {
+  /** 페이지 로딩 추이(실사용자 RUM). days에 따라 버킷 크기 자동 선택. */
+  async getPageLoadSeries(days: number) {
     const safeDays = Math.max(1, Math.min(30, Math.trunc(days)));
     // 1일: 1시간 단위, 7일/30일: 1일(24시간) 단위
     const bucketHours = safeDays <= 1 ? 1 : 24;
     const rows = await this.monitoringRepo.findPageLoadSeries(
-      source,
       safeDays,
       bucketHours,
     );
@@ -198,54 +193,6 @@ export class AdminMonitoringService implements OnModuleInit {
         isSuccess: success,
       });
     }
-  }
-
-  /** 메인페이지 HTML 문서를 받아 TTFB/문서완료 시간을 합성 측정해 기록(10분). */
-  @Cron('0 */10 * * * *')
-  async probeMainPage() {
-    const url = process.env.MONITORING_MAINPAGE_URL ?? 'https://www.lomoa.kr/';
-    try {
-      const { ttfbMs, loadMs } = await this.measureDocument(url);
-      await this.monitoringRepo.recordPageLoad({
-        source: 'synthetic',
-        path: '/',
-        deviceType: 'server',
-        ttfbMs,
-        dclMs: null,
-        lcpMs: null,
-        loadMs,
-      });
-    } catch (err: unknown) {
-      this.logger.warn(`mainpage probe failed: ${toErrorMessage(err)}`);
-    }
-  }
-
-  /** HTML 문서 1건을 받아 TTFB(헤더 수신)·문서 완료 시간을 ms로 측정. */
-  private measureDocument(
-    url: string,
-  ): Promise<{ ttfbMs: number; loadMs: number }> {
-    return new Promise((resolve, reject) => {
-      const client = url.startsWith('https:') ? https : http;
-      const startedAt = process.hrtime.bigint();
-      const elapsed = () =>
-        Math.round(Number(process.hrtime.bigint() - startedAt) / 1_000_000);
-
-      const req = client.get(url, { timeout: 15_000 }, (res) => {
-        const status = res.statusCode ?? 0;
-        // 2xx만 정상 측정 — 3xx/4xx/5xx의 작은 응답이 평균을 왜곡하지 않도록 실패 처리
-        if (status < 200 || status >= 300) {
-          res.resume();
-          req.destroy(new Error(`probe status ${status}`));
-          return;
-        }
-        const ttfbMs = elapsed();
-        res.on('data', () => undefined); // 본문 소비
-        res.on('end', () => resolve({ ttfbMs, loadMs: elapsed() }));
-        res.on('error', reject);
-      });
-      req.on('timeout', () => req.destroy(new Error('probe timeout')));
-      req.on('error', reject);
-    });
   }
 
   @Cron('0 0 3 * * *')

--- a/server/src/admin/repositories/monitoring.repository.ts
+++ b/server/src/admin/repositories/monitoring.repository.ts
@@ -45,8 +45,6 @@ type RetentionTable =
   | 'monitoring_api_probes'
   | 'apm_page_load_timings';
 
-export type PageLoadSource = 'rum' | 'synthetic';
-
 export interface PageLoadSeriesRow {
   bucket: string;
   avg_ttfb: number | null;
@@ -160,7 +158,7 @@ export class MonitoringRepository {
         created_at TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP
       )
     `;
-    // 페이지 로딩 속도(RUM: 실사용자 / synthetic: 서버 합성 프로브). 지표는 NULL 허용.
+    // 페이지 로딩 속도(실사용자 RUM). source 컬럼은 과거 데이터 호환을 위해 유지. 지표는 NULL 허용.
     await this.prisma.$executeRaw`
       CREATE TABLE IF NOT EXISTS apm_page_load_timings (
         id BIGSERIAL PRIMARY KEY,
@@ -334,9 +332,8 @@ export class MonitoringRepository {
     `;
   }
 
-  /** 페이지 로딩 측정값 1건 저장. 지표는 NULL 허용(소스별로 채워지는 지표가 다름). */
+  /** 페이지 로딩 측정값 1건 저장(실사용자 RUM). 지표는 NULL 허용. */
   async recordPageLoad(input: {
-    source: PageLoadSource;
     path: string;
     deviceType: string;
     ttfbMs: number | null;
@@ -348,7 +345,7 @@ export class MonitoringRepository {
       INSERT INTO apm_page_load_timings
         (source, path, device_type, ttfb_ms, dcl_ms, lcp_ms, load_ms, created_at)
       VALUES (
-        ${input.source},
+        'rum',
         ${input.path},
         ${input.deviceType},
         ${input.ttfbMs},
@@ -360,12 +357,8 @@ export class MonitoringRepository {
     `;
   }
 
-  /** source별 시간버킷 평균(ttfb/dcl/lcp/load). 빈 버킷도 채워 반환. */
-  async findPageLoadSeries(
-    source: PageLoadSource,
-    rangeDays: number,
-    bucketHours: number,
-  ) {
+  /** 시간버킷 평균(ttfb/dcl/lcp/load). 빈 버킷도 채워 반환. */
+  async findPageLoadSeries(rangeDays: number, bucketHours: number) {
     // 시간 단위 버킷(1일 보기)은 시각만, 일 단위 버킷(7/30일 보기)은 날짜만 표기
     const bucketFormat = bucketHours < 24 ? 'HH24:MI' : 'MM-DD';
     return this.prisma.$queryRaw<PageLoadSeriesRow[]>`
@@ -374,7 +367,7 @@ export class MonitoringRepository {
           TO_TIMESTAMP(FLOOR(EXTRACT(EPOCH FROM created_at) / (${bucketHours} * 3600)) * (${bucketHours} * 3600)) AS bucket_start,
           ttfb_ms, dcl_ms, lcp_ms, load_ms
         FROM apm_page_load_timings
-        WHERE source = ${source}
+        WHERE source = 'rum'
           AND created_at >= NOW() - (${rangeDays}::int * INTERVAL '1 day')
       ),
       buckets AS (


### PR DESCRIPTION
@
리뷰에서 짚었던 두 가지 후속 정리. (base: `admin`)

## 1. 합성(synthetic) 페이지 로딩 측정 제거
모니터링 UI에서 합성/실사용자 토글을 없앤 뒤로 합성 데이터를 볼 방법이 없어졌는데, 백엔드는 10분마다 계속 합성 데이터를 쌓고 있었음. 더 이상 안 쓰므로 관련 경로를 제거하고 실사용자(rum) 단일 소스로 단순화.

- `probeMainPage` 10분 크론 + `measureDocument` 헬퍼 제거, `http`/`https` import 제거
- `getPageLoadSeries` / `/admin/monitoring/page-load-series`에서 `source` 파라미터 제거
- `PageLoadSource` 타입 제거, `recordPageLoad`/`findPageLoadSeries`에서 source 분기 제거 → `rum` 고정
- client `page-load-series` 라우트에서 `source` 전달 제거

> DB `apm_page_load_timings.source` 컬럼은 과거 데이터 호환을 위해 그대로 유지 (마이그레이션 없음). 기존 synthetic 행은 조회에서 자동 제외됨.

⚠️ 참고: 모니터링의 "기능별 응답 추이(10분 자동점검)"는 별개 크론(`probeApis`)이라 그대로 동작합니다.

## 2. youtube 응답 타입 total 정리
소제목 제거 후 안 쓰이게 된 `total: number` 타입 주석 제거 (동작 변화 없음).

## 검증
- client/server `tsc --noEmit` 통과
- 변경 서버 파일 eslint 통과
- 잔여 synthetic 참조 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@