### PR TITLE
fix(monitoring): 프로브 타임아웃·실패기록 + 섹션 쿼리 인덱스 활용

### DIFF
--- a/server/src/admin/admin-monitoring.service.ts
+++ b/server/src/admin/admin-monitoring.service.ts
@@ -177,13 +177,28 @@ export class AdminMonitoringService implements OnModuleInit {
     const base =
       process.env.MONITORING_PROBE_BASE_URL ??
       `http://127.0.0.1:${process.env.PORT ?? 3001}`;
-    // 핵심 경로를 주기적으로 호출만 한다. 응답시간/상태코드는 전역 미들웨어가
-    // apm_request_timings에 기록하므로 여기서 따로 저장하지 않는다(이중 기록 제거).
+    // 핵심 경로를 주기적으로 호출. 성공하면 응답시간/상태코드는 전역 미들웨어가
+    // apm_request_timings에 기록한다(이중 기록 제거). 단 fetch 자체가 실패(네트워크/타임아웃)하면
+    // 미들웨어가 돌지 않으므로, 장애가 누락되지 않도록 여기서 실패(status 0)를 직접 기록한다.
     for (const path of this.probeTargets) {
+      const started = process.hrtime.bigint();
       try {
-        await fetch(`${base}${path}`, { method: 'GET', cache: 'no-store' });
+        await fetch(`${base}${path}`, {
+          method: 'GET',
+          cache: 'no-store',
+          signal: AbortSignal.timeout(5000),
+        });
       } catch {
-        // 실패해도 무시 — 미들웨어가 상태코드까지 기록함
+        const durationMs = Number(process.hrtime.bigint() - started) / 1_000_000;
+        const name = path.split('?')[0]; // 미들웨어 기록과 동일하게 쿼리스트링 제거
+        void this.recordRequest({
+          scope: 'route',
+          name,
+          path: name,
+          method: 'GET',
+          statusCode: 0,
+          durationMs,
+        }).catch(() => undefined);
       }
     }
   }

--- a/server/src/admin/admin-monitoring.service.ts
+++ b/server/src/admin/admin-monitoring.service.ts
@@ -177,30 +177,33 @@ export class AdminMonitoringService implements OnModuleInit {
     const base =
       process.env.MONITORING_PROBE_BASE_URL ??
       `http://127.0.0.1:${process.env.PORT ?? 3001}`;
-    // 핵심 경로를 주기적으로 호출. 성공하면 응답시간/상태코드는 전역 미들웨어가
+    // 핵심 경로를 병렬 호출. 성공하면 응답시간/상태코드는 전역 미들웨어가
     // apm_request_timings에 기록한다(이중 기록 제거). 단 fetch 자체가 실패(네트워크/타임아웃)하면
-    // 미들웨어가 돌지 않으므로, 장애가 누락되지 않도록 여기서 실패(status 0)를 직접 기록한다.
-    for (const path of this.probeTargets) {
-      const started = process.hrtime.bigint();
-      try {
-        await fetch(`${base}${path}`, {
-          method: 'GET',
-          cache: 'no-store',
-          signal: AbortSignal.timeout(5000),
-        });
-      } catch {
-        const durationMs = Number(process.hrtime.bigint() - started) / 1_000_000;
-        const name = path.split('?')[0]; // 미들웨어 기록과 동일하게 쿼리스트링 제거
-        void this.recordRequest({
-          scope: 'route',
-          name,
-          path: name,
-          method: 'GET',
-          statusCode: 0,
-          durationMs,
-        }).catch(() => undefined);
-      }
-    }
+    // 미들웨어가 돌지 않으므로, 장애가 누락되지 않도록 catch에서 실패(status 0)를 직접 기록하고 완료까지 대기한다.
+    await Promise.all(
+      this.probeTargets.map(async (path) => {
+        const started = process.hrtime.bigint();
+        try {
+          await fetch(`${base}${path}`, {
+            method: 'GET',
+            cache: 'no-store',
+            signal: AbortSignal.timeout(5000),
+          });
+        } catch {
+          const durationMs =
+            Number(process.hrtime.bigint() - started) / 1_000_000;
+          const name = path.split('?')[0]; // 미들웨어 기록과 동일하게 쿼리스트링 제거
+          await this.recordRequest({
+            scope: 'route',
+            name,
+            path: name,
+            method: 'GET',
+            statusCode: 0,
+            durationMs,
+          }).catch(() => undefined);
+        }
+      }),
+    );
   }
 
   @Cron('0 0 3 * * *')

--- a/server/src/admin/repositories/monitoring.repository.ts
+++ b/server/src/admin/repositories/monitoring.repository.ts
@@ -500,7 +500,7 @@ export class MonitoringRepository {
           t.api_key,
           r.duration_ms
         FROM apm_request_timings r
-        JOIN targets t ON t.path = r.path
+        JOIN targets t ON t.path = r.name
         WHERE r.scope = 'route'
           AND r.created_at >= NOW() - (${rangeDays}::int * INTERVAL '1 day')
       ),


### PR DESCRIPTION
PR #316 코드리뷰(gemini, HIGH 2건) 반영.

- **probeApis 안정성**: `fetch`에 5초 타임아웃(`AbortSignal.timeout`) 추가 + fetch 자체 실패(네트워크/타임아웃) 시 미들웨어가 안 돌아 기록이 누락되던 문제를 catch에서 `status 0`으로 직접 기록 (장애 가시화 복원)
- **섹션 쿼리 최적화**: `findSectionSeries` JOIN을 `r.path → r.name`으로 변경 — `path`엔 인덱스가 없고 `(scope, name)` 복합 인덱스 존재. route 행은 `name=path`로 값이 동일(불일치 0건 검증)이라 결과 동일 + 인덱스 활용

## 검증
- `tsc --noEmit` 통과
- name-join이 path-join과 동일 결과 확인 (scope=route 행 name=path 불일치 0)