### PR TITLE
fix(youtube): popular Next 라우트 stale 캐시로 삭제가 admin에 반영 안 되던 것 수정

### DIFF
--- a/client/app/api/streamers/popular/route.ts
+++ b/client/app/api/streamers/popular/route.ts
@@ -6,12 +6,17 @@ export async function GET(req: NextRequest) {
   const { searchParams } = req.nextUrl;
   const offset = searchParams.get("offset") ?? "0";
   const limit = searchParams.get("limit") ?? "0";
+  // 캐시버스터(_): 관리자 화면이 삭제를 즉시 반영하려고 붙이는 값.
+  // 이게 있으면 이 라우트의 Next Data Cache까지 우회해 오리진 최신을 받는다.
+  // (없으면 Vercel 엣지는 뚫려도 라우트 내부 캐시가 stale을 돌려줘 삭제가 안 보임)
+  const fresh = searchParams.has("_");
 
   const upstream = `${NEST_API}/api/streamers/popular?offset=${offset}&limit=${limit}`;
 
-  const res = await fetch(upstream, {
-    next: { revalidate: 3600 },
-  });
+  const res = await fetch(
+    upstream,
+    fresh ? { cache: "no-store" } : { next: { revalidate: 300 } },
+  );
 
   if (!res.ok) {
     return NextResponse.json(
@@ -23,7 +28,7 @@ export async function GET(req: NextRequest) {
   const data: unknown = await res.json();
   return NextResponse.json(data, {
     headers: {
-      "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=300",
+      "Cache-Control": fresh ? "no-store" : "public, s-maxage=300",
     },
   });
 }


### PR DESCRIPTION
@
"삭제했는데 admin 목록에 계속 뜬다"의 **진짜 원인**. (base=admin)

## 원인
`client/app/api/streamers/popular/route.ts`(Next API 라우트)가 업스트림을 `next.revalidate=3600`으로 캐싱하는데, admin이 붙이는 캐시버스터 `_`를 업스트림에 반영하지 않음. 그래서:
- Vercel 엣지는 버스터로 MISS(우회)돼도, **이 라우트 내부 Data Cache(1시간)는 우회 안 됨** → 차단 전 stale 응답(삭제 영상 포함)을 최대 1시간 동안 그대로 반환.
- Nest 직결(api.lomoa.kr)은 정상 필터(삭제 영상 없음) → 두 경로 결과가 달랐던 이유.

실측: 같은 시각 api.lomoa.kr=53개(삭제영상 없음) vs www(이 라우트)=54개(삭제영상 있음), 둘 다 fresh(MISS).

## 수정
- 캐시버스터(`_`) 있으면 업스트림 `cache:no-store` + 응답 `no-store` → admin은 항상 오리진 최신(필터 적용본).
- 없으면 revalidate 3600→300, s-maxage 3600→300(SWR 제거) → 홈 무한스크롤 청크도 ~5분 내 반영.

## 검증
서버 정상 확인(블록 set/캐시/라이브 모두 삭제영상 제외). 클라 tsc·eslint green. 마이그레이션 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@