### PR TITLE
fix(youtube): popular Next 라우트 stale 캐시로 삭제가 admin에 반영 안 되던 것 수정

### DIFF
--- a/client/app/api/streamers/popular/route.ts
+++ b/client/app/api/streamers/popular/route.ts
@@ -6,12 +6,17 @@ export async function GET(req: NextRequest) {
   const { searchParams } = req.nextUrl;
   const offset = searchParams.get("offset") ?? "0";
   const limit = searchParams.get("limit") ?? "0";
+  // 캐시버스터(_): 관리자 화면이 삭제를 즉시 반영하려고 붙이는 값.
+  // 이게 있으면 이 라우트의 Next Data Cache까지 우회해 오리진 최신을 받는다.
+  // (없으면 Vercel 엣지는 뚫려도 라우트 내부 캐시가 stale을 돌려줘 삭제가 안 보임)
+  const fresh = searchParams.has("_");
 
   const upstream = `${NEST_API}/api/streamers/popular?offset=${offset}&limit=${limit}`;
 
-  const res = await fetch(upstream, {
-    next: { revalidate: 3600 },
-  });
+  const res = await fetch(
+    upstream,
+    fresh ? { cache: "no-store" } : { next: { revalidate: 300 } },
+  );
 
   if (!res.ok) {
     return NextResponse.json(
@@ -23,7 +28,7 @@ export async function GET(req: NextRequest) {
   const data: unknown = await res.json();
   return NextResponse.json(data, {
     headers: {
-      "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=300",
+      "Cache-Control": fresh ? "no-store" : "public, s-maxage=300",
     },
   });
 }


### PR DESCRIPTION
@
admin → main. PR #308 반영.

## 원인
`client/app/api/streamers/popular` Next 라우트가 업스트림을 `revalidate=3600`으로 캐싱하면서 admin의 캐시버스터 `_`를 업스트림에 안 넘겨, 라우트 내부 Data Cache(1시간)가 우회되지 않음 → admin이 삭제 후에도 stale 목록(삭제영상 포함)을 최대 1시간 수신. (Nest 직결은 정상 필터)

## 수정
- 캐시버스터 있으면 업스트림 `no-store` → admin 항상 최신(필터본).
- 없으면 revalidate/s-maxage 3600→300(SWR 제거) → 홈 스크롤 청크도 ~5분 내 반영.

## 배포
마이그레이션 없음. main 머지 후 Vercel/Main Post Merge 자동 배포만 되면 끝.

## 검증
운영 Redis/캐시/라이브 모두 서버는 정상 필터 확인. 클라 tsc·eslint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@