### PR TITLE
fix(monitoring): 컨테이너 자원 추세 그래프 KST 표기

### DIFF
--- a/server/src/admin/repositories/monitoring.repository.ts
+++ b/server/src/admin/repositories/monitoring.repository.ts
@@ -622,14 +622,15 @@ export class MonitoringRepository {
   ): Promise<ContainerHistoryRow[]> {
     const table = DOCKER_TABLE[container];
     return this.prisma.$queryRawUnsafe<ContainerHistoryRow[]>(
-      `SELECT TO_CHAR(DATE_TRUNC('hour', created_at), 'MM-DD HH24:MI') AS bucket,
+      // 버킷/라벨은 한국시간(KST) 기준 — 그래프 시각이 운영자 기준과 일치하도록.
+      `SELECT TO_CHAR(DATE_TRUNC('hour', created_at AT TIME ZONE 'Asia/Seoul'), 'MM-DD HH24:MI') AS bucket,
               ROUND(AVG(cpu_percent)::numeric, 2)::float AS avg_cpu,
               ROUND(AVG(mem_percent)::numeric, 2)::float AS avg_mem,
               ROUND(AVG(mem_used_mb))::int AS avg_mem_used_mb
        FROM ${table}
        WHERE created_at >= NOW() - ($1::int * INTERVAL '1 day')
-       GROUP BY DATE_TRUNC('hour', created_at)
-       ORDER BY DATE_TRUNC('hour', created_at) ASC`,
+       GROUP BY DATE_TRUNC('hour', created_at AT TIME ZONE 'Asia/Seoul')
+       ORDER BY DATE_TRUNC('hour', created_at AT TIME ZONE 'Asia/Seoul') ASC`,
       days,
     );
   }
@@ -819,7 +820,6 @@ export class MonitoringRepository {
     );
     return deleted.length;
   }
-
 }
 
 function sleep(ms: number) {


### PR DESCRIPTION
@
컨테이너 현황의 "자원 추세(7일)" 그래프 X축이 **UTC**로 표시되던 문제 수정. (base: `admin`)

## 문제
`findDockerMetricSeries`가 `DATE_TRUNC(hour, created_at)`를 타임존 변환 없이 써서 시간버킷이 UTC 기준 → 그래프상 "18:00"이 실제로는 03:00 KST였음. (이 때문에 "매일 18시 CPU 스파이크"로 오인 → 실제는 새벽 3시 inven 파이프라인)

## 수정
`AT TIME ZONE Asia/Seoul`로 버킷/정렬을 KST 기준으로 변환 (SELECT/GROUP BY/ORDER BY 3곳). `findContainerHourlyCpu`가 이미 쓰던 방식과 동일.

## 검증
- server `tsc --noEmit`·eslint 통과
- EC2 DB 시간대별 실측으로 교차검증: 03시(KST) avg CPU 60.5%가 최대 피크 = inven 크롤 파이프라인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@