### PR TITLE
컨테이너 AI 챗봇 + 배포 로깅 (admin → main)

### DIFF
--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -66,6 +66,7 @@ jobs:
           EC2_INSTANCE_ID: ${{ secrets.EC2_INSTANCE_ID }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
           NEXT_REVALIDATE_SECRET: ${{ secrets.NEXT_REVALIDATE_SECRET }}
+          DEPLOY_EVENT_TOKEN: ${{ secrets.DEPLOY_EVENT_TOKEN }}
           ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
           ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
           IMAGE_TAG: ${{ github.sha }}
@@ -79,6 +80,8 @@ jobs:
           grep -q '^NEXT_REVALIDATE_URL=' .env || echo 'NEXT_REVALIDATE_URL=https://www.lomoa.kr/api/revalidate' >> .env
           sed -i '/^NEXT_REVALIDATE_SECRET=/d' .env
           echo 'NEXT_REVALIDATE_SECRET=${NEXT_REVALIDATE_SECRET}' >> .env
+          sed -i '/^DEPLOY_EVENT_TOKEN=/d' .env
+          echo 'DEPLOY_EVENT_TOKEN=${DEPLOY_EVENT_TOKEN}' >> .env
           sed -i '/^NEST_IMAGE=/d' .env
           echo 'NEST_IMAGE=${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}' >> .env
           echo '${ECR_PASSWORD}' | docker login --username AWS --password-stdin ${ECR_REGISTRY}

--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -137,3 +137,19 @@ jobs:
             exit 0
           fi
           curl -f "$HEALTHCHECK_URL"
+
+      # nest 배포 시점을 모니터링(container_events)에 기록. 실패해도 배포는 성공 처리.
+      - name: Log deploy event (nest)
+        if: success()
+        env:
+          DEPLOY_EVENT_TOKEN: ${{ secrets.DEPLOY_EVENT_TOKEN }}
+        run: |
+          if [ -z "$DEPLOY_EVENT_TOKEN" ]; then
+            echo "DEPLOY_EVENT_TOKEN secret not set. Skip deploy log."
+            exit 0
+          fi
+          curl -fsS -X POST https://api.lomoa.kr/api/webhooks/deploy \
+            -H "Content-Type: application/json" \
+            -H "x-deploy-token: $DEPLOY_EVENT_TOKEN" \
+            -d "{\"service\":\"nest\",\"sha\":\"${{ github.sha }}\"}" \
+            || echo "deploy log POST failed (non-fatal)"

--- a/.github/workflows/vercel-deploy-log.yml
+++ b/.github/workflows/vercel-deploy-log.yml
@@ -1,0 +1,33 @@
+name: Log Vercel Deploy (next)
+
+# Vercel(Git 연동)이 production 배포를 끝내면 GitHub deployment_status 이벤트가 발생한다.
+# 그때 next 배포 시점을 모니터링(container_events)에 기록한다. (Vercel 유료 웹훅 불필요)
+on:
+  deployment_status:
+
+permissions:
+  contents: read
+
+jobs:
+  log:
+    # production 배포 성공만 기록(프리뷰 제외)
+    if: >-
+      github.event.deployment_status.state == 'success' &&
+      (github.event.deployment_status.environment == 'Production' ||
+       github.event.deployment_status.environment == 'production')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log deploy event (next)
+        env:
+          DEPLOY_EVENT_TOKEN: ${{ secrets.DEPLOY_EVENT_TOKEN }}
+          SHA: ${{ github.event.deployment.sha }}
+        run: |
+          if [ -z "$DEPLOY_EVENT_TOKEN" ]; then
+            echo "DEPLOY_EVENT_TOKEN secret not set. Skip deploy log."
+            exit 0
+          fi
+          curl -fsS -X POST https://api.lomoa.kr/api/webhooks/deploy \
+            -H "Content-Type: application/json" \
+            -H "x-deploy-token: $DEPLOY_EVENT_TOKEN" \
+            -d "{\"service\":\"next\",\"sha\":\"${SHA}\"}" \
+            || echo "deploy log POST failed (non-fatal)"

--- a/client/app/admin/containers/page.tsx
+++ b/client/app/admin/containers/page.tsx
@@ -18,8 +18,6 @@ interface ContainerStat {
   memUsedMb: number;
   memTotalMb: number;
   memPercent: number;
-  netInMb: number;
-  netOutMb: number;
 }
 
 interface ContainerStatus {
@@ -51,6 +49,15 @@ interface ContainersResponse {
   containers: ContainerStat[];
   host: HostStats | null;
   statuses: ContainerStatus[];
+}
+
+interface AiDiagnosis {
+  summary: string;
+  anomalies: string[];
+  costSuggestions: string[];
+  generatedAt: string;
+  model: string;
+  ec2: { instanceType: string | null; region: string };
 }
 
 // 카드 정렬 순서 (서비스 의존도 순)
@@ -131,6 +138,34 @@ export default function ContainersPage() {
   >(containerHistoryCache["nest"] ?? []);
   const [historyLoading, setHistoryLoading] = useState(false);
   const [activeChart, setActiveChart] = useState<string | null>(null);
+
+  const [aiResult, setAiResult] = useState<AiDiagnosis | null>(null);
+  const [aiLoading, setAiLoading] = useState(false);
+  const [aiError, setAiError] = useState("");
+
+  async function runDiagnosis() {
+    setAiLoading(true);
+    setAiError("");
+    try {
+      const res = await fetch("/api/admin/monitoring/ai-diagnosis", {
+        cache: "no-store",
+      });
+      const data = (await res.json().catch(() => ({}))) as
+        | AiDiagnosis
+        | { message?: string };
+      if (!res.ok) {
+        setAiError(
+          ("message" in data && data.message) || "AI 진단에 실패했습니다.",
+        );
+        return;
+      }
+      setAiResult(data as AiDiagnosis);
+    } catch {
+      setAiError("AI 진단 요청 중 오류가 발생했습니다.");
+    } finally {
+      setAiLoading(false);
+    }
+  }
 
   useEffect(() => {
     let alive = true;
@@ -364,9 +399,6 @@ export default function ContainersPage() {
                           {stat.memUsedMb}MB / {stat.memTotalMb}MB
                         </p>
                       </div>
-                      <p className="text-[11px] text-[color:var(--admin-text-muted)] tabular-nums">
-                        NET ↓{stat.netInMb}MB · ↑{stat.netOutMb}MB
-                      </p>
                     </div>
                   ) : (
                     <p className="text-[11px] text-[color:var(--admin-text-subtle)]">
@@ -489,6 +521,94 @@ export default function ContainersPage() {
                 </div>
               </div>
             </div>
+          </div>
+
+          {/* AI 진단 */}
+          <div className="admin-card p-4">
+            <div className="mb-3 flex items-center justify-between gap-2">
+              <div>
+                <p className="text-sm font-semibold">AI 진단</p>
+                <p className="mt-0.5 text-[11px] text-[color:var(--admin-text-muted)]">
+                  최근 7일 자원 사용량 + EC2 정보를 바탕으로 현황·이상 징후·비용
+                  절감을 분석합니다.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={runDiagnosis}
+                disabled={aiLoading}
+                className="admin-btn admin-btn-primary admin-btn-sm shrink-0"
+              >
+                {aiLoading ? "분석 중..." : "AI 진단 실행"}
+              </button>
+            </div>
+
+            {aiError && (
+              <p className="text-sm text-red-500">{aiError}</p>
+            )}
+
+            {!aiError && !aiResult && !aiLoading && (
+              <p className="text-sm text-[color:var(--admin-text-muted)]">
+                버튼을 눌러 진단을 시작하세요.
+              </p>
+            )}
+
+            {aiResult && (
+              <div className="space-y-4">
+                <div>
+                  <p className="mb-1 text-xs font-semibold text-[color:var(--admin-text-muted)]">
+                    현황 요약
+                  </p>
+                  <p className="text-sm whitespace-pre-wrap">
+                    {aiResult.summary || "—"}
+                  </p>
+                </div>
+
+                <div>
+                  <p className="mb-1 text-xs font-semibold text-[color:var(--admin-text-muted)]">
+                    이상 징후
+                  </p>
+                  {aiResult.anomalies.length === 0 ? (
+                    <p className="text-sm text-[color:var(--admin-text-muted)]">
+                      특이사항 없음
+                    </p>
+                  ) : (
+                    <ul className="list-disc space-y-1 pl-5 text-sm">
+                      {aiResult.anomalies.map((a, i) => (
+                        <li key={i}>{a}</li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+
+                <div>
+                  <p className="mb-1 text-xs font-semibold text-[color:var(--admin-text-muted)]">
+                    비용 절감 제안
+                  </p>
+                  {aiResult.costSuggestions.length === 0 ? (
+                    <p className="text-sm text-[color:var(--admin-text-muted)]">
+                      제안 없음
+                    </p>
+                  ) : (
+                    <ul className="list-disc space-y-1 pl-5 text-sm">
+                      {aiResult.costSuggestions.map((s, i) => (
+                        <li key={i}>{s}</li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+
+                <p className="text-[11px] text-[color:var(--admin-text-subtle)]">
+                  {aiResult.ec2.instanceType
+                    ? `${aiResult.ec2.instanceType} · ${aiResult.ec2.region}`
+                    : "EC2 정보 없음(로컬/IMDS 미가용)"}{" "}
+                  · {aiResult.model} ·{" "}
+                  {new Date(aiResult.generatedAt).toLocaleString("ko-KR", {
+                    hour12: false,
+                  })}
+                </p>
+              </div>
+            )}
           </div>
         </div>
       )}

--- a/client/app/admin/containers/page.tsx
+++ b/client/app/admin/containers/page.tsx
@@ -196,6 +196,8 @@ export default function ContainersPage() {
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
+    // 메시지가 있을 때만 스크롤 (마운트 시 페이지가 챗봇으로 끌려가는 것 방지)
+    if (messages.length === 0) return;
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages, chatLoading]);
 

--- a/client/app/admin/containers/page.tsx
+++ b/client/app/admin/containers/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   Area,
   AreaChart,
@@ -58,6 +58,56 @@ interface AiDiagnosis {
   generatedAt: string;
   model: string;
   ec2: { instanceType: string | null; region: string };
+}
+
+interface ChatMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+// 채팅 시작용 예시 버튼. diagnosis=true 는 구조화 진단 엔드포인트 호출.
+const QUICK_PROMPTS: { label: string; prompt?: string; diagnosis?: boolean }[] =
+  [
+    { label: "종합 AI 진단", diagnosis: true },
+    {
+      label: "CPU 사용량",
+      prompt:
+        "각 컨테이너의 최근 7일 CPU 사용량(평균/최대/최소/p95)을 표로 요약해줘.",
+    },
+    {
+      label: "메모리 상태",
+      prompt: "컨테이너별 메모리 사용 상태와 여유가 충분한지 알려줘.",
+    },
+    {
+      label: "현재 월 예상 요금",
+      prompt: "현재 인스턴스 기준 월 예상 요금과 그 내역을 알려줘.",
+    },
+    {
+      label: "비용 절감 방법",
+      prompt: "지금 사용량 기준으로 AWS 비용을 줄일 방법을 제안해줘.",
+    },
+    {
+      label: "CPU 스파이크 원인",
+      prompt:
+        "특정 시간대에 CPU가 튀는 구간이 있는지, 있다면 최근 배포/재시작 이력과 연결해 원인과 대응을 알려줘.",
+    },
+  ];
+
+function formatDiagnosis(d: AiDiagnosis): string {
+  const blocks = [`📋 현황 요약\n${d.summary || "—"}`];
+  if (d.anomalies.length > 0) {
+    blocks.push(`⚠️ 이상 징후\n${d.anomalies.map((a) => `• ${a}`).join("\n")}`);
+  }
+  if (d.costSuggestions.length > 0) {
+    blocks.push(
+      `💰 비용 절감 제안\n${d.costSuggestions.map((s) => `• ${s}`).join("\n")}`,
+    );
+  }
+  const where = d.ec2.instanceType
+    ? `${d.ec2.instanceType} · ${d.ec2.region}`
+    : "EC2 정보 없음";
+  blocks.push(`— ${where}`);
+  return blocks.join("\n\n");
 }
 
 // 카드 정렬 순서 (서비스 의존도 순)
@@ -139,13 +189,55 @@ export default function ContainersPage() {
   const [historyLoading, setHistoryLoading] = useState(false);
   const [activeChart, setActiveChart] = useState<string | null>(null);
 
-  const [aiResult, setAiResult] = useState<AiDiagnosis | null>(null);
-  const [aiLoading, setAiLoading] = useState(false);
-  const [aiError, setAiError] = useState("");
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [chatInput, setChatInput] = useState("");
+  const [chatLoading, setChatLoading] = useState(false);
+  const [chatError, setChatError] = useState("");
+  const messagesEndRef = useRef<HTMLDivElement | null>(null);
 
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, chatLoading]);
+
+  async function sendMessage(text: string) {
+    const content = text.trim();
+    if (!content || chatLoading) return;
+    const next: ChatMessage[] = [...messages, { role: "user", content }];
+    setMessages(next);
+    setChatInput("");
+    setChatLoading(true);
+    setChatError("");
+    try {
+      const res = await fetch("/api/admin/monitoring/ai-chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ messages: next }),
+      });
+      const data = (await res.json().catch(() => ({}))) as {
+        reply?: string;
+        message?: string;
+      };
+      if (!res.ok) {
+        setChatError(data.message ?? "응답을 받지 못했습니다.");
+        return;
+      }
+      setMessages((m) => [
+        ...m,
+        { role: "assistant", content: data.reply ?? "(빈 응답)" },
+      ]);
+    } catch {
+      setChatError("요청 중 오류가 발생했습니다.");
+    } finally {
+      setChatLoading(false);
+    }
+  }
+
+  // "종합 AI 진단" — 구조화 진단 엔드포인트를 호출해 메시지로 표시
   async function runDiagnosis() {
-    setAiLoading(true);
-    setAiError("");
+    if (chatLoading) return;
+    setMessages((m) => [...m, { role: "user", content: "종합 AI 진단" }]);
+    setChatLoading(true);
+    setChatError("");
     try {
       const res = await fetch("/api/admin/monitoring/ai-diagnosis", {
         cache: "no-store",
@@ -154,16 +246,19 @@ export default function ContainersPage() {
         | AiDiagnosis
         | { message?: string };
       if (!res.ok) {
-        setAiError(
+        setChatError(
           ("message" in data && data.message) || "AI 진단에 실패했습니다.",
         );
         return;
       }
-      setAiResult(data as AiDiagnosis);
+      setMessages((m) => [
+        ...m,
+        { role: "assistant", content: formatDiagnosis(data as AiDiagnosis) },
+      ]);
     } catch {
-      setAiError("AI 진단 요청 중 오류가 발생했습니다.");
+      setChatError("AI 진단 요청 중 오류가 발생했습니다.");
     } finally {
-      setAiLoading(false);
+      setChatLoading(false);
     }
   }
 
@@ -523,92 +618,90 @@ export default function ContainersPage() {
             </div>
           </div>
 
-          {/* AI 진단 */}
+          {/* AI 운영 챗봇 */}
           <div className="admin-card p-4">
-            <div className="mb-3 flex items-center justify-between gap-2">
-              <div>
-                <p className="text-sm font-semibold">AI 진단</p>
-                <p className="mt-0.5 text-[11px] text-[color:var(--admin-text-muted)]">
-                  최근 7일 자원 사용량 + EC2 정보를 바탕으로 현황·이상 징후·비용
-                  절감을 분석합니다.
-                </p>
-              </div>
-              <button
-                type="button"
-                onClick={runDiagnosis}
-                disabled={aiLoading}
-                className="admin-btn admin-btn-primary admin-btn-sm shrink-0"
-              >
-                {aiLoading ? "분석 중..." : "AI 진단 실행"}
-              </button>
+            <div className="mb-3">
+              <p className="text-sm font-semibold">AI 운영 챗봇</p>
+              <p className="mt-0.5 text-[11px] text-[color:var(--admin-text-muted)]">
+                컨테이너 자원·EC2 비용·최근 배포 이력을 바탕으로 질문에
+                답합니다. (민감정보는 관리자만)
+              </p>
             </div>
 
-            {aiError && (
-              <p className="text-sm text-red-500">{aiError}</p>
-            )}
-
-            {!aiError && !aiResult && !aiLoading && (
-              <p className="text-sm text-[color:var(--admin-text-muted)]">
-                버튼을 눌러 진단을 시작하세요.
-              </p>
-            )}
-
-            {aiResult && (
-              <div className="space-y-4">
-                <div>
-                  <p className="mb-1 text-xs font-semibold text-[color:var(--admin-text-muted)]">
-                    현황 요약
-                  </p>
-                  <p className="text-sm whitespace-pre-wrap">
-                    {aiResult.summary || "—"}
-                  </p>
-                </div>
-
-                <div>
-                  <p className="mb-1 text-xs font-semibold text-[color:var(--admin-text-muted)]">
-                    이상 징후
-                  </p>
-                  {aiResult.anomalies.length === 0 ? (
-                    <p className="text-sm text-[color:var(--admin-text-muted)]">
-                      특이사항 없음
-                    </p>
-                  ) : (
-                    <ul className="list-disc space-y-1 pl-5 text-sm">
-                      {aiResult.anomalies.map((a, i) => (
-                        <li key={i}>{a}</li>
-                      ))}
-                    </ul>
-                  )}
-                </div>
-
-                <div>
-                  <p className="mb-1 text-xs font-semibold text-[color:var(--admin-text-muted)]">
-                    비용 절감 제안
-                  </p>
-                  {aiResult.costSuggestions.length === 0 ? (
-                    <p className="text-sm text-[color:var(--admin-text-muted)]">
-                      제안 없음
-                    </p>
-                  ) : (
-                    <ul className="list-disc space-y-1 pl-5 text-sm">
-                      {aiResult.costSuggestions.map((s, i) => (
-                        <li key={i}>{s}</li>
-                      ))}
-                    </ul>
-                  )}
-                </div>
-
-                <p className="text-[11px] text-[color:var(--admin-text-subtle)]">
-                  {aiResult.ec2.instanceType
-                    ? `${aiResult.ec2.instanceType} · ${aiResult.ec2.region}`
-                    : "EC2 정보 없음(로컬/IMDS 미가용)"}{" "}
-                  · {aiResult.model} ·{" "}
-                  {new Date(aiResult.generatedAt).toLocaleString("ko-KR", {
-                    hour12: false,
-                  })}
+            <div className="mb-3 max-h-80 space-y-2 overflow-y-auto">
+              {messages.length === 0 ? (
+                <p className="text-sm text-[color:var(--admin-text-muted)]">
+                  아래 버튼을 누르거나 직접 질문을 입력해보세요.
                 </p>
-              </div>
+              ) : (
+                messages.map((m, i) => (
+                  <div
+                    key={i}
+                    className={m.role === "user" ? "text-right" : "text-left"}
+                  >
+                    <span
+                      className={`inline-block max-w-[85%] whitespace-pre-wrap rounded-lg px-3 py-2 text-left text-sm ${
+                        m.role === "user"
+                          ? "bg-blue-600 text-white"
+                          : "bg-slate-100 text-[color:var(--admin-text)]"
+                      }`}
+                    >
+                      {m.content}
+                    </span>
+                  </div>
+                ))
+              )}
+              {chatLoading && (
+                <p className="text-xs text-[color:var(--admin-text-muted)]">
+                  답변 생성 중...
+                </p>
+              )}
+              <div ref={messagesEndRef} />
+            </div>
+
+            {chatError && (
+              <p className="mb-2 text-sm text-red-500">{chatError}</p>
             )}
+
+            <div className="mb-2 flex flex-wrap gap-1.5">
+              {QUICK_PROMPTS.map((q) => (
+                <button
+                  key={q.label}
+                  type="button"
+                  disabled={chatLoading}
+                  onClick={() =>
+                    q.diagnosis ? runDiagnosis() : sendMessage(q.prompt ?? "")
+                  }
+                  className="admin-btn admin-btn-sm admin-btn-secondary"
+                >
+                  {q.label}
+                </button>
+              ))}
+            </div>
+
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                sendMessage(chatInput);
+              }}
+              className="flex gap-2"
+            >
+              <input
+                type="text"
+                value={chatInput}
+                onChange={(e) => setChatInput(e.target.value)}
+                disabled={chatLoading}
+                placeholder="질문을 입력하세요"
+                className="admin-input flex-1"
+              />
+              <button
+                type="submit"
+                disabled={chatLoading || !chatInput.trim()}
+                className="admin-btn admin-btn-primary shrink-0"
+              >
+                전송
+              </button>
+            </form>
           </div>
         </div>
       )}

--- a/client/app/api/admin/monitoring/ai-chat/route.ts
+++ b/client/app/api/admin/monitoring/ai-chat/route.ts
@@ -1,0 +1,30 @@
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+
+const NEST_API = process.env.NEST_API_URL ?? "http://localhost:3001";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(req: NextRequest) {
+  const store = await cookies();
+  const token = store.get("admin_token")?.value ?? "";
+  const body = await req.text();
+  try {
+    const res = await fetch(`${NEST_API}/api/admin/monitoring/ai-chat`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-admin-session": token,
+      },
+      body,
+      cache: "no-store",
+    });
+    const data = await res.json().catch(() => ({}));
+    return NextResponse.json(data, { status: res.status });
+  } catch {
+    return NextResponse.json(
+      { message: "AI 챗봇 요청에 실패했습니다." },
+      { status: 503 },
+    );
+  }
+}

--- a/client/app/api/admin/monitoring/ai-diagnosis/route.ts
+++ b/client/app/api/admin/monitoring/ai-diagnosis/route.ts
@@ -1,0 +1,24 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+const NEST_API = process.env.NEST_API_URL ?? "http://localhost:3001";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const store = await cookies();
+  const token = store.get("admin_token")?.value ?? "";
+  try {
+    const res = await fetch(`${NEST_API}/api/admin/monitoring/ai-diagnosis`, {
+      headers: { "x-admin-session": token },
+      cache: "no-store",
+    });
+    const data = await res.json().catch(() => ({}));
+    return NextResponse.json(data, { status: res.status });
+  } catch {
+    return NextResponse.json(
+      { message: "AI 진단 요청에 실패했습니다." },
+      { status: 503 },
+    );
+  }
+}

--- a/server/src/admin/admin-monitoring.controller.ts
+++ b/server/src/admin/admin-monitoring.controller.ts
@@ -15,6 +15,7 @@ import type { Request } from 'express';
 import { AdminGuard } from './admin.guard';
 import { AdminMonitoringService } from './admin-monitoring.service';
 import { DockerStatsService } from './docker-stats.service';
+import { AiDiagnosisService } from './ai-diagnosis.service';
 
 @Controller('api')
 export class AdminMonitoringController {
@@ -27,6 +28,7 @@ export class AdminMonitoringController {
   constructor(
     private readonly monitoring: AdminMonitoringService,
     private readonly dockerStats: DockerStatsService,
+    private readonly aiDiagnosis: AiDiagnosisService,
   ) {}
 
   @UseGuards(AdminGuard)
@@ -58,6 +60,13 @@ export class AdminMonitoringController {
   @Get('admin/monitoring/container-history')
   containerHistory(@Query('container') container?: string) {
     return this.dockerStats.getContainerHistory(container ?? 'nest');
+  }
+
+  // 버튼 클릭 시 1회만 호출(비용 통제). 컨테이너 메트릭+EC2 정보를 LLM에 보내 진단.
+  @UseGuards(AdminGuard)
+  @Get('admin/monitoring/ai-diagnosis')
+  getAiDiagnosis() {
+    return this.aiDiagnosis.diagnose();
   }
 
   @UseGuards(AdminGuard)

--- a/server/src/admin/admin-monitoring.controller.ts
+++ b/server/src/admin/admin-monitoring.controller.ts
@@ -13,15 +13,10 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import type { Request } from 'express';
-import { createHmac, timingSafeEqual } from 'crypto';
 import { AdminGuard } from './admin.guard';
 import { AdminMonitoringService } from './admin-monitoring.service';
 import { DockerStatsService } from './docker-stats.service';
-import {
-  AiDiagnosisService,
-  type AdminRole,
-  type ChatMessage,
-} from './ai-diagnosis.service';
+import { AiDiagnosisService, type ChatMessage } from './ai-diagnosis.service';
 
 @Controller('api')
 export class AdminMonitoringController {
@@ -68,23 +63,26 @@ export class AdminMonitoringController {
     return this.dockerStats.getContainerHistory(container ?? 'nest');
   }
 
-  // Vercel 배포 성공 웹훅(서명 검증). next(프론트) 배포 시점을 이벤트로 기록.
-  // 관리자 인증 대신 x-vercel-signature(HMAC-SHA1) 로 검증한다.
-  @Post('webhooks/vercel-deploy')
+  // 배포 이벤트 기록(GitHub Actions가 호출). 관리자 세션 대신 공유 토큰으로 인증.
+  // nest: 배포 워크플로에서, next: Vercel 배포 성공 시 deployment_status 워크플로에서 POST.
+  @Post('webhooks/deploy')
   @HttpCode(HttpStatus.OK)
-  async vercelDeploy(
-    @Req() req: Request & { rawBody?: Buffer },
-    @Headers('x-vercel-signature') signature: string | undefined,
-    @Body() body: { type?: string; payload?: Record<string, unknown> },
+  async deployEvent(
+    @Headers('x-deploy-token') token: string | undefined,
+    @Body() body: { service?: string; sha?: string; detail?: string },
   ) {
-    const secret = process.env.VERCEL_WEBHOOK_SECRET ?? '';
-    if (!secret) {
-      throw new ForbiddenException('webhook이 구성되지 않았습니다');
+    const expected = process.env.DEPLOY_EVENT_TOKEN ?? '';
+    if (!expected || token !== expected) {
+      throw new ForbiddenException('invalid deploy token');
     }
-    if (!verifyVercelSignature(req.rawBody, signature, secret)) {
-      throw new ForbiddenException('서명이 유효하지 않습니다');
+    if (body?.service !== 'nest' && body?.service !== 'next') {
+      return { ok: false };
     }
-    await this.monitoring.recordNextDeployFromVercel(body);
+    await this.monitoring.recordDeployEvent({
+      service: body.service,
+      sha: body.sha,
+      detail: body.detail,
+    });
     return { ok: true };
   }
 
@@ -95,16 +93,12 @@ export class AdminMonitoringController {
     return this.aiDiagnosis.diagnose();
   }
 
-  // 운영 챗봇. 세션 role(master/guest)을 함께 넘겨 민감 질문은 guest에게 거부 응답.
+  // 운영 챗봇. 운영 데이터는 모든 관리자(guest 포함)가 동일하게 조회 가능.
+  // 민감정보(계정/시크릿/토큰/env)는 애초에 컨텍스트에 없어 누구도 못 봄.
   @UseGuards(AdminGuard)
   @Post('admin/monitoring/ai-chat')
-  aiChat(
-    @Req() req: Request & { adminUser?: { role?: 'master' | 'guest' } },
-    @Body() body: { messages?: ChatMessage[] },
-  ) {
-    const role: AdminRole =
-      req.adminUser?.role === 'master' ? 'master' : 'guest';
-    return this.aiDiagnosis.chat(body?.messages ?? [], role);
+  aiChat(@Body() body: { messages?: ChatMessage[] }) {
+    return this.aiDiagnosis.chat(body?.messages ?? []);
   }
 
   @UseGuards(AdminGuard)
@@ -282,17 +276,4 @@ export class AdminMonitoringController {
       );
     }
   }
-}
-
-/** Vercel 웹훅 서명(x-vercel-signature = HMAC-SHA1(rawBody, secret)) 검증. */
-function verifyVercelSignature(
-  rawBody: Buffer | undefined,
-  signature: string | undefined,
-  secret: string,
-): boolean {
-  if (!rawBody || !signature) return false;
-  const expected = createHmac('sha1', secret).update(rawBody).digest('hex');
-  const a = Buffer.from(expected);
-  const b = Buffer.from(signature);
-  return a.length === b.length && timingSafeEqual(a, b);
 }

--- a/server/src/admin/admin-monitoring.controller.ts
+++ b/server/src/admin/admin-monitoring.controller.ts
@@ -4,6 +4,7 @@ import {
   ForbiddenException,
   Get,
   Headers,
+  HttpCode,
   HttpException,
   HttpStatus,
   Post,
@@ -12,10 +13,15 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import type { Request } from 'express';
+import { createHmac, timingSafeEqual } from 'crypto';
 import { AdminGuard } from './admin.guard';
 import { AdminMonitoringService } from './admin-monitoring.service';
 import { DockerStatsService } from './docker-stats.service';
-import { AiDiagnosisService } from './ai-diagnosis.service';
+import {
+  AiDiagnosisService,
+  type AdminRole,
+  type ChatMessage,
+} from './ai-diagnosis.service';
 
 @Controller('api')
 export class AdminMonitoringController {
@@ -62,11 +68,43 @@ export class AdminMonitoringController {
     return this.dockerStats.getContainerHistory(container ?? 'nest');
   }
 
+  // Vercel 배포 성공 웹훅(서명 검증). next(프론트) 배포 시점을 이벤트로 기록.
+  // 관리자 인증 대신 x-vercel-signature(HMAC-SHA1) 로 검증한다.
+  @Post('webhooks/vercel-deploy')
+  @HttpCode(HttpStatus.OK)
+  async vercelDeploy(
+    @Req() req: Request & { rawBody?: Buffer },
+    @Headers('x-vercel-signature') signature: string | undefined,
+    @Body() body: { type?: string; payload?: Record<string, unknown> },
+  ) {
+    const secret = process.env.VERCEL_WEBHOOK_SECRET ?? '';
+    if (!secret) {
+      throw new ForbiddenException('webhook이 구성되지 않았습니다');
+    }
+    if (!verifyVercelSignature(req.rawBody, signature, secret)) {
+      throw new ForbiddenException('서명이 유효하지 않습니다');
+    }
+    await this.monitoring.recordNextDeployFromVercel(body);
+    return { ok: true };
+  }
+
   // 버튼 클릭 시 1회만 호출(비용 통제). 컨테이너 메트릭+EC2 정보를 LLM에 보내 진단.
   @UseGuards(AdminGuard)
   @Get('admin/monitoring/ai-diagnosis')
   getAiDiagnosis() {
     return this.aiDiagnosis.diagnose();
+  }
+
+  // 운영 챗봇. 세션 role(master/guest)을 함께 넘겨 민감 질문은 guest에게 거부 응답.
+  @UseGuards(AdminGuard)
+  @Post('admin/monitoring/ai-chat')
+  aiChat(
+    @Req() req: Request & { adminUser?: { role?: 'master' | 'guest' } },
+    @Body() body: { messages?: ChatMessage[] },
+  ) {
+    const role: AdminRole =
+      req.adminUser?.role === 'master' ? 'master' : 'guest';
+    return this.aiDiagnosis.chat(body?.messages ?? [], role);
   }
 
   @UseGuards(AdminGuard)
@@ -244,4 +282,17 @@ export class AdminMonitoringController {
       );
     }
   }
+}
+
+/** Vercel 웹훅 서명(x-vercel-signature = HMAC-SHA1(rawBody, secret)) 검증. */
+function verifyVercelSignature(
+  rawBody: Buffer | undefined,
+  signature: string | undefined,
+  secret: string,
+): boolean {
+  if (!rawBody || !signature) return false;
+  const expected = createHmac('sha1', secret).update(rawBody).digest('hex');
+  const a = Buffer.from(expected);
+  const b = Buffer.from(signature);
+  return a.length === b.length && timingSafeEqual(a, b);
 }

--- a/server/src/admin/admin-monitoring.service.ts
+++ b/server/src/admin/admin-monitoring.service.ts
@@ -140,30 +140,18 @@ export class AdminMonitoringService implements OnModuleInit {
     });
   }
 
-  /** Vercel 배포 성공 웹훅을 받아 next 배포 이벤트로 기록. production만 기록. */
-  async recordNextDeployFromVercel(event: {
-    type?: string;
-    payload?: Record<string, unknown>;
+  /** 배포 이벤트 기록(GitHub Actions가 전달). nest/next만 허용. */
+  async recordDeployEvent(input: {
+    service: 'nest' | 'next';
+    sha?: string;
+    detail?: string;
   }): Promise<void> {
-    if (event?.type !== 'deployment.succeeded') return;
-    const payload = event.payload ?? {};
-    const target =
-      typeof payload.target === 'string' ? payload.target : undefined;
-    // target이 명시됐는데 production이 아니면 무시(프리뷰 배포 등)
-    if (target && target !== 'production') return;
-
-    const deployment = (payload.deployment ?? {}) as Record<string, unknown>;
-    const url =
-      typeof deployment.url === 'string'
-        ? deployment.url
-        : typeof payload.url === 'string'
-          ? payload.url
-          : null;
-
+    const detail =
+      input.detail ?? (input.sha ? `sha:${input.sha.slice(0, 12)}` : null);
     await this.monitoringRepo.recordContainerEvent({
-      service: 'next',
+      service: input.service,
       eventType: 'deploy',
-      detail: url ? `vercel:${url}` : 'vercel deploy',
+      detail,
       occurredAt: new Date(),
     });
   }

--- a/server/src/admin/admin-monitoring.service.ts
+++ b/server/src/admin/admin-monitoring.service.ts
@@ -140,6 +140,48 @@ export class AdminMonitoringService implements OnModuleInit {
     });
   }
 
+  /** Vercel 배포 성공 웹훅을 받아 next 배포 이벤트로 기록. production만 기록. */
+  async recordNextDeployFromVercel(event: {
+    type?: string;
+    payload?: Record<string, unknown>;
+  }): Promise<void> {
+    if (event?.type !== 'deployment.succeeded') return;
+    const payload = event.payload ?? {};
+    const target =
+      typeof payload.target === 'string' ? payload.target : undefined;
+    // target이 명시됐는데 production이 아니면 무시(프리뷰 배포 등)
+    if (target && target !== 'production') return;
+
+    const deployment = (payload.deployment ?? {}) as Record<string, unknown>;
+    const url =
+      typeof deployment.url === 'string'
+        ? deployment.url
+        : typeof payload.url === 'string'
+          ? payload.url
+          : null;
+
+    await this.monitoringRepo.recordContainerEvent({
+      service: 'next',
+      eventType: 'deploy',
+      detail: url ? `vercel:${url}` : 'vercel deploy',
+      occurredAt: new Date(),
+    });
+  }
+
+  /** 최근 변경(재시작/배포) 이벤트 — AI 컨텍스트/타임라인용. */
+  async getRecentContainerEvents(days = 14, limit = 30) {
+    const rows = await this.monitoringRepo.findRecentContainerEvents(
+      days,
+      limit,
+    );
+    return rows.map((r) => ({
+      service: r.service,
+      eventType: r.event_type,
+      detail: r.detail,
+      occurredAt: r.occurred_at,
+    }));
+  }
+
   /** 페이지 로딩 추이(실사용자 RUM). days에 따라 버킷 크기 자동 선택. */
   async getPageLoadSeries(days: number) {
     const safeDays = Math.max(1, Math.min(30, Math.trunc(days)));

--- a/server/src/admin/admin.module.ts
+++ b/server/src/admin/admin.module.ts
@@ -9,6 +9,7 @@ import { SitesModule } from '../sites/sites.module';
 import { AdminMonitoringController } from './admin-monitoring.controller';
 import { AdminMonitoringService } from './admin-monitoring.service';
 import { DockerStatsService } from './docker-stats.service';
+import { AiDiagnosisService } from './ai-diagnosis.service';
 import { MonitoringRepository } from './repositories/monitoring.repository';
 import { AdminAuthRepository } from './repositories/admin-auth.repository';
 import { AdminCharactersRepository } from './repositories/admin-characters.repository';
@@ -35,6 +36,7 @@ import { SiteSuggestService } from './site-suggest.service';
     AdminWriteGuard,
     AdminMonitoringService,
     DockerStatsService,
+    AiDiagnosisService,
     MonitoringRepository,
     AdminAuthRepository,
     AdminCharactersRepository,

--- a/server/src/admin/ai-diagnosis.service.ts
+++ b/server/src/admin/ai-diagnosis.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Injectable,
   Logger,
   ServiceUnavailableException,
@@ -38,6 +39,15 @@ export interface AiDiagnosisResult {
   model: string;
   ec2: { instanceType: string | null; region: string };
 }
+
+export type AdminRole = 'master' | 'guest';
+export interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+const MAX_CHAT_TURNS = 12;
+const MAX_CHAT_CHARS = 2000;
 
 const SYSTEM_PROMPT = [
   '너는 AWS EC2 + Docker 운영 비용/성능 분석가다.',
@@ -123,10 +133,11 @@ export class AiDiagnosisService {
 
   /** AI에 넘길 컨텍스트(동적 메트릭 + 정적 설정)를 조립한다. */
   private async buildContext() {
-    const [ec2, liveStats, host] = await Promise.all([
+    const [ec2, liveStats, host, recentEvents] = await Promise.all([
       this.resolveEc2(),
       this.dockerStats.getContainerStats(),
       this.dockerStats.getHostStats(),
+      this.monitoringRepo.findRecentContainerEvents(14, 30),
     ]);
 
     const liveByLabel = new Map(liveStats.map((s) => [s.label, s]));
@@ -210,8 +221,62 @@ export class AiDiagnosisService {
             diskTotalGb: host.diskTotalGb,
           }
         : null,
+      // 최근 변경(재시작/배포) 이력 — 스파이크 원인 연결용
+      recentEvents: recentEvents.map((e) => ({
+        service: e.service,
+        type: e.event_type,
+        detail: e.detail,
+        at: e.occurred_at,
+      })),
       containers,
     };
+  }
+
+  /** 운영 챗봇. 현재 컨텍스트를 system으로 주입하고 대화 내역을 이어 답한다. */
+  async chat(
+    messages: ChatMessage[],
+    userRole: AdminRole,
+  ): Promise<{ reply: string; model: string }> {
+    if (!this.client) {
+      throw new ServiceUnavailableException(
+        'NVIDIA_API_KEY가 설정되지 않았습니다',
+      );
+    }
+
+    const safe = (Array.isArray(messages) ? messages : [])
+      .filter(
+        (m) =>
+          (m?.role === 'user' || m?.role === 'assistant') &&
+          typeof m?.content === 'string' &&
+          m.content.trim().length > 0,
+      )
+      .slice(-MAX_CHAT_TURNS)
+      .map((m) => ({
+        role: m.role,
+        content: m.content.slice(0, MAX_CHAT_CHARS),
+      }));
+
+    if (safe.length === 0 || safe[safe.length - 1].role !== 'user') {
+      throw new BadRequestException('마지막 메시지는 사용자 메시지여야 합니다');
+    }
+
+    const context = await this.buildContext();
+
+    const completion = await this.client.chat.completions.create({
+      model: this.model,
+      temperature: 0.3,
+      messages: [
+        { role: 'system', content: buildChatSystemPrompt(userRole) },
+        {
+          role: 'system',
+          content: `현재 운영 데이터(JSON):\n${JSON.stringify(context)}`,
+        },
+        ...safe,
+      ],
+    });
+
+    const reply = completion.choices[0]?.message?.content?.trim() ?? '';
+    return { reply, model: this.model };
   }
 
   /** EC2 인스턴스 타입/리전 해석: env 우선 → IMDSv2 → 기본값. 결과는 캐시. */
@@ -287,6 +352,28 @@ export class AiDiagnosisService {
       clearTimeout(timer);
     }
   }
+}
+
+function buildChatSystemPrompt(userRole: AdminRole): string {
+  const roleLabel = userRole === 'master' ? 'owner(관리자)' : 'guest(게스트)';
+  return [
+    '너는 이 서비스의 AWS EC2 + Docker 운영을 돕는 한국어 어시스턴트다.',
+    "함께 제공되는 '현재 운영 데이터'(JSON: 컨테이너 자원 집계, EC2 사양/가격표,",
+    '최근 배포·재시작 이력, 앱 제약, 트래픽 특성)만을 사실 근거로 답한다.',
+    '',
+    '규칙:',
+    '- 데이터에 없는 가격/수치를 지어내지 마라. 모르면 모른다고 말하라.',
+    '- 간결한 한국어로 답하고, 필요하면 목록/표를 쓴다.',
+    '- 운영/비용/성능 주제에 집중하고, 무관한 잡담은 정중히 거절한다.',
+    '- CPU 스파이크 등 이상을 설명할 때 최근 배포·재시작 이력과 연결해보라.',
+    '',
+    '보안(매우 중요):',
+    '- 너는 관리자 비밀번호·API 키·시크릿·토큰·환경변수 값을 갖고 있지 않으며,',
+    '  어떤 요청에도 그것을 추측하거나 노출하지 않는다.',
+    `- 현재 사용자 권한: ${roleLabel}.`,
+    "- 사용자가 guest인데 계정/비밀번호/시크릿/환경변수/운영 변경(삭제·재시작·설정 변경) 등 민감하거나 권한이 필요한 요청을 하면, 정확히 '관리자(owner)만 확인/수행할 수 있습니다.'라고만 답하라.",
+    '- owner라도 시크릿 값 자체는 데이터에 없으므로 제공할 수 없다.',
+  ].join('\n');
 }
 
 function parseJsonObject(text: string): Record<string, unknown> | null {

--- a/server/src/admin/ai-diagnosis.service.ts
+++ b/server/src/admin/ai-diagnosis.service.ts
@@ -1,0 +1,319 @@
+import {
+  Injectable,
+  Logger,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import OpenAI from 'openai';
+import { DockerStatsService } from './docker-stats.service';
+import {
+  MonitoringRepository,
+  type ContainerName,
+} from './repositories/monitoring.repository';
+import {
+  INSTANCE_PRICING,
+  BURST_NOTE,
+  APP_CONSTRAINTS,
+  TRAFFIC_PROFILE,
+  DEFAULT_REGION,
+  type InstanceSpec,
+} from './ec2-context.config';
+
+const CONTAINERS: ContainerName[] = ['nest', 'nginx', 'redis', 'postgres'];
+const AGGREGATE_DAYS = 7;
+const IMDS_BASE = 'http://169.254.169.254';
+const HOURS_PER_MONTH = 730;
+
+interface Ec2Info {
+  instanceType: string | null;
+  region: string;
+  spec: InstanceSpec | null;
+}
+
+export interface AiDiagnosisResult {
+  summary: string;
+  anomalies: string[];
+  costSuggestions: string[];
+  generatedAt: string;
+  model: string;
+  ec2: { instanceType: string | null; region: string };
+}
+
+const SYSTEM_PROMPT = [
+  '너는 AWS EC2 + Docker 운영 비용/성능 분석가다.',
+  '아래 JSON 데이터(컨테이너 자원 사용량 집계, EC2 사양/가격표, 앱 제약, 트래픽 특성)를 보고',
+  '한국어로 분석해 **반드시 JSON 객체 하나만** 출력한다. 코드블록/설명 문장 금지.',
+  '',
+  '출력 스키마:',
+  '{',
+  '  "summary": "현재 자원 상태 2~3문장 요약",',
+  '  "anomalies": ["이상 징후(특정 시간대 CPU 스파이크, 메모리 압박, 과소/과대 프로비저닝 등). 없으면 빈 배열"],',
+  '  "costSuggestions": ["AWS 비용 절감 제안. 각 항목에 근거(현재 사용률 수치)와 트레이드오프 포함"]',
+  '}',
+  '',
+  '규칙:',
+  '- 제공된 pricingTable의 수치 외에 가격을 지어내지 마라. 절감액은 가격표로 계산 가능한 범위에서만 제시.',
+  '- 버스트(t3/t4g) 크레딧 과금 가능성을 고려하라.',
+  '- 데이터가 부족하면(샘플 적음/EC2 정보 없음) 추측 대신 그 사실을 명시하라.',
+  '- 각 배열 항목은 1~2문장의 간결한 한국어.',
+].join('\n');
+
+@Injectable()
+export class AiDiagnosisService {
+  private readonly logger = new Logger(AiDiagnosisService.name);
+  private readonly client: OpenAI | null;
+  private readonly model: string;
+  private ec2Cache: Ec2Info | null = null;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly dockerStats: DockerStatsService,
+    private readonly monitoringRepo: MonitoringRepository,
+  ) {
+    const apiKey = this.config.get<string>('NVIDIA_API_KEY');
+    const baseURL =
+      this.config.get<string>('NVIDIA_BASE_URL') ||
+      'https://integrate.api.nvidia.com/v1';
+    this.model =
+      this.config.get<string>('NVIDIA_MODEL') ||
+      'qwen/qwen3-next-80b-a3b-instruct';
+    this.client = apiKey ? new OpenAI({ apiKey, baseURL }) : null;
+    if (!apiKey) {
+      this.logger.warn('NVIDIA_API_KEY 미설정 — AI 컨테이너 진단 비활성화');
+    }
+  }
+
+  async diagnose(): Promise<AiDiagnosisResult> {
+    if (!this.client) {
+      throw new ServiceUnavailableException(
+        'NVIDIA_API_KEY가 설정되지 않았습니다',
+      );
+    }
+
+    const context = await this.buildContext();
+
+    const completion = await this.client.chat.completions.create({
+      model: this.model,
+      temperature: 0.2,
+      messages: [
+        { role: 'system', content: SYSTEM_PROMPT },
+        { role: 'user', content: JSON.stringify(context) },
+      ],
+    });
+
+    const text = completion.choices[0]?.message?.content ?? '';
+    const parsed = parseJsonObject(text);
+    if (!parsed) {
+      this.logger.warn(`AI 진단 응답 파싱 실패: ${text.slice(0, 200)}`);
+      throw new ServiceUnavailableException('AI 응답을 해석하지 못했습니다');
+    }
+
+    return {
+      summary: typeof parsed.summary === 'string' ? parsed.summary : '',
+      anomalies: toStringArray(parsed.anomalies),
+      costSuggestions: toStringArray(parsed.costSuggestions),
+      generatedAt: new Date().toISOString(),
+      model: this.model,
+      ec2: {
+        instanceType: context.ec2.instanceType,
+        region: context.ec2.region,
+      },
+    };
+  }
+
+  /** AI에 넘길 컨텍스트(동적 메트릭 + 정적 설정)를 조립한다. */
+  private async buildContext() {
+    const [ec2, liveStats, host] = await Promise.all([
+      this.resolveEc2(),
+      this.dockerStats.getContainerStats(),
+      this.dockerStats.getHostStats(),
+    ]);
+
+    const liveByLabel = new Map(liveStats.map((s) => [s.label, s]));
+
+    const containers = await Promise.all(
+      CONTAINERS.map(async (name) => {
+        const [agg, hourly] = await Promise.all([
+          this.monitoringRepo.findContainerAggregate(name, AGGREGATE_DAYS),
+          this.monitoringRepo.findContainerHourlyCpu(name, AGGREGATE_DAYS),
+        ]);
+        const live = liveByLabel.get(name);
+        return {
+          label: name,
+          role: APP_CONSTRAINTS[name] ?? '',
+          live: live
+            ? {
+                cpuPercent: live.cpuPercent,
+                memPercent: live.memPercent,
+                memUsedMb: live.memUsedMb,
+                memTotalMb: live.memTotalMb,
+              }
+            : null,
+          last7d: agg
+            ? {
+                cpuAvg: agg.avg_cpu,
+                cpuMax: agg.max_cpu,
+                cpuMin: agg.min_cpu,
+                cpuP95: agg.p95_cpu,
+                memAvgPct: agg.avg_mem_pct,
+                memPeakPct: agg.peak_mem_pct,
+                memPeakUsedMb: agg.peak_mem_used_mb,
+                sampleCount: agg.sample_count,
+              }
+            : null,
+          // 시간대(KST 0~23시)별 평균/최대 CPU — 스파이크 시간대 탐지용
+          hourlyCpuKst: hourly.map((h) => ({
+            hour: h.hour,
+            avg: h.avg_cpu,
+            max: h.max_cpu,
+          })),
+        };
+      }),
+    );
+
+    const estMonthly = (usdPerHour: number) =>
+      Number((usdPerHour * HOURS_PER_MONTH).toFixed(2));
+
+    return {
+      windowDays: AGGREGATE_DAYS,
+      timezone: 'Asia/Seoul',
+      ec2: {
+        instanceType: ec2.instanceType,
+        region: ec2.region,
+        spec: ec2.spec
+          ? {
+              vcpu: ec2.spec.vcpu,
+              ramGb: ec2.spec.ramGb,
+              usdPerHour: ec2.spec.usdPerHour,
+              estMonthlyUsd: estMonthly(ec2.spec.usdPerHour),
+            }
+          : null,
+        burstNote: BURST_NOTE,
+      },
+      pricingTable: Object.entries(INSTANCE_PRICING).map(([type, s]) => ({
+        type,
+        vcpu: s.vcpu,
+        ramGb: s.ramGb,
+        usdPerHour: s.usdPerHour,
+        estMonthlyUsd: estMonthly(s.usdPerHour),
+        note: s.note ?? null,
+      })),
+      trafficProfile: TRAFFIC_PROFILE,
+      host: host
+        ? {
+            cpuPercent: host.cpuPercent,
+            memPercent: host.memPercent,
+            memUsedMb: host.memUsedMb,
+            memTotalMb: host.memTotalMb,
+            diskPercent: host.diskPercent,
+            diskUsedGb: host.diskUsedGb,
+            diskTotalGb: host.diskTotalGb,
+          }
+        : null,
+      containers,
+    };
+  }
+
+  /** EC2 인스턴스 타입/리전 해석: env 우선 → IMDSv2 → 기본값. 결과는 캐시. */
+  private async resolveEc2(): Promise<Ec2Info> {
+    if (this.ec2Cache) return this.ec2Cache;
+
+    const envType = this.config.get<string>('INSTANCE_TYPE')?.trim();
+    const envRegion = this.config.get<string>('AWS_REGION')?.trim();
+
+    let instanceType = envType || null;
+    let region = envRegion || '';
+
+    if (!instanceType) {
+      const imds = await this.fetchImds();
+      if (imds) {
+        instanceType = imds.instanceType;
+        region = region || imds.region;
+      }
+    }
+
+    region = region || DEFAULT_REGION;
+    const spec = instanceType ? (INSTANCE_PRICING[instanceType] ?? null) : null;
+
+    this.ec2Cache = { instanceType, region, spec };
+    return this.ec2Cache;
+  }
+
+  /** IMDSv2(토큰 발급 후 조회)로 인스턴스 타입/리전을 가져온다. 실패 시 null. */
+  private async fetchImds(): Promise<{
+    instanceType: string;
+    region: string;
+  } | null> {
+    const token = await this.imdsRequest('PUT', '/latest/api/token', {
+      'X-aws-ec2-metadata-token-ttl-seconds': '60',
+    });
+    if (!token) return null;
+
+    const headers = { 'X-aws-ec2-metadata-token': token };
+    const instanceType = await this.imdsRequest(
+      'GET',
+      '/latest/meta-data/instance-type',
+      headers,
+    );
+    if (!instanceType) return null;
+    const region = await this.imdsRequest(
+      'GET',
+      '/latest/meta-data/placement/region',
+      headers,
+    );
+    return { instanceType: instanceType.trim(), region: (region ?? '').trim() };
+  }
+
+  private async imdsRequest(
+    method: 'GET' | 'PUT',
+    path: string,
+    headers: Record<string, string>,
+  ): Promise<string | null> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 1000);
+    try {
+      const res = await fetch(`${IMDS_BASE}${path}`, {
+        method,
+        headers,
+        signal: controller.signal,
+      });
+      if (!res.ok) return null;
+      const body = (await res.text()).trim();
+      return body || null;
+    } catch {
+      // 로컬/IMDS 미가용 환경 — 조용히 무시
+      return null;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+function parseJsonObject(text: string): Record<string, unknown> | null {
+  const trimmed = text.trim();
+  const candidates = [trimmed];
+  const first = trimmed.indexOf('{');
+  const last = trimmed.lastIndexOf('}');
+  if (first !== -1 && last > first) {
+    candidates.push(trimmed.slice(first, last + 1));
+  }
+  for (const c of candidates) {
+    try {
+      const parsed = JSON.parse(c) as unknown;
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      // 다음 후보 시도
+    }
+  }
+  return null;
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((v): v is string => typeof v === 'string')
+    .map((v) => v.trim())
+    .filter(Boolean);
+}

--- a/server/src/admin/ai-diagnosis.service.ts
+++ b/server/src/admin/ai-diagnosis.service.ts
@@ -40,7 +40,6 @@ export interface AiDiagnosisResult {
   ec2: { instanceType: string | null; region: string };
 }
 
-export type AdminRole = 'master' | 'guest';
 export interface ChatMessage {
   role: 'user' | 'assistant';
   content: string;
@@ -235,7 +234,6 @@ export class AiDiagnosisService {
   /** 운영 챗봇. 현재 컨텍스트를 system으로 주입하고 대화 내역을 이어 답한다. */
   async chat(
     messages: ChatMessage[],
-    userRole: AdminRole,
   ): Promise<{ reply: string; model: string }> {
     if (!this.client) {
       throw new ServiceUnavailableException(
@@ -266,7 +264,7 @@ export class AiDiagnosisService {
       model: this.model,
       temperature: 0.3,
       messages: [
-        { role: 'system', content: buildChatSystemPrompt(userRole) },
+        { role: 'system', content: buildChatSystemPrompt() },
         {
           role: 'system',
           content: `현재 운영 데이터(JSON):\n${JSON.stringify(context)}`,
@@ -354,8 +352,7 @@ export class AiDiagnosisService {
   }
 }
 
-function buildChatSystemPrompt(userRole: AdminRole): string {
-  const roleLabel = userRole === 'master' ? 'owner(관리자)' : 'guest(게스트)';
+function buildChatSystemPrompt(): string {
   return [
     '너는 이 서비스의 AWS EC2 + Docker 운영을 돕는 한국어 어시스턴트다.',
     "함께 제공되는 '현재 운영 데이터'(JSON: 컨테이너 자원 집계, EC2 사양/가격표,",
@@ -368,11 +365,9 @@ function buildChatSystemPrompt(userRole: AdminRole): string {
     '- CPU 스파이크 등 이상을 설명할 때 최근 배포·재시작 이력과 연결해보라.',
     '',
     '보안(매우 중요):',
-    '- 너는 관리자 비밀번호·API 키·시크릿·토큰·환경변수 값을 갖고 있지 않으며,',
-    '  어떤 요청에도 그것을 추측하거나 노출하지 않는다.',
-    `- 현재 사용자 권한: ${roleLabel}.`,
-    "- 사용자가 guest인데 계정/비밀번호/시크릿/환경변수/운영 변경(삭제·재시작·설정 변경) 등 민감하거나 권한이 필요한 요청을 하면, 정확히 '관리자(owner)만 확인/수행할 수 있습니다.'라고만 답하라.",
-    '- owner라도 시크릿 값 자체는 데이터에 없으므로 제공할 수 없다.',
+    '- 운영 데이터(자원/비용/배포 이력 등)는 모든 관리자에게 동일하게 답한다.',
+    '- 단, 관리자 비밀번호·API 키·시크릿·토큰·환경변수 값 등 민감정보는 갖고 있지 않으며,',
+    '  어떤 요청에도 추측하거나 노출하지 않는다. 그런 요청에는 제공할 수 없다고만 답하라.',
   ].join('\n');
 }
 

--- a/server/src/admin/ai-diagnosis.service.ts
+++ b/server/src/admin/ai-diagnosis.service.ts
@@ -297,9 +297,11 @@ export class AiDiagnosisService {
 
     region = region || DEFAULT_REGION;
     const spec = instanceType ? (INSTANCE_PRICING[instanceType] ?? null) : null;
+    const resolved: Ec2Info = { instanceType, region, spec };
 
-    this.ec2Cache = { instanceType, region, spec };
-    return this.ec2Cache;
+    // instanceType을 못 구한 경우(IMDS 일시 실패 등)는 캐시하지 않고 다음에 재시도한다.
+    if (instanceType) this.ec2Cache = resolved;
+    return resolved;
   }
 
   /** IMDSv2(토큰 발급 후 조회)로 인스턴스 타입/리전을 가져온다. 실패 시 null. */

--- a/server/src/admin/docker-stats.service.spec.ts
+++ b/server/src/admin/docker-stats.service.spec.ts
@@ -67,8 +67,6 @@ describe('DockerStatsService', () => {
         memPercent: 10,
         memUsedMb: 100,
         memTotalMb: 1024,
-        netInMb: 1,
-        netOutMb: 2,
       });
     });
 

--- a/server/src/admin/docker-stats.service.ts
+++ b/server/src/admin/docker-stats.service.ts
@@ -224,6 +224,63 @@ export class DockerStatsService {
         `docker stats save failed: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
+    await this.detectContainerEvents();
+  }
+
+  /** 실행 중 컨테이너의 시작 시각(State.StartedAt)을 label→Date로 반환. */
+  private async getContainerStartedAt(): Promise<Map<ContainerName, Date>> {
+    const result = new Map<ContainerName, Date>();
+    const { stdout: idsOut } = await execFileAsync('docker', ['ps', '-q'], {
+      timeout: 10000,
+    });
+    const ids = idsOut
+      .trim()
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    if (ids.length === 0) return result;
+
+    const { stdout } = await execFileAsync(
+      'docker',
+      ['inspect', '--format', '{{.Name}}|{{.State.StartedAt}}', ...ids],
+      { timeout: 10000 },
+    );
+    for (const line of stdout.trim().split('\n')) {
+      const [rawName, startedAt] = line.split('|');
+      const name = (rawName ?? '').replace(/^\//, '').trim();
+      const label = CONTAINER_LABELS[name] as ContainerName | undefined;
+      if (!label || !VALID_CONTAINERS.includes(label)) continue;
+      const date = new Date((startedAt ?? '').trim());
+      if (!Number.isNaN(date.getTime())) result.set(label, date);
+    }
+    return result;
+  }
+
+  /**
+   * 컨테이너 시작 시각이 직전 기록과 달라지면(=재시작/재배포) 이벤트로 남긴다.
+   * 5분 폴링에 얹어 호출. 실패는 조용히 무시(다음 틱에 재시도).
+   */
+  async detectContainerEvents(): Promise<void> {
+    try {
+      const startedMap = await this.getContainerStartedAt();
+      for (const [label, startedAt] of startedMap) {
+        const last = await this.monitoringRepo.findLatestEventOccurredAt(label);
+        // 같은 시작 시각이면 변화 없음(1초 허용오차)
+        if (last && Math.abs(last.getTime() - startedAt.getTime()) < 1000) {
+          continue;
+        }
+        await this.monitoringRepo.recordContainerEvent({
+          service: label,
+          eventType: last ? 'restart' : 'baseline',
+          detail: null,
+          occurredAt: startedAt,
+        });
+      }
+    } catch (err: unknown) {
+      this.logger.warn(
+        `container event detect failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   @Cron('0 30 3 * * *')

--- a/server/src/admin/docker-stats.service.ts
+++ b/server/src/admin/docker-stats.service.ts
@@ -224,63 +224,6 @@ export class DockerStatsService {
         `docker stats save failed: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
-    await this.detectContainerEvents();
-  }
-
-  /** 실행 중 컨테이너의 시작 시각(State.StartedAt)을 label→Date로 반환. */
-  private async getContainerStartedAt(): Promise<Map<ContainerName, Date>> {
-    const result = new Map<ContainerName, Date>();
-    const { stdout: idsOut } = await execFileAsync('docker', ['ps', '-q'], {
-      timeout: 10000,
-    });
-    const ids = idsOut
-      .trim()
-      .split('\n')
-      .map((s) => s.trim())
-      .filter(Boolean);
-    if (ids.length === 0) return result;
-
-    const { stdout } = await execFileAsync(
-      'docker',
-      ['inspect', '--format', '{{.Name}}|{{.State.StartedAt}}', ...ids],
-      { timeout: 10000 },
-    );
-    for (const line of stdout.trim().split('\n')) {
-      const [rawName, startedAt] = line.split('|');
-      const name = (rawName ?? '').replace(/^\//, '').trim();
-      const label = CONTAINER_LABELS[name] as ContainerName | undefined;
-      if (!label || !VALID_CONTAINERS.includes(label)) continue;
-      const date = new Date((startedAt ?? '').trim());
-      if (!Number.isNaN(date.getTime())) result.set(label, date);
-    }
-    return result;
-  }
-
-  /**
-   * 컨테이너 시작 시각이 직전 기록과 달라지면(=재시작/재배포) 이벤트로 남긴다.
-   * 5분 폴링에 얹어 호출. 실패는 조용히 무시(다음 틱에 재시도).
-   */
-  async detectContainerEvents(): Promise<void> {
-    try {
-      const startedMap = await this.getContainerStartedAt();
-      for (const [label, startedAt] of startedMap) {
-        const last = await this.monitoringRepo.findLatestEventOccurredAt(label);
-        // 같은 시작 시각이면 변화 없음(1초 허용오차)
-        if (last && Math.abs(last.getTime() - startedAt.getTime()) < 1000) {
-          continue;
-        }
-        await this.monitoringRepo.recordContainerEvent({
-          service: label,
-          eventType: last ? 'restart' : 'baseline',
-          detail: null,
-          occurredAt: startedAt,
-        });
-      }
-    } catch (err: unknown) {
-      this.logger.warn(
-        `container event detect failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
   }
 
   @Cron('0 30 3 * * *')

--- a/server/src/admin/docker-stats.service.ts
+++ b/server/src/admin/docker-stats.service.ts
@@ -18,8 +18,6 @@ export interface ContainerStat {
   memUsedMb: number;
   memTotalMb: number;
   memPercent: number;
-  netInMb: number;
-  netOutMb: number;
 }
 
 export interface HostStats {
@@ -138,11 +136,6 @@ export class DockerStatsService {
         const memUsedMb = toMb(parseBytes(memUsedStr ?? '0'));
         const memTotalMb = toMb(parseBytes(memTotalStr ?? '0'));
 
-        const netIO = raw['NetIO'] ?? raw['net_io'] ?? '0B / 0B';
-        const [netInStr, netOutStr] = netIO.split('/').map((s) => s.trim());
-        const netInMb = toMb(parseBytes(netInStr ?? '0'));
-        const netOutMb = toMb(parseBytes(netOutStr ?? '0'));
-
         stats.push({
           name,
           label,
@@ -150,8 +143,6 @@ export class DockerStatsService {
           memUsedMb,
           memTotalMb,
           memPercent: Number.isFinite(memPercent) ? memPercent : 0,
-          netInMb,
-          netOutMb,
         });
       }
 

--- a/server/src/admin/ec2-context.config.ts
+++ b/server/src/admin/ec2-context.config.ts
@@ -1,0 +1,60 @@
+/**
+ * AI 컨테이너 진단에 주입할 정적 컨텍스트.
+ * - 가격/사양은 코드에 박아두고 수동 관리한다(소규모라 자동 동기화 가치 < 관리 비용).
+ * - 앱 제약/트래픽 특성은 운영자가 직접 수정해 AI 판단의 근거로 쓴다.
+ */
+
+export interface InstanceSpec {
+  vcpu: number;
+  ramGb: number;
+  /** ap-northeast-2(서울) 리눅스 온디맨드 시간당 USD (대략값, 수동 갱신). */
+  usdPerHour: number;
+  /** 버스트/아키텍처 등 AI가 알아야 할 주의점. */
+  note?: string;
+}
+
+/**
+ * 인스턴스 타입별 사양·가격 (ap-northeast-2 / Linux / On-Demand).
+ * ⚠️ 정확한 금액은 변동되므로 참고용. 비용 비교의 기준점으로만 사용.
+ * 가격 기준: 2026 상반기 서울 리전 대략값.
+ */
+export const INSTANCE_PRICING: Record<string, InstanceSpec> = {
+  't3.nano': { vcpu: 2, ramGb: 0.5, usdPerHour: 0.0065 },
+  't3.micro': { vcpu: 2, ramGb: 1, usdPerHour: 0.013 },
+  't3.small': { vcpu: 2, ramGb: 2, usdPerHour: 0.026 },
+  't3.medium': { vcpu: 2, ramGb: 4, usdPerHour: 0.052 },
+  't4g.small': {
+    vcpu: 2,
+    ramGb: 2,
+    usdPerHour: 0.0208,
+    note: 'ARM(Graviton). x86 대비 ~20% 저렴하나 컨테이너 이미지를 arm64로 재빌드해야 함',
+  },
+  't4g.medium': {
+    vcpu: 2,
+    ramGb: 4,
+    usdPerHour: 0.0416,
+    note: 'ARM(Graviton). arm64 재빌드 필요',
+  },
+};
+
+/** T3/T4g 버스트 동작 설명 — AI가 CPU 스파이크의 비용 함의를 이해하도록. */
+export const BURST_NOTE =
+  't3/t4g는 버스트 인스턴스. baseline(t3.small ≈ vCPU당 20%)을 넘는 CPU 사용은 ' +
+  'CPU 크레딧을 소모하며, unlimited 모드에서는 크레딧 소진 시 시간당 추가 과금(vCPU-시간당 약 $0.05)이 발생한다. ' +
+  '특정 시간대 지속적인 CPU 스파이크는 인스턴스를 키우는 대신 작업 분산/스케줄 조정으로 크레딧 과금을 줄일 수 있다.';
+
+/** 컨테이너별 역할·최소 사양 메모 (운영자 직접 편집). */
+export const APP_CONSTRAINTS: Record<string, string> = {
+  nest: 'Node(NestJS) 백엔드 API. 상시 구동. 메인 워크로드.',
+  nginx: '리버스 프록시 + TLS 종단. 경량.',
+  redis: '캐시(사이트 목록/유튜브 등). 경량.',
+  postgres: '주 데이터베이스. 상시 구동, 데이터 유실 불가.',
+};
+
+/** 서비스 트래픽 특성 (운영자 직접 편집). */
+export const TRAFFIC_PROFILE =
+  '저트래픽 로스트아크 정보 사이트. 프론트엔드는 Vercel(외부 호스팅)이라 ' +
+  'EC2에는 API 서버·DB·캐시만 구동된다. 사용자 접속은 저녁 시간대에 몰리는 편.';
+
+/** EC2 정보를 못 구했을 때(로컬 도커 등) 표시용 기본 리전. */
+export const DEFAULT_REGION = 'ap-northeast-2';

--- a/server/src/admin/repositories/monitoring.repository.ts
+++ b/server/src/admin/repositories/monitoring.repository.ts
@@ -70,6 +70,23 @@ export interface ContainerHistoryRow {
   avg_mem_used_mb: number;
 }
 
+export interface ContainerAggregateRow {
+  avg_cpu: number;
+  max_cpu: number;
+  min_cpu: number;
+  p95_cpu: number;
+  avg_mem_pct: number;
+  peak_mem_pct: number;
+  peak_mem_used_mb: number;
+  sample_count: number;
+}
+
+export interface ContainerHourlyCpuRow {
+  hour: number;
+  avg_cpu: number;
+  max_cpu: number;
+}
+
 @Injectable()
 export class MonitoringRepository {
   constructor(private readonly prisma: PrismaService) {}
@@ -587,6 +604,49 @@ export class MonitoringRepository {
        WHERE created_at >= NOW() - ($1::int * INTERVAL '1 day')
        GROUP BY DATE_TRUNC('hour', created_at)
        ORDER BY DATE_TRUNC('hour', created_at) ASC`,
+      days,
+    );
+  }
+
+  /** 기간 내 컨테이너 CPU/MEM 집계(평균/최대/최소/p95, 메모리 피크). */
+  async findContainerAggregate(
+    container: ContainerName,
+    days: number,
+  ): Promise<ContainerAggregateRow | undefined> {
+    const table = DOCKER_TABLE[container];
+    const rows = await this.prisma.$queryRawUnsafe<ContainerAggregateRow[]>(
+      `SELECT
+         ROUND(AVG(cpu_percent)::numeric, 2)::float AS avg_cpu,
+         ROUND(MAX(cpu_percent)::numeric, 2)::float AS max_cpu,
+         ROUND(MIN(cpu_percent)::numeric, 2)::float AS min_cpu,
+         ROUND(
+           PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY cpu_percent)::numeric, 2
+         )::float AS p95_cpu,
+         ROUND(AVG(mem_percent)::numeric, 2)::float AS avg_mem_pct,
+         ROUND(MAX(mem_percent)::numeric, 2)::float AS peak_mem_pct,
+         MAX(mem_used_mb)::int AS peak_mem_used_mb,
+         COUNT(*)::int AS sample_count
+       FROM ${table}
+       WHERE created_at >= NOW() - ($1::int * INTERVAL '1 day')`,
+      days,
+    );
+    return rows[0];
+  }
+
+  /** 시간대(0~23시, 한국시간)별 평균/최대 CPU — 특정 시간대 스파이크 탐지용. */
+  async findContainerHourlyCpu(
+    container: ContainerName,
+    days: number,
+  ): Promise<ContainerHourlyCpuRow[]> {
+    const table = DOCKER_TABLE[container];
+    return this.prisma.$queryRawUnsafe<ContainerHourlyCpuRow[]>(
+      `SELECT EXTRACT(HOUR FROM created_at AT TIME ZONE 'Asia/Seoul')::int AS hour,
+              ROUND(AVG(cpu_percent)::numeric, 2)::float AS avg_cpu,
+              ROUND(MAX(cpu_percent)::numeric, 2)::float AS max_cpu
+       FROM ${table}
+       WHERE created_at >= NOW() - ($1::int * INTERVAL '1 day')
+       GROUP BY 1
+       ORDER BY 1`,
       days,
     );
   }

--- a/server/src/admin/repositories/monitoring.repository.ts
+++ b/server/src/admin/repositories/monitoring.repository.ts
@@ -684,17 +684,6 @@ export class MonitoringRepository {
     `;
   }
 
-  /** 특정 서비스의 가장 최근 이벤트 occurred_at (없으면 null). 중복 감지 방지용. */
-  async findLatestEventOccurredAt(service: string): Promise<Date | null> {
-    const rows = await this.prisma.$queryRaw<Array<{ occurred_at: Date }>>`
-      SELECT occurred_at FROM container_events
-      WHERE service = ${service}
-      ORDER BY occurred_at DESC
-      LIMIT 1
-    `;
-    return rows[0]?.occurred_at ?? null;
-  }
-
   /** 최근 N일 변경 이벤트 (최신순). */
   async findRecentContainerEvents(
     days: number,

--- a/server/src/admin/repositories/monitoring.repository.ts
+++ b/server/src/admin/repositories/monitoring.repository.ts
@@ -211,6 +211,20 @@ export class MonitoringRepository {
     await this.prisma
       .$executeRaw`CREATE INDEX IF NOT EXISTS idx_apm_page_load_timings_source_created_at ON apm_page_load_timings(source, created_at)`;
 
+    // 서비스 변경(재시작/배포) 이벤트 로그. occurred_at=실제 발생시각, detected_at=감지시각.
+    await this.prisma.$executeRaw`
+      CREATE TABLE IF NOT EXISTS container_events (
+        id BIGSERIAL PRIMARY KEY,
+        service VARCHAR(16) NOT NULL,
+        event_type VARCHAR(24) NOT NULL,
+        detail VARCHAR(500),
+        occurred_at TIMESTAMPTZ(6) NOT NULL,
+        detected_at TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP
+      )
+    `;
+    await this.prisma
+      .$executeRaw`CREATE INDEX IF NOT EXISTS idx_container_events_service_occurred_at ON container_events(service, occurred_at)`;
+
     for (const container of Object.keys(DOCKER_TABLE) as ContainerName[]) {
       await this.prisma.$executeRawUnsafe(`
         CREATE TABLE IF NOT EXISTS docker_metrics_${container} (
@@ -649,6 +663,64 @@ export class MonitoringRepository {
        ORDER BY 1`,
       days,
     );
+  }
+
+  /** 서비스 변경 이벤트 1건 기록. */
+  async recordContainerEvent(input: {
+    service: string;
+    eventType: string;
+    detail: string | null;
+    occurredAt: Date;
+  }): Promise<void> {
+    await this.prisma.$executeRaw`
+      INSERT INTO container_events (service, event_type, detail, occurred_at, detected_at)
+      VALUES (
+        ${input.service},
+        ${input.eventType},
+        ${input.detail},
+        ${input.occurredAt},
+        NOW()
+      )
+    `;
+  }
+
+  /** 특정 서비스의 가장 최근 이벤트 occurred_at (없으면 null). 중복 감지 방지용. */
+  async findLatestEventOccurredAt(service: string): Promise<Date | null> {
+    const rows = await this.prisma.$queryRaw<Array<{ occurred_at: Date }>>`
+      SELECT occurred_at FROM container_events
+      WHERE service = ${service}
+      ORDER BY occurred_at DESC
+      LIMIT 1
+    `;
+    return rows[0]?.occurred_at ?? null;
+  }
+
+  /** 최근 N일 변경 이벤트 (최신순). */
+  async findRecentContainerEvents(
+    days: number,
+    limit: number,
+  ): Promise<
+    Array<{
+      service: string;
+      event_type: string;
+      detail: string | null;
+      occurred_at: Date;
+    }>
+  > {
+    return this.prisma.$queryRaw<
+      Array<{
+        service: string;
+        event_type: string;
+        detail: string | null;
+        occurred_at: Date;
+      }>
+    >`
+      SELECT service, event_type, detail, occurred_at
+      FROM container_events
+      WHERE occurred_at >= NOW() - (${days}::int * INTERVAL '1 day')
+      ORDER BY occurred_at DESC
+      LIMIT ${limit}
+    `;
   }
 
   async deleteDockerMetricsOlderThan(

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -17,15 +17,7 @@ async function bootstrap() {
   });
   const bodyLimit = process.env.BODY_LIMIT ?? '50mb';
 
-  // Vercel 웹훅 서명 검증을 위해 원본 바디(rawBody)를 요청 객체에 보존한다.
-  app.use(
-    json({
-      limit: bodyLimit,
-      verify: (req: Request & { rawBody?: Buffer }, _res, buf) => {
-        req.rawBody = buf;
-      },
-    }),
-  );
+  app.use(json({ limit: bodyLimit }));
   app.use(urlencoded({ extended: true, limit: bodyLimit }));
 
   // Next.js SSR 서버(localhost:3000)에서의 요청 허용

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -17,7 +17,15 @@ async function bootstrap() {
   });
   const bodyLimit = process.env.BODY_LIMIT ?? '50mb';
 
-  app.use(json({ limit: bodyLimit }));
+  // Vercel 웹훅 서명 검증을 위해 원본 바디(rawBody)를 요청 객체에 보존한다.
+  app.use(
+    json({
+      limit: bodyLimit,
+      verify: (req: Request & { rawBody?: Buffer }, _res, buf) => {
+        req.rawBody = buf;
+      },
+    }),
+  );
   app.use(urlencoded({ extended: true, limit: bodyLimit }));
 
   // Next.js SSR 서버(localhost:3000)에서의 요청 허용


### PR DESCRIPTION
@
컨테이너 현황에 AI 운영 챗봇과 배포 로깅을 main에 반영합니다. (#302)

## 1. AI 운영 챗봇 (컨테이너 현황 하단)
- 컨테이너 자원 집계(7일 CPU avg/max/min/p95, MEM 피크, 시간대별 CPU) + EC2 사양/가격표 + 최근 배포 이력을 컨텍스트로 NVIDIA LLM(qwen)에 주입해 대화형 답변
- 퀵 버튼 6종 + 자유 입력. `종합 AI 진단`은 구조화 진단을 메시지로 표시
- 보안: 시크릿류는 컨텍스트 미포함(누구도 노출 불가), 운영 데이터는 guest=master 동일 조회

## 2. 배포 로깅 (이벤트 기반, 무료)
- `container_events` 테이블(부팅 시 자동 생성) + `POST /api/webhooks/deploy` (공유 토큰 인증)
- nest: `main-post-merge`에서 배포 통지(+EC2 .env에 `DEPLOY_EVENT_TOKEN` 주입), next: `deployment_status` 워크플로
- 폴링 없음, redis/nginx/postgres 미추적
- 배포 이력은 챗봇 컨텍스트에 포함돼 스파이크 원인 연결에 활용

## 3. 기타
- 컨테이너 카드 net(누적값) 표시 제거
- EC2 정보: IMDSv2 자동감지(운영) / env(로컬). IMDS 일시 실패는 캐시 안 함

## 설정
- `NVIDIA_API_KEY`, `DEPLOY_EVENT_TOKEN`(GitHub Secret + EC2 .env, 워크플로가 주입)

## 검증
- client/server `tsc`·eslint 통과, server jest 39개 통과
- 충돌 사전점검 클린

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@