### PR TITLE
fix(monitoring): 로딩 속도 추이 그래프 점 표시

### DIFF
--- a/client/app/admin/monitoring/page.tsx
+++ b/client/app/admin/monitoring/page.tsx
@@ -417,7 +417,7 @@ export default function MonitoringPage() {
                       dataKey={m.key}
                       name={m.label}
                       stroke={m.color}
-                      dot={false}
+                      dot={{ r: 2 }}
                       strokeWidth={2}
                       connectNulls
                     />


### PR DESCRIPTION
## 배경
메인페이지 로딩 속도 추이(1일 보기)에서 "08~13시만 데이터가 있다"는 현상.
- 원인은 버그 아님: 해당 그래프는 실사용자 측정(`source='rum'`)이라 실제 방문 시각에만 샘플이 생김. 오늘은 08시(1건)·13시(3건)에만 방문이 있었음.
- 다만 `dot={false}`라 값이 단일/양끝에만 있을 때 선이 안 그려져 **아무것도 없는 것처럼** 보였음.

## 변경
- 페이지 로딩 추이 라인의 `dot={false}` → `dot={{ r: 2 }}`
- 샘플이 있는 시간엔 선이 없어도 점이 찍혀 데이터 존재가 보임.
- X축(00~23 24칸)·`connectNulls`·집계 로직은 그대로.

🤖 Generated with [Claude Code](https://claude.com/claude-code)