### PR TITLE
fix(youtube): 삭제 명칭 정리 + 홈 반영 지연 단축

### DIFF
--- a/client/app/admin/youtube/page.tsx
+++ b/client/app/admin/youtube/page.tsx
@@ -180,8 +180,8 @@ export default function AdminYoutubePage() {
   }, []);
 
   async function handleBlock(videoId: string, title: string) {
-    if (!requireMaster("영상 숨김")) return;
-    if (!window.confirm(`이 영상을 인기 목록에서 숨길까요?\n\n${title}`)) return;
+    if (!requireMaster("영상 삭제")) return;
+    if (!window.confirm(`이 영상을 인기 목록에서 삭제할까요?\n\n${title}`)) return;
     setBusyId(videoId);
     try {
       const res = await fetch("/api/admin/youtube/block", {
@@ -195,7 +195,7 @@ export default function AdminYoutubePage() {
           prev.includes(videoId) ? prev : [...prev, videoId],
         );
       } else {
-        alert("영상 숨김 처리에 실패했습니다.");
+        alert("영상 삭제에 실패했습니다.");
       }
     } catch {
       alert("네트워크 오류가 발생했습니다.");
@@ -205,7 +205,7 @@ export default function AdminYoutubePage() {
   }
 
   async function handleUnblock(videoId: string) {
-    if (!requireMaster("숨김 해제")) return;
+    if (!requireMaster("삭제 되돌리기")) return;
     setBusyId(videoId);
     try {
       const res = await fetch("/api/admin/youtube/unblock", {
@@ -215,9 +215,9 @@ export default function AdminYoutubePage() {
       });
       if (res.ok) {
         setBlockedIds((prev) => prev.filter((id) => id !== videoId));
-        await load(); // 복원된 영상이 목록에 다시 나타나도록 갱신
+        await load(); // 되돌린 영상이 목록에 다시 나타나도록 갱신
       } else {
-        alert("숨김 해제에 실패했습니다.");
+        alert("되돌리기에 실패했습니다.");
       }
     } catch {
       alert("네트워크 오류가 발생했습니다.");
@@ -342,7 +342,7 @@ export default function AdminYoutubePage() {
             onClick={() => setShowBlocked((v) => !v)}
             className="admin-btn admin-btn-secondary"
           >
-            숨김 {blockedIds.length}
+            삭제됨 {blockedIds.length}
           </button>
           <button
             onClick={handlePurge}
@@ -378,15 +378,15 @@ export default function AdminYoutubePage() {
         </div>
       </div>
 
-      {/* 숨김 관리 패널 */}
+      {/* 삭제 관리 패널 */}
       {showBlocked && (
         <div className="admin-card admin-card-padded mb-4 shrink-0">
           <p className="text-xs font-semibold text-[color:var(--admin-text-muted)] mb-2 uppercase tracking-wide">
-            숨긴 영상 ({blockedIds.length})
+            삭제한 영상 ({blockedIds.length})
           </p>
           {blockedIds.length === 0 ? (
             <p className="text-xs text-[color:var(--admin-text-subtle)]">
-              숨긴 영상이 없습니다.
+              삭제한 영상이 없습니다.
             </p>
           ) : (
             <ul className="flex flex-col gap-1 max-h-40 overflow-y-auto">
@@ -405,7 +405,7 @@ export default function AdminYoutubePage() {
                     disabled={busyId === id}
                     className="admin-btn admin-btn-sm admin-btn-secondary shrink-0"
                   >
-                    복원
+                    되돌리기
                   </button>
                 </li>
               ))}
@@ -470,7 +470,7 @@ export default function AdminYoutubePage() {
                     <button
                       onClick={() => void handleBlock(v.videoId, v.title)}
                       disabled={busyId === v.videoId}
-                      title="목록에서 숨기기"
+                      title="목록에서 삭제"
                       className="admin-btn admin-btn-sm admin-btn-secondary mr-3 shrink-0 text-red-600 disabled:opacity-50"
                     >
                       {busyId === v.videoId ? "..." : "삭제"}

--- a/client/components/youtube/YoutubeSection.tsx
+++ b/client/components/youtube/YoutubeSection.tsx
@@ -5,7 +5,8 @@ const API = process.env.NEST_API_URL ?? "http://localhost:3001";
 
 export default async function YoutubeSection() {
   const data = await fetch(`${API}/api/streamers/popular?offset=0&limit=8`, {
-    next: { revalidate: 3600 },
+    // 5분(홈 라우트 ISR과 동일) — 관리자 삭제가 홈에 빨리 반영되도록.
+    next: { revalidate: 300 },
   })
     .then<{
       items: YoutubeVideo[];

--- a/server/src/streamers/streamers.controller.ts
+++ b/server/src/streamers/streamers.controller.ts
@@ -19,9 +19,11 @@ export class StreamersController {
    * 로스트아크 최근 7일 동영상 게시일순 (Redis 4시간 캐시)
    */
   @Get('popular')
-  // s-maxage 5분 — 관리자 삭제(숨김)가 홈/CDN에 빨리 반영되도록.
+  // s-maxage 5분 — 관리자 삭제가 홈/CDN에 빨리 반영되도록.
+  // stale-while-revalidate는 제외: 만료 후 stale 응답이 다시 캐싱돼 반영이
+  // 최대 2배 지연될 수 있고, 오리진이 Redis 캐시라 블로킹 재검증 비용도 미미.
   // admin은 캐시버스터로 즉시 갱신되므로 영향 없음.
-  @Header('Cache-Control', 'public, s-maxage=300, stale-while-revalidate=300')
+  @Header('Cache-Control', 'public, s-maxage=300')
   searchPopular(
     @Query('offset') offsetRaw?: string,
     @Query('limit') limitRaw?: string,

--- a/server/src/streamers/streamers.controller.ts
+++ b/server/src/streamers/streamers.controller.ts
@@ -19,7 +19,9 @@ export class StreamersController {
    * 로스트아크 최근 7일 동영상 게시일순 (Redis 4시간 캐시)
    */
   @Get('popular')
-  @Header('Cache-Control', 'public, s-maxage=3600, stale-while-revalidate=300')
+  // s-maxage 5분 — 관리자 삭제(숨김)가 홈/CDN에 빨리 반영되도록.
+  // admin은 캐시버스터로 즉시 갱신되므로 영향 없음.
+  @Header('Cache-Control', 'public, s-maxage=300, stale-while-revalidate=300')
   searchPopular(
     @Query('offset') offsetRaw?: string,
     @Query('limit') limitRaw?: string,


### PR DESCRIPTION
@
admin 유튜브 "삭제"가 "숨김"으로 표기돼 혼란스럽고, 삭제가 홈에 늦게 반영되던 문제. (base=admin)

## 배경
삭제는 **서버에서 정상 작동 중**(라이브 확인: 차단한 영상이 서빙 목록에서 빠짐). 다만:
- admin은 캐시버스터로 즉시 갱신되는데, **홈은 CDN+Next 캐시(최대 1시간)**라 늦게 반영 → "삭제했는데 (홈에서) 다시 뜬다"로 보였음.

## 변경
- **명칭 정리**: admin "숨김/복원" → "삭제/되돌리기" (확인창·헤더 버튼·패널·alert·tooltip). 메커니즘은 그대로 블록리스트 — DB row를 진짜 지우면 크론이 재수집해 되살아나므로 블록 방식이 "삭제 유지"의 핵심.
- **홈 반영 단축**: popular `s-maxage` 3600→300, `YoutubeSection` fetch revalidate 3600→300 (홈 라우트 ISR 300과 동일). 이제 홈도 ~5분 내 반영. admin은 캐시버스터라 영향 없음.

## 검증
서버 tsc/eslint green, 클라 tsc/eslint green. 마이그레이션 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@