### PR TITLE
로딩 속도 추이 그래프에 점 표시

### DIFF
--- a/client/app/admin/monitoring/page.tsx
+++ b/client/app/admin/monitoring/page.tsx
@@ -417,7 +417,7 @@ export default function MonitoringPage() {
                       dataKey={m.key}
                       name={m.label}
                       stroke={m.color}
-                      dot={false}
+                      dot={{ r: 2 }}
                       strokeWidth={2}
                       connectNulls
                     />


### PR DESCRIPTION
어드민 모니터링 "메인페이지 로딩 속도 추이"에서 트래픽 적은 시간대에 데이터가 없어 보이던 문제 수정.

- `dot={false}` → `dot={{ r: 2 }}`: 샘플이 단일/양끝에만 있어도 점이 찍혀 데이터 존재가 보임
- 축(00~23 24칸)·connectNulls·집계 로직은 그대로 — 다른 그래프 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)