### PR TITLE
모니터링 일별 방문 추이 정상화 및 대시보드 조회 최적화

### DIFF
--- a/server/src/admin/admin-monitoring.service.ts
+++ b/server/src/admin/admin-monitoring.service.ts
@@ -268,32 +268,33 @@ export class AdminMonitoringService implements OnModuleInit {
             : safeRangeDays === 10
               ? 12
               : 30;
-    const summary = await this.monitoringRepo.findSummary(
-      this.SLOW_THRESHOLD_MS,
-    );
-
-    const siteClickSeriesRows =
-      await this.monitoringRepo.findSiteClickSeriesDays(14);
-
-    const youtubeClickSeriesRows =
-      await this.monitoringRepo.findYoutubeClickSeriesDays(14);
-
-    const sectionSeries = await this.monitoringRepo.findSectionSeries(
-      bucketHours,
-      safeRangeDays,
-    );
-
-    const visitRows = await this.monitoringRepo.findPageVisits();
-    const countryRows = await this.monitoringRepo.findCountryVisits();
-    const osRows = await this.monitoringRepo.findOsVisits();
-    const browserRows = await this.monitoringRepo.findBrowserVisits();
-
-    const siteClickRows = await this.monitoringRepo.findSiteClicks();
     const safePvDays = Math.max(1, Math.min(30, Math.trunc(pvDays)));
-    const [pageVisitSeriesRows, youtubeClickTotal] = await Promise.all([
+    // 서로 의존 없는 조회들은 병렬로(Promise.all) 실행 → 대시보드 로딩 = 가장 느린 1개 수준.
+    const [
+      summary,
+      siteClickSeriesRows,
+      youtubeClickSeriesRows,
+      sectionSeries,
+      visitRows,
+      dimensionRows,
+      siteClickRows,
+      pageVisitSeriesRows,
+      youtubeClickTotal,
+    ] = await Promise.all([
+      this.monitoringRepo.findSummary(this.SLOW_THRESHOLD_MS),
+      this.monitoringRepo.findSiteClickSeriesDays(14),
+      this.monitoringRepo.findYoutubeClickSeriesDays(14),
+      this.monitoringRepo.findSectionSeries(bucketHours, safeRangeDays),
+      this.monitoringRepo.findPageVisits(),
+      this.monitoringRepo.findDimensionVisits(),
+      this.monitoringRepo.findSiteClicks(),
       this.monitoringRepo.findPageVisitSeriesDays(safePvDays),
       this.monitoringRepo.findYoutubeClickTotal(),
     ]);
+    // 한 번의 왕복으로 받은 차원 데이터를 국가/OS/브라우저로 분리.
+    const countryRows = dimensionRows.filter((r) => r.dim === 'country');
+    const osRows = dimensionRows.filter((r) => r.dim === 'os');
+    const browserRows = dimensionRows.filter((r) => r.dim === 'browser');
 
     return {
       summary: {

--- a/server/src/admin/repositories/monitoring.repository.ts
+++ b/server/src/admin/repositories/monitoring.repository.ts
@@ -33,6 +33,12 @@ export interface DimensionRow {
   count: bigint | number;
 }
 
+export type VisitDimension = 'country' | 'os' | 'browser';
+
+export interface DimensionVisitRow extends DimensionRow {
+  dim: VisitDimension;
+}
+
 export interface SiteClickRow {
   site_name: string;
   site_href: string;
@@ -129,6 +135,21 @@ export class MonitoringRepository {
         created_at TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
         CONSTRAINT uk_page_device_country_os_browser_day UNIQUE (path, device_type, country_code, os_name, browser_name, visit_day)
       )
+    `;
+    // 일별 방문 추이 뷰: apm_page_visits를 visit_day로 합산해 날짜별 집계를 바로 조회(pgAdmin 등).
+    // 별도 저장/동기화 없이 항상 최신. SELECT * FROM apm_page_visit_daily;
+    await this.prisma.$executeRaw`
+      CREATE OR REPLACE VIEW apm_page_visit_daily AS
+      SELECT visit_day,
+             SUM(visits)                                        AS total,
+             SUM(visits) FILTER (WHERE device_type = 'desktop') AS desktop,
+             SUM(visits) FILTER (WHERE device_type = 'mobile')  AS mobile,
+             SUM(visits) FILTER (WHERE device_type = 'tablet')  AS tablet,
+             SUM(visits) FILTER (WHERE device_type = 'bot')     AS bot,
+             COUNT(*)                                           AS rows
+      FROM apm_page_visits
+      GROUP BY visit_day
+      ORDER BY visit_day DESC
     `;
     await this.prisma.$executeRaw`
       CREATE TABLE IF NOT EXISTS apm_request_timings (
@@ -443,20 +464,21 @@ export class MonitoringRepository {
   }
 
   async findPageVisitSeriesDays(days: number) {
-    // visit_day(방문 날짜)별 visits 합 = 그날 실제 방문 횟수. generate_series로 빈 날도 0.
-    // 일자 경계는 한국시간(Asia/Seoul) 기준 — DB 서버 타임존(프로덕션=UTC)과 무관하게 '오늘'까지 표시.
+    // 일별 방문 추이: 날짜축(generate_series)에 apm_page_visit_daily 뷰를 LEFT JOIN.
+    //   - 합계는 뷰(visit_day별 visits 합)에서 와서 pgAdmin 값과 일치.
+    //   - 방문 0인 날(오늘 포함)도 COALESCE로 0을 채워 그래프가 끊기지 않음.
+    //   - 일자 경계는 한국시간(Asia/Seoul) 기준 — 최근 days일까지.
     return this.prisma.$queryRaw<
       Array<{ bucket: string; count: bigint | number }>
     >`
       SELECT TO_CHAR(d.day, 'MM-DD') AS bucket,
-             COALESCE(SUM(p.visits), 0) AS count
+             COALESCE(v.total, 0) AS count
       FROM generate_series(
              ((NOW() AT TIME ZONE 'Asia/Seoul')::date - ((${days}::int - 1) * INTERVAL '1 day'))::date,
              (NOW() AT TIME ZONE 'Asia/Seoul')::date,
              INTERVAL '1 day'
            ) AS d(day)
-      LEFT JOIN apm_page_visits p ON p.visit_day = d.day
-      GROUP BY d.day
+      LEFT JOIN apm_page_visit_daily v ON v.visit_day = d.day
       ORDER BY d.day ASC
     `;
   }
@@ -555,16 +577,32 @@ export class MonitoringRepository {
     `;
   }
 
-  async findCountryVisits() {
-    return this.findDimensionRows('country_code');
-  }
-
-  async findOsVisits() {
-    return this.findDimensionRows('os_name');
-  }
-
-  async findBrowserVisits() {
-    return this.findDimensionRows('browser_name');
+  /**
+   * 국가/OS/브라우저별 방문 합계(각 차원 상위 20)를 한 번의 왕복으로 조회.
+   * 세 차원을 UNION ALL로 모으고 차원별 ROW_NUMBER로 상위 20만 남김 — 집계는 DB가 수행.
+   */
+  async findDimensionVisits(): Promise<DimensionVisitRow[]> {
+    return this.prisma.$queryRaw<DimensionVisitRow[]>`
+      WITH agg AS (
+        SELECT 'country' AS dim, country_code AS name, SUM(visits) AS count
+        FROM apm_page_visits GROUP BY country_code
+        UNION ALL
+        SELECT 'os' AS dim, os_name AS name, SUM(visits) AS count
+        FROM apm_page_visits GROUP BY os_name
+        UNION ALL
+        SELECT 'browser' AS dim, browser_name AS name, SUM(visits) AS count
+        FROM apm_page_visits GROUP BY browser_name
+      ),
+      ranked AS (
+        SELECT dim, name, count,
+               ROW_NUMBER() OVER (PARTITION BY dim ORDER BY count DESC) AS rn
+        FROM agg
+      )
+      SELECT dim, name, count
+      FROM ranked
+      WHERE rn <= 20
+      ORDER BY dim, count DESC
+    `;
   }
 
   async findYoutubeClickTotal(): Promise<number> {
@@ -786,20 +824,6 @@ export class MonitoringRepository {
       chunkSize,
     );
     return deleted.length;
-  }
-
-  private async findDimensionRows(
-    columnName: 'country_code' | 'os_name' | 'browser_name',
-  ) {
-    return this.prisma.$queryRawUnsafe<DimensionRow[]>(
-      `
-      SELECT ${columnName} AS name, SUM(visits) AS count
-      FROM apm_page_visits
-      GROUP BY ${columnName}
-      ORDER BY count DESC
-      LIMIT 20
-      `,
-    );
   }
 
   private async deleteRequestTimingRowsOlderThan(

--- a/server/src/admin/repositories/monitoring.repository.ts
+++ b/server/src/admin/repositories/monitoring.repository.ts
@@ -138,8 +138,11 @@ export class MonitoringRepository {
     `;
     // 일별 방문 추이 뷰: apm_page_visits를 visit_day로 합산해 날짜별 집계를 바로 조회(pgAdmin 등).
     // 별도 저장/동기화 없이 항상 최신. SELECT * FROM apm_page_visit_daily;
+    // 컬럼 구성이 바뀌어도 startup이 깨지지 않도록 DROP 후 재생성
+    // (CREATE OR REPLACE VIEW는 컬럼 추가/삭제/순서변경 시 에러로 기동 실패할 수 있음).
+    await this.prisma.$executeRaw`DROP VIEW IF EXISTS apm_page_visit_daily`;
     await this.prisma.$executeRaw`
-      CREATE OR REPLACE VIEW apm_page_visit_daily AS
+      CREATE VIEW apm_page_visit_daily AS
       SELECT visit_day,
              SUM(visits)                                        AS total,
              SUM(visits) FILTER (WHERE device_type = 'desktop') AS desktop,
@@ -464,21 +467,23 @@ export class MonitoringRepository {
   }
 
   async findPageVisitSeriesDays(days: number) {
-    // 일별 방문 추이: 날짜축(generate_series)에 apm_page_visit_daily 뷰를 LEFT JOIN.
-    //   - 합계는 뷰(visit_day별 visits 합)에서 와서 pgAdmin 값과 일치.
+    // 일별 방문 추이: 날짜축(generate_series)에 apm_page_visits를 직접 LEFT JOIN + GROUP BY.
+    //   - 최근 days 기간의 행만 조인/집계 → 뷰 전체 집계(풀스캔) 회피, 테이블이 커져도 효율적.
+    //   - 값은 SUM(visits)로 pgAdmin 뷰(apm_page_visit_daily)와 동일.
     //   - 방문 0인 날(오늘 포함)도 COALESCE로 0을 채워 그래프가 끊기지 않음.
     //   - 일자 경계는 한국시간(Asia/Seoul) 기준 — 최근 days일까지.
     return this.prisma.$queryRaw<
       Array<{ bucket: string; count: bigint | number }>
     >`
       SELECT TO_CHAR(d.day, 'MM-DD') AS bucket,
-             COALESCE(v.total, 0) AS count
+             COALESCE(SUM(p.visits), 0) AS count
       FROM generate_series(
              ((NOW() AT TIME ZONE 'Asia/Seoul')::date - ((${days}::int - 1) * INTERVAL '1 day'))::date,
              (NOW() AT TIME ZONE 'Asia/Seoul')::date,
              INTERVAL '1 day'
            ) AS d(day)
-      LEFT JOIN apm_page_visit_daily v ON v.visit_day = d.day
+      LEFT JOIN apm_page_visits p ON p.visit_day = d.day
+      GROUP BY d.day
       ORDER BY d.day ASC
     `;
   }
@@ -579,19 +584,26 @@ export class MonitoringRepository {
 
   /**
    * 국가/OS/브라우저별 방문 합계(각 차원 상위 20)를 한 번의 왕복으로 조회.
-   * 세 차원을 UNION ALL로 모으고 차원별 ROW_NUMBER로 상위 20만 남김 — 집계는 DB가 수행.
+   * GROUPING SETS로 테이블을 단 한 번만 스캔해 세 차원을 동시 집계하고,
+   * 차원별 ROW_NUMBER로 상위 20만 남김 — 집계는 DB가 수행. (해당 컬럼들은 NOT NULL이라 GROUPING() 판별이 안전)
    */
   async findDimensionVisits(): Promise<DimensionVisitRow[]> {
     return this.prisma.$queryRaw<DimensionVisitRow[]>`
       WITH agg AS (
-        SELECT 'country' AS dim, country_code AS name, SUM(visits) AS count
-        FROM apm_page_visits GROUP BY country_code
-        UNION ALL
-        SELECT 'os' AS dim, os_name AS name, SUM(visits) AS count
-        FROM apm_page_visits GROUP BY os_name
-        UNION ALL
-        SELECT 'browser' AS dim, browser_name AS name, SUM(visits) AS count
-        FROM apm_page_visits GROUP BY browser_name
+        SELECT
+          CASE
+            WHEN GROUPING(country_code) = 0 THEN 'country'
+            WHEN GROUPING(os_name) = 0 THEN 'os'
+            ELSE 'browser'
+          END AS dim,
+          CASE
+            WHEN GROUPING(country_code) = 0 THEN country_code
+            WHEN GROUPING(os_name) = 0 THEN os_name
+            ELSE browser_name
+          END AS name,
+          SUM(visits) AS count
+        FROM apm_page_visits
+        GROUP BY GROUPING SETS ((country_code), (os_name), (browser_name))
       ),
       ranked AS (
         SELECT dim, name, count,


### PR DESCRIPTION
일별 방문 추이가 마이그레이션(visit_day) 이전 누적 잔재로 특정 날짜에 비정상 표시되던 문제를 바로잡고, 대시보드 조회를 최적화합니다.

- 일별 방문 추이 뷰(`apm_page_visit_daily`) 도입 — pgAdmin/대시보드 공용, startup 시 안전 재생성
- 추이 조회를 날짜축 + 직접 집계 방식으로 정리(빈 날 0 채우기 유지), 잔재 행은 운영/로컬 DB에서 정리 완료
- 국가/OS/브라우저 조회를 GROUPING SETS 단일 쿼리로 통합하고 getDashboard를 병렬화(Promise.all)해 로딩 최적화