### PR TITLE
feat(admin): 유튜브 인기 영상 숨김(삭제) 관리 + admin/홈 목록 동기화

### DIFF
--- a/client/app/admin/youtube/page.tsx
+++ b/client/app/admin/youtube/page.tsx
@@ -112,6 +112,9 @@ export default function AdminYoutubePage() {
   >([]);
   const [historyLoading, setHistoryLoading] = useState(false);
   const [accessNotice, setAccessNotice] = useState("");
+  const [blockedIds, setBlockedIds] = useState<string[]>([]);
+  const [showBlocked, setShowBlocked] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null);
   const role = useAdminRole();
   const isGuest = role === "guest";
 
@@ -137,9 +140,12 @@ export default function AdminYoutubePage() {
   async function load() {
     setLoading(true);
     try {
-      const res = await fetch("/api/streamers/popular?offset=0&limit=0", {
-        cache: "no-store",
-      });
+      // 캐시버스터(_=ts) — 엔드포인트가 public s-maxage라 no-store만으론
+      // 공유 CDN 캐시를 못 건너뜀. 유니크 URL로 항상 오리진 최신을 받는다.
+      const res = await fetch(
+        `/api/streamers/popular?offset=0&limit=0&_=${Date.now()}`,
+        { cache: "no-store" },
+      );
       if (!res.ok) throw new Error();
       const data = (await res.json()) as {
         items: YoutubeVideo[];
@@ -155,6 +161,62 @@ export default function AdminYoutubePage() {
   useEffect(() => {
     void load();
   }, []);
+
+  async function loadBlocked() {
+    try {
+      const res = await fetch("/api/admin/youtube/blocked", {
+        cache: "no-store",
+      });
+      if (!res.ok) return;
+      const data = (await res.json()) as { items?: string[] };
+      setBlockedIds(data.items ?? []);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  useEffect(() => {
+    void loadBlocked();
+  }, []);
+
+  async function handleBlock(videoId: string, title: string) {
+    if (!requireMaster("영상 숨김")) return;
+    if (!window.confirm(`이 영상을 인기 목록에서 숨길까요?\n\n${title}`)) return;
+    setBusyId(videoId);
+    try {
+      const res = await fetch("/api/admin/youtube/block", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ videoId }),
+      });
+      if (res.ok) {
+        setItems((prev) => prev.filter((v) => v.videoId !== videoId));
+        setBlockedIds((prev) =>
+          prev.includes(videoId) ? prev : [...prev, videoId],
+        );
+      }
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function handleUnblock(videoId: string) {
+    if (!requireMaster("숨김 해제")) return;
+    setBusyId(videoId);
+    try {
+      const res = await fetch("/api/admin/youtube/unblock", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ videoId }),
+      });
+      if (res.ok) {
+        setBlockedIds((prev) => prev.filter((id) => id !== videoId));
+        await load(); // 복원된 영상이 목록에 다시 나타나도록 갱신
+      }
+    } finally {
+      setBusyId(null);
+    }
+  }
 
   useEffect(() => {
     void (async () => {
@@ -191,6 +253,9 @@ export default function AdminYoutubePage() {
     });
     setPurgeResult(res.ok ? "done" : "error");
     setPurging(false);
+    if (res.ok) {
+      void load(); // 캐시 비운 뒤 최신 목록 다시 불러오기
+    }
     setTimeout(() => setPurgeResult("idle"), 3000);
   }
 
@@ -266,6 +331,12 @@ export default function AdminYoutubePage() {
             <span className="text-xs text-red-500">✗ 오류</span>
           )}
           <button
+            onClick={() => setShowBlocked((v) => !v)}
+            className="admin-btn admin-btn-secondary"
+          >
+            숨김 {blockedIds.length}
+          </button>
+          <button
             onClick={handlePurge}
             disabled={purging}
             className="admin-btn admin-btn-secondary"
@@ -299,6 +370,42 @@ export default function AdminYoutubePage() {
         </div>
       </div>
 
+      {/* 숨김 관리 패널 */}
+      {showBlocked && (
+        <div className="admin-card admin-card-padded mb-4 shrink-0">
+          <p className="text-xs font-semibold text-[color:var(--admin-text-muted)] mb-2 uppercase tracking-wide">
+            숨긴 영상 ({blockedIds.length})
+          </p>
+          {blockedIds.length === 0 ? (
+            <p className="text-xs text-[color:var(--admin-text-subtle)]">
+              숨긴 영상이 없습니다.
+            </p>
+          ) : (
+            <ul className="flex flex-col gap-1 max-h-40 overflow-y-auto">
+              {blockedIds.map((id) => (
+                <li key={id} className="flex items-center gap-2 text-xs">
+                  <a
+                    href={`https://www.youtube.com/watch?v=${id}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-600 truncate flex-1 tabular-nums"
+                  >
+                    {id}
+                  </a>
+                  <button
+                    onClick={() => void handleUnblock(id)}
+                    disabled={busyId === id}
+                    className="admin-btn admin-btn-sm admin-btn-secondary shrink-0"
+                  >
+                    복원
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
       {/* 본문: 목록 + 통계 */}
       <div className="flex flex-1 gap-5 min-h-0">
         {/* 좌측: 영상 목록 */}
@@ -317,12 +424,12 @@ export default function AdminYoutubePage() {
             ) : (
               <ul className="divide-y divide-[color:var(--admin-border)]">
                 {filtered.map((v) => (
-                  <li key={v.videoId}>
+                  <li key={v.videoId} className="flex items-center">
                     <a
                       href={`https://www.youtube.com/watch?v=${v.videoId}`}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="flex items-center gap-3 px-4 py-3 hover:bg-[color:var(--admin-surface-muted)] transition-colors"
+                      className="flex flex-1 min-w-0 items-center gap-3 px-4 py-3 hover:bg-[color:var(--admin-surface-muted)] transition-colors"
                     >
                       <div className="w-28 shrink-0 aspect-video bg-gray-100 rounded-md overflow-hidden">
                         {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -352,6 +459,14 @@ export default function AdminYoutubePage() {
                         </div>
                       </div>
                     </a>
+                    <button
+                      onClick={() => void handleBlock(v.videoId, v.title)}
+                      disabled={busyId === v.videoId}
+                      title="목록에서 숨기기"
+                      className="admin-btn admin-btn-sm admin-btn-secondary mr-3 shrink-0 text-red-600 disabled:opacity-50"
+                    >
+                      {busyId === v.videoId ? "..." : "삭제"}
+                    </button>
                   </li>
                 ))}
               </ul>

--- a/client/app/admin/youtube/page.tsx
+++ b/client/app/admin/youtube/page.tsx
@@ -194,7 +194,11 @@ export default function AdminYoutubePage() {
         setBlockedIds((prev) =>
           prev.includes(videoId) ? prev : [...prev, videoId],
         );
+      } else {
+        alert("영상 숨김 처리에 실패했습니다.");
       }
+    } catch {
+      alert("네트워크 오류가 발생했습니다.");
     } finally {
       setBusyId(null);
     }
@@ -212,7 +216,11 @@ export default function AdminYoutubePage() {
       if (res.ok) {
         setBlockedIds((prev) => prev.filter((id) => id !== videoId));
         await load(); // 복원된 영상이 목록에 다시 나타나도록 갱신
+      } else {
+        alert("숨김 해제에 실패했습니다.");
       }
+    } catch {
+      alert("네트워크 오류가 발생했습니다.");
     } finally {
       setBusyId(null);
     }

--- a/client/app/api/admin/youtube/block/route.ts
+++ b/client/app/api/admin/youtube/block/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+const NEST_API = process.env.NEST_API_URL ?? "http://localhost:3001";
+
+async function getToken(): Promise<string> {
+  const store = await cookies();
+  return store.get("admin_token")?.value ?? "";
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const token = await getToken();
+    const body = await req.json();
+    const res = await fetch(`${NEST_API}/api/admin/youtube/block`, {
+      method: "POST",
+      headers: {
+        "x-admin-session": token,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json().catch(() => ({}));
+    return NextResponse.json(data, { status: res.status });
+  } catch {
+    return NextResponse.json(
+      { message: "admin youtube block upstream unavailable" },
+      { status: 503 },
+    );
+  }
+}

--- a/client/app/api/admin/youtube/blocked/route.ts
+++ b/client/app/api/admin/youtube/blocked/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+const NEST_API = process.env.NEST_API_URL ?? "http://localhost:3001";
+
+async function getToken(): Promise<string> {
+  const store = await cookies();
+  return store.get("admin_token")?.value ?? "";
+}
+
+export async function GET() {
+  try {
+    const token = await getToken();
+    const res = await fetch(`${NEST_API}/api/admin/youtube/blocked`, {
+      headers: { "x-admin-session": token },
+      cache: "no-store",
+    });
+    const data = await res.json().catch(() => ({ items: [] }));
+    return NextResponse.json(data, { status: res.status });
+  } catch {
+    return NextResponse.json(
+      { message: "admin youtube blocked upstream unavailable" },
+      { status: 503 },
+    );
+  }
+}

--- a/client/app/api/admin/youtube/unblock/route.ts
+++ b/client/app/api/admin/youtube/unblock/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+const NEST_API = process.env.NEST_API_URL ?? "http://localhost:3001";
+
+async function getToken(): Promise<string> {
+  const store = await cookies();
+  return store.get("admin_token")?.value ?? "";
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const token = await getToken();
+    const body = await req.json();
+    const res = await fetch(`${NEST_API}/api/admin/youtube/unblock`, {
+      method: "POST",
+      headers: {
+        "x-admin-session": token,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json().catch(() => ({}));
+    return NextResponse.json(data, { status: res.status });
+  } catch {
+    return NextResponse.json(
+      { message: "admin youtube unblock upstream unavailable" },
+      { status: 503 },
+    );
+  }
+}

--- a/server/src/admin/admin-youtube.controller.ts
+++ b/server/src/admin/admin-youtube.controller.ts
@@ -1,0 +1,38 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Body,
+  UseGuards,
+  BadRequestException,
+} from '@nestjs/common';
+import { StreamersService } from '../streamers/streamers.service';
+import { AdminWriteGuard } from './admin.guard';
+
+@Controller('api/admin/youtube')
+@UseGuards(AdminWriteGuard)
+export class AdminYoutubeController {
+  constructor(private readonly streamers: StreamersService) {}
+
+  /** 인기 영상 목록에서 특정 영상을 숨김(삭제) 처리 */
+  @Post('block')
+  async block(@Body() body: { videoId?: string }) {
+    if (!body.videoId) throw new BadRequestException('videoId는 필수입니다');
+    await this.streamers.blockVideo(body.videoId);
+    return { ok: true, videoId: body.videoId };
+  }
+
+  /** 숨김 해제(복원) */
+  @Post('unblock')
+  async unblock(@Body() body: { videoId?: string }) {
+    if (!body.videoId) throw new BadRequestException('videoId는 필수입니다');
+    await this.streamers.unblockVideo(body.videoId);
+    return { ok: true, videoId: body.videoId };
+  }
+
+  /** 현재 숨김 처리된 videoId 목록 */
+  @Get('blocked')
+  async blocked() {
+    return { items: await this.streamers.listBlocked() };
+  }
+}

--- a/server/src/admin/admin-youtube.controller.ts
+++ b/server/src/admin/admin-youtube.controller.ts
@@ -18,7 +18,11 @@ export class AdminYoutubeController {
   @Post('block')
   async block(@Body() body: { videoId?: string }) {
     if (!body.videoId) throw new BadRequestException('videoId는 필수입니다');
-    await this.streamers.blockVideo(body.videoId);
+    try {
+      await this.streamers.blockVideo(body.videoId);
+    } catch (err) {
+      throw new BadRequestException((err as Error).message);
+    }
     return { ok: true, videoId: body.videoId };
   }
 
@@ -26,7 +30,11 @@ export class AdminYoutubeController {
   @Post('unblock')
   async unblock(@Body() body: { videoId?: string }) {
     if (!body.videoId) throw new BadRequestException('videoId는 필수입니다');
-    await this.streamers.unblockVideo(body.videoId);
+    try {
+      await this.streamers.unblockVideo(body.videoId);
+    } catch (err) {
+      throw new BadRequestException((err as Error).message);
+    }
     return { ok: true, videoId: body.videoId };
   }
 

--- a/server/src/admin/admin.module.ts
+++ b/server/src/admin/admin.module.ts
@@ -4,8 +4,10 @@ import { AdminAuthController } from './admin-auth.controller';
 import { AdminSitesController } from './admin-sites.controller';
 import { AdminCacheController } from './admin-cache.controller';
 import { AdminCharactersController } from './admin-characters.controller';
+import { AdminYoutubeController } from './admin-youtube.controller';
 import { AdminGuard, AdminWriteGuard } from './admin.guard';
 import { SitesModule } from '../sites/sites.module';
+import { StreamersModule } from '../streamers/streamers.module';
 import { AdminMonitoringController } from './admin-monitoring.controller';
 import { AdminMonitoringService } from './admin-monitoring.service';
 import { DockerStatsService } from './docker-stats.service';
@@ -21,12 +23,13 @@ import { SiteExtractorService } from './site-extractor.service';
 import { SiteSuggestService } from './site-suggest.service';
 
 @Module({
-  imports: [SitesModule],
+  imports: [SitesModule, StreamersModule],
   controllers: [
     AdminAuthController,
     AdminSitesController,
     AdminCacheController,
     AdminCharactersController,
+    AdminYoutubeController,
     AdminMonitoringController,
     AdminInvenController,
   ],

--- a/server/src/streamers/streamers.service.ts
+++ b/server/src/streamers/streamers.service.ts
@@ -466,6 +466,9 @@ export class StreamersService implements OnModuleInit {
 
   /** 영상을 숨김 목록에 추가하고 서빙 캐시를 비워 즉시 반영 */
   async blockVideo(videoId: string): Promise<void> {
+    if (this.youtubeRedisReadOnly) {
+      throw new Error('YOUTUBE_REDIS_READONLY 활성화 — 숨김 쓰기 불가');
+    }
     await this.youtubeRedis.sadd(BLOCKED_KEY, videoId);
     await this.youtubeRedis.del(POPULAR_CACHE_KEY).catch(() => {});
     this.logger.log(`YouTube 영상 숨김: ${videoId}`);
@@ -473,6 +476,9 @@ export class StreamersService implements OnModuleInit {
 
   /** 영상을 숨김 목록에서 제거(복원)하고 서빙 캐시를 비움 */
   async unblockVideo(videoId: string): Promise<void> {
+    if (this.youtubeRedisReadOnly) {
+      throw new Error('YOUTUBE_REDIS_READONLY 활성화 — 숨김 쓰기 불가');
+    }
     await this.youtubeRedis.srem(BLOCKED_KEY, videoId);
     await this.youtubeRedis.del(POPULAR_CACHE_KEY).catch(() => {});
     this.logger.log(`YouTube 영상 숨김 해제: ${videoId}`);

--- a/server/src/streamers/streamers.service.ts
+++ b/server/src/streamers/streamers.service.ts
@@ -18,6 +18,7 @@ const POPULAR_MAX_RESULTS = 50;
 const POPULAR_MAX_LIMIT = 50;
 const POPULAR_MAX_PAGES = 8;
 const POPULAR_WINDOW_DAYS = 7; // 인기 영상 노출 창(게시일 기준 최근 7일)
+const BLOCKED_KEY = 'youtube:blocked'; // 관리자가 숨긴 videoId Set
 
 export interface PopularResponse {
   items: YoutubeVideoItem[];
@@ -272,11 +273,10 @@ export class StreamersService implements OnModuleInit {
       );
       // 1) 새로 가져온 영상을 DB에 누적 저장(메타데이터 + 조회수 스냅샷)
       await this.snapshotViewCounts(uniqueItems);
-      // 2) 서빙 캐시는 DB의 최근 7일 누적분으로 재구성한다.
+      // 2) 서빙 캐시는 DB의 최근 7일 누적분(관리자 숨김 제외)으로 재구성한다.
       //    YouTube 검색이 도달하지 못해 이번에 안 잡힌 영상도 게시일이
       //    7일 이내면 DB에 남아 있어 계속 노출된다(= 누적 서빙).
-      const recent =
-        await this.streamersRepo.findRecentVideos(POPULAR_WINDOW_DAYS);
+      const recent = await this.loadServingList();
       await this.cachePopular(recent);
       this.logger.log(
         `YouTube 인기 영상 ${recent.length}건 캐시 저장 (DB 누적 ${POPULAR_WINDOW_DAYS}일)`,
@@ -427,10 +427,10 @@ export class StreamersService implements OnModuleInit {
       );
     }
 
-    // 2. 캐시 미스 → DB에서 최근 7일 누적분 조회 후 캐싱
+    // 2. 캐시 미스 → DB에서 최근 7일 누적분(관리자 숨김 제외) 조회 후 캐싱
     let items: YoutubeVideoItem[];
     try {
-      items = await this.streamersRepo.findRecentVideos(POPULAR_WINDOW_DAYS);
+      items = await this.loadServingList();
     } catch (err: unknown) {
       this.logger.error(`popular DB 조회 실패: ${toErrorMessage(err)}`);
       return { items: [], nextOffset: null, hasMore: false, total: 0 };
@@ -438,6 +438,49 @@ export class StreamersService implements OnModuleInit {
 
     await this.cachePopular(items);
     return this.slicePopular(items, safeOffset, safeLimit);
+  }
+
+  /**
+   * DB의 최근 7일 누적분에서 관리자가 숨긴(blocked) 영상을 제외한 서빙 목록.
+   * refresh()와 searchPopularVideos() 양쪽이 캐시를 만들 때 공통으로 쓰므로
+   * 캐시를 purge해도 숨김은 항상 다시 적용된다.
+   */
+  private async loadServingList(): Promise<YoutubeVideoItem[]> {
+    const items =
+      await this.streamersRepo.findRecentVideos(POPULAR_WINDOW_DAYS);
+    const blocked = await this.getBlockedIds();
+    if (blocked.size === 0) return items;
+    return items.filter((v) => !blocked.has(v.videoId));
+  }
+
+  /** 관리자가 숨긴 videoId 집합 */
+  private async getBlockedIds(): Promise<Set<string>> {
+    try {
+      const ids = await this.youtubeRedis.smembers(BLOCKED_KEY);
+      return new Set(ids);
+    } catch (error: unknown) {
+      this.logger.debug(`숨김 목록 조회 실패(무시): ${toErrorMessage(error)}`);
+      return new Set();
+    }
+  }
+
+  /** 영상을 숨김 목록에 추가하고 서빙 캐시를 비워 즉시 반영 */
+  async blockVideo(videoId: string): Promise<void> {
+    await this.youtubeRedis.sadd(BLOCKED_KEY, videoId);
+    await this.youtubeRedis.del(POPULAR_CACHE_KEY).catch(() => {});
+    this.logger.log(`YouTube 영상 숨김: ${videoId}`);
+  }
+
+  /** 영상을 숨김 목록에서 제거(복원)하고 서빙 캐시를 비움 */
+  async unblockVideo(videoId: string): Promise<void> {
+    await this.youtubeRedis.srem(BLOCKED_KEY, videoId);
+    await this.youtubeRedis.del(POPULAR_CACHE_KEY).catch(() => {});
+    this.logger.log(`YouTube 영상 숨김 해제: ${videoId}`);
+  }
+
+  /** 숨김 목록(videoId 배열) */
+  async listBlocked(): Promise<string[]> {
+    return this.getBlockedIds().then((s) => [...s]);
   }
 
   /** DB의 최근 7일 영상 목록을 popular 읽기 캐시에 저장 */


### PR DESCRIPTION
@
admin → main. PR #304(유튜브 숨김 관리)를 main에 반영.

## 변경
- **admin↔홈 동기화**: admin `load()` 캐시버스터로 CDN 우회(항상 최신), "캐시 새로고침"이 목록도 재로드.
- **영상 숨김(삭제) 관리**: youtube Redis Set `youtube:blocked` 기반. 서빙 공통 경로 `loadServingList()`가 항상 제외 → 캐시 purge·크론 재수집에도 안 되살아남(영상은 7일 뒤 자연 탈락). `AdminYoutubeController`(block/unblock/blocked, AdminWriteGuard) + Next 프록시 라우트. admin 페이지에 삭제 버튼 + "숨김 N" 토글(목록/복원).
- **리뷰 반영(#304)**: readonly 가드, 서비스 에러→BadRequest, 프론트 실패 alert.

## 배포
**마이그레이션 없음**(Redis Set만 사용). main 머지 후 Main Post Merge 자동 배포만 되면 끝.

## 검증
서버 39 / 클라 58 테스트 통과, tsc·eslint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@