### PR TITLE
feat(inven): 증분 크롤링 + 댓글 제거 (새벽 CPU 분산)

### DIFF
--- a/server/src/admin/admin-inven-cron.service.ts
+++ b/server/src/admin/admin-inven-cron.service.ts
@@ -8,10 +8,13 @@ export class AdminInvenCronService {
 
   constructor(private readonly pipeline: AdminInvenPipelineService) {}
 
-  /** 매일 새벽 3시(KST) 자동 실행 — 어제 날짜를 파이프라인 서비스에 위임 */
-  @Cron('0 3 * * *', { timeZone: 'Asia/Seoul' })
-  runNightlyPipeline() {
-    this.logger.log('야간 인벤 파이프라인 시작');
+  /**
+   * 2시간마다 증분 실행 — 마지막 크롤 이후의 새 글만 수집(부하 분산).
+   * targetDate 없이 run() → 파이프라인이 게시판별 최신 post_id 기준 증분 모드로 동작.
+   */
+  @Cron('0 */2 * * *', { timeZone: 'Asia/Seoul' })
+  runScheduledPipeline() {
+    this.logger.log('인벤 증분 파이프라인 시작');
     const result = this.pipeline.run();
     if (!result.started) {
       this.logger.warn(`파이프라인 건너뜀: ${result.reason}`);

--- a/server/src/admin/admin-inven-pipeline.service.ts
+++ b/server/src/admin/admin-inven-pipeline.service.ts
@@ -74,8 +74,8 @@ export class AdminInvenPipelineService {
       return { started: false, reason: '이미 실행 중입니다' };
     }
 
-    const date =
-      targetDate ?? new Date(Date.now() - 86400000).toISOString().slice(0, 10); // 어제
+    // targetDate 지정 → 날짜 백필(수동), 없으면 → 증분(post_id 기준) 모드(스케줄)
+    const date = targetDate ?? null;
 
     this.state = {
       running: true,
@@ -83,7 +83,9 @@ export class AdminInvenPipelineService {
       stepIndex: 0,
       totalSteps: STEPS.length,
       percent: 0,
-      message: '파이프라인 시작...',
+      message: date
+        ? `파이프라인 시작 (날짜 ${date})`
+        : '파이프라인 시작 (증분)',
       error: null,
       startedAt: new Date().toISOString(),
       finishedAt: null,
@@ -106,11 +108,12 @@ export class AdminInvenPipelineService {
     this.state.percent = Math.round((done / TOTAL_WEIGHT) * 100);
   }
 
-  private async runPipeline(date: string): Promise<void> {
+  private async runPipeline(date: string | null): Promise<void> {
+    const label = date ?? '증분';
     try {
       // 1) 크롤링 (Python — stdout JSON 수신, DB 미접근)
       this.setStep(0, '크롤링 진행 중...');
-      this.logger.log(`[크롤링] 시작 (${date})`);
+      this.logger.log(`[크롤링] 시작 (${label})`);
       const posts = await this.crawl(date);
       this.logger.log(`[크롤링] 완료 — 게시글 ${posts.length}개`);
 
@@ -133,9 +136,9 @@ export class AdminInvenPipelineService {
       this.state.running = false;
       this.state.step = 'done';
       this.state.percent = 100;
-      this.state.message = `완료 (${date}) — 게시글 ${savedCount}개, 추천 후보 ${candCount}개`;
+      this.state.message = `완료 (${label}) — 게시글 ${savedCount}개, 추천 후보 ${candCount}개`;
       this.state.finishedAt = new Date().toISOString();
-      this.logger.log(`파이프라인 완료 (${date})`);
+      this.logger.log(`파이프라인 완료 (${label})`);
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : '알 수 없는 오류';
       this.state.running = false;
@@ -147,18 +150,28 @@ export class AdminInvenPipelineService {
     }
   }
 
-  /** crawl.py 실행 → stdout JSON 파싱 → 게시글 배열 반환 */
-  private async crawl(date: string): Promise<CrawledPost[]> {
+  /**
+   * crawl.py 실행 → stdout JSON 파싱 → 게시글 배열 반환.
+   * date 지정 시 날짜 백필, 없으면 게시판별 최신 post_id 이후만 증분 크롤.
+   */
+  private async crawl(date: string | null): Promise<CrawledPost[]> {
     const scriptPath = join(SITE_FINDER_DIR, 'crawl.py');
-    const { stdout } = await execFileAsync(
-      PYTHON_BIN,
-      [scriptPath, '--date', date],
-      {
-        timeout: 60 * 60 * 1000, // 최대 1시간
-        maxBuffer: 256 * 1024 * 1024, // 256MB (수천 게시글 JSON 대비)
-        env: { ...process.env },
-      },
-    );
+    const args = [scriptPath];
+    if (date) {
+      args.push('--date', date);
+    } else {
+      const maxIds = await this.invenRepo.getMaxPostIdByBoard();
+      args.push('--since-free', String(maxIds.free ?? 0));
+      args.push('--since-tip', String(maxIds.tip ?? 0));
+      this.logger.log(
+        `[크롤링] 증분 기준 since free=${maxIds.free ?? 0} tip=${maxIds.tip ?? 0}`,
+      );
+    }
+    const { stdout } = await execFileAsync(PYTHON_BIN, args, {
+      timeout: 60 * 60 * 1000, // 최대 1시간
+      maxBuffer: 256 * 1024 * 1024, // 256MB (수천 게시글 JSON 대비)
+      env: { ...process.env },
+    });
     const parsed = JSON.parse(stdout) as {
       target_date: string;
       posts: CrawledPost[];

--- a/server/src/admin/repositories/admin-inven.repository.ts
+++ b/server/src/admin/repositories/admin-inven.repository.ts
@@ -36,13 +36,17 @@ export interface SiteCandidate {
 export class AdminInvenRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  /** 추천 사이트 후보 목록 (status별 필터). 기본은 검토 대기(pending). */
+  /**
+   * 추천 사이트 후보 목록 (status별 필터). 기본은 검토 대기(pending).
+   * 노출 임계값: 누적 언급 2회 이상만 (1회성 URL 노이즈 숨김 — 증분 누적과 짝).
+   */
   async getSiteCandidates(status = 'pending'): Promise<SiteCandidate[]> {
     return this.prisma.$queryRaw<SiteCandidate[]>`
       SELECT id, url, domain, name, description, category,
              mention_count, sample_post_id, status, created_at
       FROM inven_site_candidates
       WHERE status = ${status}
+        AND mention_count >= 2
       ORDER BY mention_count DESC, created_at DESC
     `;
   }

--- a/server/src/admin/repositories/admin-inven.repository.ts
+++ b/server/src/admin/repositories/admin-inven.repository.ts
@@ -94,7 +94,8 @@ export class AdminInvenRepository {
 
   /**
    * 크롤된 게시글을 inven_posts에 일괄 upsert한다.
-   * post_id 충돌 시 조회/추천/본문/댓글/제목을 최신값으로 갱신.
+   * post_id 충돌 시 조회/추천/본문/제목을 최신값으로 갱신.
+   * 댓글은 더 이상 수집하지 않음(본문만 사용) — comments는 빈 배열로 저장.
    */
   async upsertPosts(posts: CrawledPost[]): Promise<number> {
     let saved = 0;
@@ -105,22 +106,36 @@ export class AdminInvenRepository {
         VALUES (
           ${p.board}, ${p.post_id}, ${p.url}, ${p.title}, ${p.author},
           ${p.date_str}, ${p.views}, ${p.likes}, ${p.content},
-          ${JSON.stringify(p.comments ?? [])}::jsonb
+          '[]'::jsonb
         )
         ON CONFLICT (post_id) DO UPDATE SET
           views    = EXCLUDED.views,
           likes    = EXCLUDED.likes,
           content  = COALESCE(EXCLUDED.content, inven_posts.content),
-          comments = CASE
-                       WHEN jsonb_array_length(EXCLUDED.comments) > 0
-                       THEN EXCLUDED.comments
-                       ELSE inven_posts.comments
-                     END,
           title    = EXCLUDED.title
       `;
       saved += 1;
     }
     return saved;
+  }
+
+  /**
+   * 게시판별 최신 post_id(증분 크롤 기준). 데이터 없는 게시판은 0.
+   * post_id는 숫자 문자열이라 bigint로 캐스팅해 최대값을 구한다.
+   */
+  async getMaxPostIdByBoard(): Promise<Record<string, number>> {
+    const rows = await this.prisma.$queryRaw<
+      Array<{ board: string; max_id: bigint | number | null }>
+    >`
+      SELECT board, MAX(post_id::bigint) AS max_id
+      FROM inven_posts
+      GROUP BY board
+    `;
+    const result: Record<string, number> = {};
+    for (const r of rows) {
+      result[r.board] = r.max_id != null ? Number(r.max_id) : 0;
+    }
+    return result;
   }
 
   /**

--- a/server/src/admin/site-extractor.service.ts
+++ b/server/src/admin/site-extractor.service.ts
@@ -131,11 +131,8 @@ export class SiteExtractorService {
     >();
 
     for (const post of posts) {
-      const texts = [post.content ?? ''];
-      for (const c of post.comments ?? []) {
-        if (c && typeof c.text === 'string') texts.push(c.text);
-      }
-      const blob = texts.join(' ');
+      // 본문만 스캔 (댓글은 더 이상 수집하지 않음)
+      const blob = post.content ?? '';
       const matches = blob.match(URL_RE) ?? [];
 
       for (const match of matches) {

--- a/server/src/admin/site-extractor.service.ts
+++ b/server/src/admin/site-extractor.service.ts
@@ -67,7 +67,9 @@ const EXCLUDE_DOMAINS = new Set([
   'lostark.game.onstove.com',
 ]);
 
-const MIN_MENTIONS = 2; // 최소 언급 횟수 (1회만 언급된 건 노이즈로 제외)
+// 증분 크롤은 실행 배치가 작아(2시간치) 배치별 임계값을 두면 저빈도 사이트를 놓친다.
+// → extract는 1회 이상이면 후보로 만들어 누적시키고, 노출 임계값(누적 ≥2)은 조회 시점에 적용.
+const MIN_MENTIONS = 1;
 const URL_RE = /https?:\/\/[^\s"<>)\]}]+/g;
 
 // URL 끝의 구두점·괄호·zero-width space(U+200B) 제거.

--- a/site-finder/crawl.py
+++ b/site-finder/crawl.py
@@ -53,9 +53,23 @@ TARGET_DATE: date = (
     if _arg("--date")
     else date.today() - timedelta(days=1)
 )
-MAX_PAGES: int = 500  # 비상 안전장치 (실제로는 날짜 조건으로 먼저 중단)
+MAX_PAGES: int = 500  # 비상 안전장치 (실제로는 날짜/id 조건으로 먼저 중단)
 DEBUG: bool = "--debug" in sys.argv
 RUN_DATE: date = date.today()  # 스크립트 실행일 (date_str 파싱 기준)
+
+
+# 증분 모드: 게시판별 마지막 크롤 post_id(--since-free/--since-tip) 이후의 새 글만 수집.
+# --date가 주어지면 날짜 모드가 우선(수동 백필). 둘 다 없으면 날짜 모드(어제).
+def _since(flag: str) -> int | None:
+    v = _arg(flag)
+    return int(v) if v is not None and v.isdigit() else None
+
+
+SINCE: dict[str, int | None] = (
+    {"free": None, "tip": None}
+    if _arg("--date")
+    else {"free": _since("--since-free"), "tip": _since("--since-tip")}
+)
 
 # ── 설정 ─────────────────────────────────────────────────────────────────────
 
@@ -146,11 +160,14 @@ def _td(tr, *classes: str) -> str:
     return ""
 
 
-def parse_list_page(html: str, board_key: str) -> tuple[list[dict], bool]:
+def parse_list_page(
+    html: str, board_key: str, since_id: int | None = None
+) -> tuple[list[dict], bool]:
     """
     Returns:
         (posts, should_stop)
-        should_stop=True  → 이 페이지에 target_date보다 오래된 글만 남음, 페이지네이션 중단.
+        - 날짜 모드(since_id=None): target_date보다 오래된 글이 나오면 중단.
+        - 증분 모드(since_id 지정): post_id <= since_id(이미 크롤됨) 만나면 중단.
     """
     soup = BeautifulSoup(html, "lxml")
     board_id = BOARDS[board_key]["id"]
@@ -187,14 +204,20 @@ def parse_list_page(html: str, board_key: str) -> tuple[list[dict], bool]:
         date_str = _td(tr, "date")
         post_date = parse_post_date(date_str)
 
-        # 대상 날짜보다 오래된 글 → 페이지네이션 중단 신호
-        if post_date is not None and post_date < TARGET_DATE:
-            found_older = True
-            continue
-
-        # 오늘 글 (대상 날짜보다 최신) → 수집 안 함
-        if post_date is not None and post_date > TARGET_DATE:
-            continue
+        if since_id is not None:
+            # 증분 모드: 이미 크롤한 글(post_id <= since_id) → 중단 신호
+            if int(post_id) <= since_id:
+                found_older = True
+                continue
+            # post_id > since_id → 새 글, 수집
+        else:
+            # 날짜 모드: 대상 날짜보다 오래된 글 → 중단 신호
+            if post_date is not None and post_date < TARGET_DATE:
+                found_older = True
+                continue
+            # 오늘 글 (대상 날짜보다 최신) → 수집 안 함
+            if post_date is not None and post_date > TARGET_DATE:
+                continue
 
         url = href if href.startswith("http") else f"https:{href}"
         seen.add(post_id)
@@ -232,45 +255,6 @@ def parse_post_content(html: str) -> str:
     return content_el.get_text(separator="\n", strip=True)
 
 
-COMMENT_HEADERS = {
-    **HEADERS,
-    "Origin": "https://www.inven.co.kr",
-    "X-Requested-With": "XMLHttpRequest",
-}
-COMMENT_API = "https://www.inven.co.kr/common/board/comment.json.php"
-
-
-async def fetch_comments(session: AsyncSession, board_id: int, post_id: str) -> list[dict]:
-    """댓글 JSON API (POST) → [{name, text, date, recommend}] 반환."""
-    try:
-        resp = await session.post(
-            COMMENT_API,
-            data={"comeidx": str(board_id), "articlecode": post_id,
-                  "act": "list", "out": "json", "sortorder": "date", "page": "1"},
-            headers=COMMENT_HEADERS,
-            timeout=10,
-        )
-        d = resp.json()
-        if d.get("message") != 1:
-            return []
-        raw = d.get("commentlist", [{}])[0].get("list", [])
-        comments = []
-        for c in raw:
-            raw_html = c.get("o_comment", "").replace("&nbsp;", " ")
-            text = BeautifulSoup(raw_html, "lxml").get_text(" ", strip=True)
-            if text:
-                comments.append({
-                    "name": c.get("o_name", ""),
-                    "text": text,
-                    "date": c.get("o_date", ""),
-                    "recommend": int(c.get("o_recommend", 0) or 0),
-                })
-        return comments
-    except Exception as e:
-        log.debug(f"댓글 fetch 실패 ({post_id}): {e}")
-        return []
-
-
 # ── 크롤러 ───────────────────────────────────────────────────────────────────
 
 
@@ -281,13 +265,16 @@ async def fetch(session: AsyncSession, url: str) -> str:
     return resp.text
 
 
-async def crawl_board(session: AsyncSession, board_key: str) -> list[dict]:
+async def crawl_board(
+    session: AsyncSession, board_key: str, since_id: int | None = None
+) -> list[dict]:
     """
-    target_date보다 오래된 글이 처음 나오는 순간 중단.
-    오늘 글(너무 최신) → 스킵하고 계속, 어제 글 → 수집, 더 오래된 글 → 중단.
+    날짜 모드: target_date보다 오래된 글이 처음 나오는 순간 중단.
+    증분 모드(since_id): post_id <= since_id(이미 크롤됨)를 만나는 순간 중단.
     """
     board = BOARDS[board_key]
     collected: dict[str, dict] = {}
+    mode = f"since={since_id}" if since_id is not None else f"date={TARGET_DATE}"
 
     for page in range(1, MAX_PAGES + 1):
         url = f"{BASE}/{board['id']}" + (f"?p={page}" if page > 1 else "")
@@ -299,14 +286,14 @@ async def crawl_board(session: AsyncSession, board_key: str) -> list[dict]:
             log.error(f"페이지 fetch 실패: {e}")
             break
 
-        posts, should_stop = parse_list_page(html, board_key)
+        posts, should_stop = parse_list_page(html, board_key, since_id)
         for p in posts:
             collected[p["post_id"]] = p
 
-        log.info(f"  -> {TARGET_DATE} 게시글 {len(posts)}개 (누적 {len(collected)}, 중단={should_stop})")
+        log.info(f"  -> [{mode}] 게시글 {len(posts)}개 (누적 {len(collected)}, 중단={should_stop})")
 
         if should_stop:
-            log.info("  target_date 이전 글 도달 -> 페이지네이션 중단")
+            log.info("  중단 조건 도달(오래된/이미 크롤된 글) -> 페이지네이션 중단")
             break
 
         await asyncio.sleep(0.5)
@@ -315,22 +302,19 @@ async def crawl_board(session: AsyncSession, board_key: str) -> list[dict]:
 
 
 async def crawl_contents(session: AsyncSession, posts: list[dict]) -> None:
-    """수집된 게시글 전체의 상세 페이지를 순회해 본문과 댓글을 채운다."""
+    """수집된 게시글 전체의 상세 페이지를 순회해 본문을 채운다(댓글 미수집)."""
     targets = [p for p in posts if p["content"] is None]
-    log.info(f"본문+댓글 크롤링: {len(targets)}개 (전체)")
+    log.info(f"본문 크롤링: {len(targets)}개 (전체)")
 
     for i, post in enumerate(targets):
-        board_id = BOARDS[post["board"]]["id"]
         try:
             log.info(f"  [{i+1}/{len(targets)}] {post['title'][:40]}")
             html = await fetch(session, post["url"])
             post["content"] = parse_post_content(html)
-            post["comments"] = await fetch_comments(session, board_id, post["post_id"])
             await asyncio.sleep(0.4)
         except Exception as e:
             log.warning(f"  본문 실패: {e}")
             post["content"] = ""
-            post["comments"] = []
 
 
 # ── 메인 ─────────────────────────────────────────────────────────────────────
@@ -341,12 +325,14 @@ async def main():
     두 게시판을 크롤링하고 결과를 stdout에 JSON으로 출력한다 (DB 미접근).
     Nest가 stdout JSON을 받아 Prisma로 저장한다.
     """
-    log.info(f"=== 인벤 크롤러 | target={TARGET_DATE} pages<={MAX_PAGES} debug={DEBUG} ===")
+    incremental = any(v is not None for v in SINCE.values())
+    mode_desc = f"증분 since={SINCE}" if incremental else f"날짜 target={TARGET_DATE}"
+    log.info(f"=== 인벤 크롤러 | {mode_desc} pages<={MAX_PAGES} debug={DEBUG} ===")
 
     all_posts: list[dict] = []
     async with AsyncSession() as session:
         for board_key in BOARDS:
-            all_posts.extend(await crawl_board(session, board_key))
+            all_posts.extend(await crawl_board(session, board_key, SINCE.get(board_key)))
         await crawl_contents(session, all_posts)
 
     by_board: dict[str, int] = {}


### PR DESCRIPTION
@
inven 추천 파이프라인을 **2시간 주기 증분 크롤링**으로 바꿔 새벽 3시 CPU 스파이크(avg 60%)를 분산합니다. 본문만 쓰므로 **댓글 수집은 제거**. (base: `admin`)

## 배경
- DB 실측: 하루 ~2,900개 크롤, 새벽 3시(KST) 한 방에 처리 → 03시 avg CPU 60.5% (최대 피크).
- 댓글은 추천(사이트 추출)에 쓰였지만 운영자 판단상 **본문이 핵심** → 댓글 제거. 본문은 작성 즉시 완성돼 증분 크롤과 궁합이 좋음(숙성 대기 불필요).

## 변경
- **crawl.py**: 댓글 fetch/상수 제거(본문만 수집), `--since-free/--since-tip` 추가 → `post_id > since` 수집, `<= since`(이미 크롤됨) 만나면 페이지네이션 중단. `--date`(수동 백필)는 유지.
- **repo**: `getMaxPostIdByBoard()` 추가, `upsertPosts`에서 댓글 저장 제거(`[]` 고정).
- **site-extractor**: 본문만 스캔.
- **pipeline**: `targetDate` 있으면 날짜 백필, 없으면 증분(게시판별 max post_id를 crawl.py에 전달).
- **cron**: `0 3 * * *` → `0 */2 * * *` (2시간 주기, Asia/Seoul).

## 효과
- ~2,900/일을 12회로 분산 → 회당 ~240개, 각 실행 짧고 가벼움 → 03시 봉우리 제거.
- 댓글 fetch(글당 POST 1회) 제거로 요청·파싱량 추가 감소.

## 검증
- server `tsc`·eslint 통과, jest 39개 통과, crawl.py ast 파싱 OK
- ⚠️ crawl.py는 로컬에서 실행(네트워크/파이썬 의존) 테스트는 안 함 — 로직 리뷰 기준. 배포 후 첫 2시간 틱 로그(`인벤 증분 파이프라인`, `증분 기준 since ...`)로 동작 확인 권장.

## 참고
- 첫 배포 시: DB에 이미 35k+ 글이 있어 게시판별 max post_id가 크므로, 첫 증분 실행은 "마지막 일배치 이후 새 글"만 가져옴(전체 재크롤 아님).
- 수동 백필(`run(date)` / 어드민)은 기존처럼 날짜 모드로 동작.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@