### PR TITLE
인벤 2시간 크롤 CPU 폭주/데스 스파이럴 차단

### DIFF
--- a/server/src/admin/admin-inven-pipeline.service.ts
+++ b/server/src/admin/admin-inven-pipeline.service.ts
@@ -21,6 +21,11 @@ const PYTHON_BIN =
   process.env.PYTHON_BIN ??
   (process.platform === 'win32' ? 'python' : 'python3');
 
+// 증분 1회 실행에서 본문(상세페이지)을 fetch할 최대 글 수. 목록 메타데이터는
+// 캡과 무관하게 새 글 전체를 저장하므로 since_id는 매 런 gap 없이 전진한다.
+// 2시간치 신규 글(보통 수백)보다 넉넉하게 잡아 정상 운영 시엔 캡에 걸리지 않게 한다.
+const INVEN_MAX_DETAIL = Number(process.env.INVEN_MAX_DETAIL ?? 500);
+
 export interface PipelineStatus {
   running: boolean;
   step: string; // 현재 단계 이름
@@ -158,13 +163,17 @@ export class AdminInvenPipelineService {
     const scriptPath = join(SITE_FINDER_DIR, 'crawl.py');
     const args = [scriptPath];
     if (date) {
+      // 수동 날짜 백필: 본문 전체 수집(캡 해제)
       args.push('--date', date);
+      args.push('--max-detail', '0');
     } else {
       const maxIds = await this.invenRepo.getMaxPostIdByBoard();
       args.push('--since-free', String(maxIds.free ?? 0));
       args.push('--since-tip', String(maxIds.tip ?? 0));
+      // 증분: 본문 fetch는 캡으로 제한(목록 메타는 전체 저장 → since_id 정상 전진)
+      args.push('--max-detail', String(INVEN_MAX_DETAIL));
       this.logger.log(
-        `[크롤링] 증분 기준 since free=${maxIds.free ?? 0} tip=${maxIds.tip ?? 0}`,
+        `[크롤링] 증분 기준 since free=${maxIds.free ?? 0} tip=${maxIds.tip ?? 0} maxDetail=${INVEN_MAX_DETAIL}`,
       );
     }
     const { stdout } = await execFileAsync(PYTHON_BIN, args, {

--- a/site-finder/crawl.py
+++ b/site-finder/crawl.py
@@ -26,6 +26,8 @@ date_str 형식:
 사용법:
   python crawl.py                    # 어제 게시물 → stdout JSON
   python crawl.py --date 2026-05-20  # 특정 날짜
+  python crawl.py --since-free N --since-tip M  # 게시판별 post_id 증분
+  python crawl.py --max-detail 500   # 본문 fetch 최대 500개(최신순), 0/미지정=무제한
   python crawl.py --debug            # 상세 로그 출력 (stderr)
 """
 
@@ -70,6 +72,19 @@ SINCE: dict[str, int | None] = (
     if _arg("--date")
     else {"free": _since("--since-free"), "tip": _since("--since-tip")}
 )
+
+# 본문 크롤 캡: 한 번에 상세페이지를 fetch할 최대 글 수(최신순). 0 이하면 무제한.
+# 목록 크롤(메타데이터)은 캡과 무관하게 새 글 전체를 수집/저장하므로 since_id는
+# gap 없이 전진하고, 캡을 넘는 글은 content=null로 저장된다(다음부터 재방문 안 함).
+def _max_detail() -> int | None:
+    v = _arg("--max-detail")
+    if v is None:
+        return None
+    n = int(v) if v.lstrip("-").isdigit() else 0
+    return n if n > 0 else None
+
+
+MAX_DETAIL: int | None = _max_detail()
 
 # ── 설정 ─────────────────────────────────────────────────────────────────────
 
@@ -301,10 +316,20 @@ async def crawl_board(
     return list(collected.values())
 
 
-async def crawl_contents(session: AsyncSession, posts: list[dict]) -> None:
-    """수집된 게시글 전체의 상세 페이지를 순회해 본문을 채운다(댓글 미수집)."""
-    targets = [p for p in posts if p["content"] is None]
-    log.info(f"본문 크롤링: {len(targets)}개 (전체)")
+async def crawl_contents(
+    session: AsyncSession, posts: list[dict], max_detail: int | None = None
+) -> None:
+    """
+    수집된 게시글의 상세 페이지를 순회해 본문을 채운다(댓글 미수집).
+    max_detail이 주어지면 최신순으로 그만큼만 fetch한다(CPU/시간 폭주 방지).
+    나머지는 content=None 유지 → DB엔 null로 저장된다.
+    """
+    pending = [p for p in posts if p["content"] is None]
+    targets = pending[:max_detail] if max_detail is not None else pending
+    skipped = len(pending) - len(targets)
+    log.info(
+        f"본문 크롤링: {len(targets)}개 (대상 {len(pending)}, 캡 {max_detail}, 스킵 {skipped})"
+    )
 
     for i, post in enumerate(targets):
         try:
@@ -333,7 +358,7 @@ async def main():
     async with AsyncSession() as session:
         for board_key in BOARDS:
             all_posts.extend(await crawl_board(session, board_key, SINCE.get(board_key)))
-        await crawl_contents(session, all_posts)
+        await crawl_contents(session, all_posts, MAX_DETAIL)
 
     by_board: dict[str, int] = {}
     for p in all_posts:


### PR DESCRIPTION
인벤 증분 크롤이 매 2시간마다 신규 글 전체의 본문을 fetch하려다 1시간 timeout에 걸려 저장 실패 → since_id 정체 → 백로그 누적 악순환에 빠져 CPU를 폭주시키던 문제를 차단한다.

- 목록 메타데이터는 새 글 전체 저장으로 since_id가 gap 없이 매 런 전진(악순환 차단, 자동 복구)
- 본문 fetch는 런당 캡(--max-detail, 기본 500, INVEN_MAX_DETAIL env)으로 CPU/시간 폭주 차단
- 수동 --date 백필은 기존대로 본문 무제한

근거: docker_metrics_nest CPU가 짝수시에만 55~90%/peak 100~400%, 서버 로그상 13:00 시작→14:00:02 timeout 실패(신규 13,706건), 06-13 이후 저장 중단.

PR #329(perf/inven-crawl-split → perf/inven-crawl) 머지분.

🤖 Generated with [Claude Code](https://claude.com/claude-code)