### PR TITLE
fix(monitoring): 컨테이너 자원 추세 그래프 KST 표기 (admin → main)

### DIFF
--- a/server/src/admin/repositories/monitoring.repository.ts
+++ b/server/src/admin/repositories/monitoring.repository.ts
@@ -622,14 +622,15 @@ export class MonitoringRepository {
   ): Promise<ContainerHistoryRow[]> {
     const table = DOCKER_TABLE[container];
     return this.prisma.$queryRawUnsafe<ContainerHistoryRow[]>(
-      `SELECT TO_CHAR(DATE_TRUNC('hour', created_at), 'MM-DD HH24:MI') AS bucket,
+      // 버킷/라벨은 한국시간(KST) 기준 — 그래프 시각이 운영자 기준과 일치하도록.
+      `SELECT TO_CHAR(DATE_TRUNC('hour', created_at AT TIME ZONE 'Asia/Seoul'), 'MM-DD HH24:MI') AS bucket,
               ROUND(AVG(cpu_percent)::numeric, 2)::float AS avg_cpu,
               ROUND(AVG(mem_percent)::numeric, 2)::float AS avg_mem,
               ROUND(AVG(mem_used_mb))::int AS avg_mem_used_mb
        FROM ${table}
        WHERE created_at >= NOW() - ($1::int * INTERVAL '1 day')
-       GROUP BY DATE_TRUNC('hour', created_at)
-       ORDER BY DATE_TRUNC('hour', created_at) ASC`,
+       GROUP BY DATE_TRUNC('hour', created_at AT TIME ZONE 'Asia/Seoul')
+       ORDER BY DATE_TRUNC('hour', created_at AT TIME ZONE 'Asia/Seoul') ASC`,
       days,
     );
   }
@@ -819,7 +820,6 @@ export class MonitoringRepository {
     );
     return deleted.length;
   }
-
 }
 
 function sleep(ms: number) {


### PR DESCRIPTION
@
컨테이너 현황 "자원 추세(7일)" 그래프의 X축 시각을 UTC → KST로 수정. (#318)

## 변경
`findDockerMetricSeries`에서 `DATE_TRUNC(hour, created_at AT TIME ZONE Asia/Seoul)`로 버킷/정렬을 KST 기준 변환 (SELECT/GROUP BY/ORDER BY).

## 배경
그래프가 UTC로 라벨링돼 "18시 스파이크"로 오인되던 게 실제론 03시(KST) inven 크롤 배치였음. EC2 DB 시간대별 실측(03시 avg CPU 60.5%)으로 교차검증 완료.

## 검증
- server tsc·eslint 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@