### PR TITLE
메인페이지 로딩 추이 달력 개편 + 어드민 UX

### DIFF
--- a/client/app/admin/layout.tsx
+++ b/client/app/admin/layout.tsx
@@ -37,6 +37,8 @@ export default function AdminLayout({
           </span>
           <Link
             href="/"
+            target="_blank"
+            rel="noopener noreferrer"
             className="mt-2 flex items-center gap-1 text-xs font-medium px-2 py-1 rounded bg-blue-50 text-blue-600 hover:bg-blue-100 transition-colors w-fit"
           >
             ↗ 메인 사이트 바로가기

--- a/client/app/admin/monitoring/page.tsx
+++ b/client/app/admin/monitoring/page.tsx
@@ -401,14 +401,22 @@ export default function MonitoringPage() {
                 value={pageLoadFrom}
                 min={pageLoadMinDate}
                 max={kstToday()}
-                onChange={setPageLoadFrom}
+                onChange={(v) => {
+                  // 시작을 끝보다 뒤로 고르면 끝도 같이 맞춰 순서 유지
+                  setPageLoadFrom(v);
+                  if (pageLoadTo && v > pageLoadTo) setPageLoadTo(v);
+                }}
               />
               <span className="text-[color:var(--admin-text-muted)]">~</span>
               <AdminDatePicker
                 value={pageLoadTo}
                 min={pageLoadMinDate}
                 max={kstToday()}
-                onChange={setPageLoadTo}
+                onChange={(v) => {
+                  // 끝을 시작보다 앞으로 고르면 시작도 같이 맞춰 순서 유지
+                  setPageLoadTo(v);
+                  if (pageLoadFrom && v < pageLoadFrom) setPageLoadFrom(v);
+                }}
               />
               <button
                 type="button"

--- a/client/app/admin/monitoring/page.tsx
+++ b/client/app/admin/monitoring/page.tsx
@@ -425,14 +425,18 @@ export default function MonitoringPage() {
                   onMouseEnter={() => setActiveChart("page-load")}
                   onMouseLeave={() => setActiveChart(null)}
                   onClick={(state) => {
-                    // 일별(여러 날) 보기에서 점 클릭 → 그날 하루(시간별)로 드릴다운
+                    // 일별(여러 날) 보기에서 점 클릭 → 그날 하루(시간별)로 드릴다운.
+                    // recharts v3는 activePayload가 없어 activeIndex/activeLabel로 행을 찾는다.
                     if (pageLoadFrom === pageLoadTo) return;
-                    const date = (
-                      state as { activePayload?: { payload?: PageLoadPoint }[] }
-                    )?.activePayload?.[0]?.payload?.date;
-                    if (date) {
-                      setPageLoadFrom(date);
-                      setPageLoadTo(date);
+                    const idx = state.activeIndex ?? state.activeTooltipIndex;
+                    const row =
+                      (idx != null ? pageLoadSeries[Number(idx)] : undefined) ??
+                      pageLoadSeries.find(
+                        (p) => p.bucket === String(state.activeLabel),
+                      );
+                    if (row?.date) {
+                      setPageLoadFrom(row.date);
+                      setPageLoadTo(row.date);
                     }
                   }}
                   className={pageLoadFrom !== pageLoadTo ? "cursor-pointer" : ""}

--- a/client/app/admin/monitoring/page.tsx
+++ b/client/app/admin/monitoring/page.tsx
@@ -30,6 +30,11 @@ const PAGE_LOAD_METRICS = [
   { key: "ttfb", label: "TTFB", color: "#f59e0b" },
 ] as const;
 
+// 사용자 로컬 타임존과 무관하게 한국시간(UTC+9) 기준 오늘 날짜(YYYY-MM-DD)
+function kstToday(): string {
+  return new Date(Date.now() + 9 * 3600 * 1000).toISOString().slice(0, 10);
+}
+
 type Dashboard = {
   summary: {
     windowMinutes: number;
@@ -124,7 +129,8 @@ export default function MonitoringPage() {
   const [sectionTab, setSectionTab] = useState<
     "sites" | "stat-builds" | "youtube"
   >("sites");
-  const [pageLoadDays, setPageLoadDays] = useState<1 | 7 | 30>(7);
+  const [pageLoadFrom, setPageLoadFrom] = useState<string>(kstToday);
+  const [pageLoadTo, setPageLoadTo] = useState<string>(kstToday);
   const [pageLoadSeries, setPageLoadSeries] = useState<PageLoadPoint[]>([]);
   const [pageLoadLoading, setPageLoadLoading] = useState(true);
   const hasLoadedRef = useRef(false);
@@ -212,7 +218,7 @@ export default function MonitoringPage() {
     async function loadPageLoad() {
       try {
         const res = await fetch(
-          `/api/admin/monitoring/page-load-series?days=${pageLoadDays}`,
+          `/api/admin/monitoring/page-load-series?from=${pageLoadFrom}&to=${pageLoadTo}`,
           { cache: "no-store" },
         );
         if (!alive || !res.ok) return;
@@ -228,7 +234,7 @@ export default function MonitoringPage() {
     return () => {
       alive = false;
     };
-  }, [pageLoadDays]);
+  }, [pageLoadFrom, pageLoadTo]);
 
   const pageLoadLatest = useMemo(() => {
     for (let i = pageLoadSeries.length - 1; i >= 0; i -= 1) {
@@ -367,19 +373,34 @@ export default function MonitoringPage() {
                 </span>
               )}
             </div>
-            <div className="flex items-center gap-2">
-              <div className="flex gap-1">
-                {([1, 7, 30] as const).map((d) => (
-                  <button
-                    key={d}
-                    type="button"
-                    onClick={() => setPageLoadDays(d)}
-                    className={`admin-btn admin-btn-sm ${pageLoadDays === d ? "admin-btn-primary" : "admin-btn-secondary"}`}
-                  >
-                    {d}일
-                  </button>
-                ))}
-              </div>
+            <div className="flex items-center gap-1 text-xs">
+              <input
+                type="date"
+                value={pageLoadFrom}
+                max={pageLoadTo}
+                onChange={(e) => setPageLoadFrom(e.target.value)}
+                className="rounded border border-slate-300 bg-white px-2 py-1 text-xs text-slate-700 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200"
+              />
+              <span className="text-[color:var(--admin-text-muted)]">~</span>
+              <input
+                type="date"
+                value={pageLoadTo}
+                min={pageLoadFrom}
+                max={kstToday()}
+                onChange={(e) => setPageLoadTo(e.target.value)}
+                className="rounded border border-slate-300 bg-white px-2 py-1 text-xs text-slate-700 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200"
+              />
+              <button
+                type="button"
+                onClick={() => {
+                  const t = kstToday();
+                  setPageLoadFrom(t);
+                  setPageLoadTo(t);
+                }}
+                className="admin-btn admin-btn-sm admin-btn-secondary"
+              >
+                오늘
+              </button>
             </div>
           </div>
           <div className="h-48">
@@ -387,7 +408,7 @@ export default function MonitoringPage() {
               <div className="grid h-full place-items-center text-sm text-[color:var(--admin-text-muted)]">
                 불러오는 중...
               </div>
-            ) : pageLoadSeries.every((p) => (p.count ?? 0) === 0) ? (
+            ) : pageLoadSeries.length === 0 ? (
               <div className="grid h-full place-items-center text-sm text-[color:var(--admin-text-muted)]">
                 데이터 없음 (수집 시작 후 표시됩니다)
               </div>

--- a/client/app/admin/monitoring/page.tsx
+++ b/client/app/admin/monitoring/page.tsx
@@ -13,6 +13,7 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
+import AdminDatePicker from "@/components/admin/AdminDatePicker";
 
 interface PageLoadPoint {
   bucket: string;
@@ -132,6 +133,7 @@ export default function MonitoringPage() {
   >("sites");
   const [pageLoadFrom, setPageLoadFrom] = useState<string>(kstToday);
   const [pageLoadTo, setPageLoadTo] = useState<string>(kstToday);
+  const [pageLoadMinDate, setPageLoadMinDate] = useState<string>("");
   const [pageLoadSeries, setPageLoadSeries] = useState<PageLoadPoint[]>([]);
   const [pageLoadLoading, setPageLoadLoading] = useState(true);
   const hasLoadedRef = useRef(false);
@@ -236,6 +238,26 @@ export default function MonitoringPage() {
       alive = false;
     };
   }, [pageLoadFrom, pageLoadTo]);
+
+  // 달력 하한(첫 데이터 날짜) 1회 조회 — 이 이전은 선택 불가
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const res = await fetch("/api/admin/monitoring/page-load-earliest", {
+          cache: "no-store",
+        });
+        if (!alive || !res.ok) return;
+        const data = (await res.json()) as { earliest: string | null };
+        if (data.earliest) setPageLoadMinDate(data.earliest);
+      } catch {
+        // 하한 없으면 그냥 전체 선택 가능
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
 
   const pageLoadLatest = useMemo(() => {
     for (let i = pageLoadSeries.length - 1; i >= 0; i -= 1) {
@@ -375,20 +397,18 @@ export default function MonitoringPage() {
               )}
             </div>
             <div className="flex items-center gap-1 text-xs">
-              <input
-                type="date"
+              <AdminDatePicker
                 value={pageLoadFrom}
+                min={pageLoadMinDate}
                 max={kstToday()}
-                onChange={(e) => setPageLoadFrom(e.target.value)}
-                className="rounded border border-slate-300 bg-white px-2 py-1 text-xs text-slate-700 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200"
+                onChange={setPageLoadFrom}
               />
               <span className="text-[color:var(--admin-text-muted)]">~</span>
-              <input
-                type="date"
+              <AdminDatePicker
                 value={pageLoadTo}
+                min={pageLoadMinDate}
                 max={kstToday()}
-                onChange={(e) => setPageLoadTo(e.target.value)}
-                className="rounded border border-slate-300 bg-white px-2 py-1 text-xs text-slate-700 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200"
+                onChange={setPageLoadTo}
               />
               <button
                 type="button"

--- a/client/app/admin/monitoring/page.tsx
+++ b/client/app/admin/monitoring/page.tsx
@@ -16,6 +16,7 @@ import {
 
 interface PageLoadPoint {
   bucket: string;
+  date: string;
   ttfb: number | null;
   dcl: number | null;
   lcp: number | null;
@@ -401,6 +402,11 @@ export default function MonitoringPage() {
               >
                 오늘
               </button>
+              {pageLoadFrom !== pageLoadTo && (
+                <span className="ml-1 text-[10px] text-[color:var(--admin-text-muted)]">
+                  점 클릭 → 해당일
+                </span>
+              )}
             </div>
           </div>
           <div className="h-48">
@@ -418,6 +424,18 @@ export default function MonitoringPage() {
                   data={pageLoadSeries}
                   onMouseEnter={() => setActiveChart("page-load")}
                   onMouseLeave={() => setActiveChart(null)}
+                  onClick={(state) => {
+                    // 일별(여러 날) 보기에서 점 클릭 → 그날 하루(시간별)로 드릴다운
+                    if (pageLoadFrom === pageLoadTo) return;
+                    const date = (
+                      state as { activePayload?: { payload?: PageLoadPoint }[] }
+                    )?.activePayload?.[0]?.payload?.date;
+                    if (date) {
+                      setPageLoadFrom(date);
+                      setPageLoadTo(date);
+                    }
+                  }}
+                  className={pageLoadFrom !== pageLoadTo ? "cursor-pointer" : ""}
                 >
                   <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
                   <XAxis

--- a/client/app/admin/monitoring/page.tsx
+++ b/client/app/admin/monitoring/page.tsx
@@ -378,7 +378,7 @@ export default function MonitoringPage() {
               <input
                 type="date"
                 value={pageLoadFrom}
-                max={pageLoadTo}
+                max={kstToday()}
                 onChange={(e) => setPageLoadFrom(e.target.value)}
                 className="rounded border border-slate-300 bg-white px-2 py-1 text-xs text-slate-700 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200"
               />
@@ -386,7 +386,6 @@ export default function MonitoringPage() {
               <input
                 type="date"
                 value={pageLoadTo}
-                min={pageLoadFrom}
                 max={kstToday()}
                 onChange={(e) => setPageLoadTo(e.target.value)}
                 className="rounded border border-slate-300 bg-white px-2 py-1 text-xs text-slate-700 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200"

--- a/client/app/api/admin/monitoring/page-load-earliest/route.ts
+++ b/client/app/api/admin/monitoring/page-load-earliest/route.ts
@@ -1,0 +1,19 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+const NEST_API = process.env.NEST_API_URL ?? "http://localhost:3001";
+
+export async function GET() {
+  const store = await cookies();
+  const token = store.get("admin_token")?.value ?? "";
+  try {
+    const res = await fetch(
+      `${NEST_API}/api/admin/monitoring/page-load-earliest`,
+      { headers: { "x-admin-session": token }, cache: "no-store" },
+    );
+    const data = await res.json().catch(() => ({ earliest: null }));
+    return NextResponse.json(data, { status: res.status });
+  } catch {
+    return NextResponse.json({ earliest: null }, { status: 503 });
+  }
+}

--- a/client/app/api/admin/monitoring/page-load-series/route.ts
+++ b/client/app/api/admin/monitoring/page-load-series/route.ts
@@ -6,10 +6,16 @@ const NEST_API = process.env.NEST_API_URL ?? "http://localhost:3001";
 export async function GET(req: NextRequest) {
   const store = await cookies();
   const token = store.get("admin_token")?.value ?? "";
-  const days = req.nextUrl.searchParams.get("days") ?? "7";
+  // 달력(from~to) 기준. 빈 값은 nest가 오늘 하루로 폴백.
+  const sp = req.nextUrl.searchParams;
+  const qs = new URLSearchParams();
+  const from = sp.get("from");
+  const to = sp.get("to");
+  if (from) qs.set("from", from);
+  if (to) qs.set("to", to);
   try {
     const res = await fetch(
-      `${NEST_API}/api/admin/monitoring/page-load-series?days=${encodeURIComponent(days)}`,
+      `${NEST_API}/api/admin/monitoring/page-load-series?${qs.toString()}`,
       { headers: { "x-admin-session": token }, cache: "no-store" },
     );
     const data = await res.json().catch(() => []);

--- a/client/components/admin/AdminDatePicker.tsx
+++ b/client/components/admin/AdminDatePicker.tsx
@@ -65,13 +65,16 @@ export default function AdminDatePicker({ value, onChange, min, max }: Props) {
     return () => document.removeEventListener("mousedown", onDown);
   }, [open]);
 
-  const dayDisabled = (ds: string) =>
-    (min != null && min !== "" && ds < min) ||
-    (max != null && max !== "" && ds > max);
+  // [start, end] 구간이 [min, max]와 전혀 안 겹치면 비활성.
+  // (하루라도 범위에 걸치면 활성 — 끝점만 보면 안 됨)
+  const intervalDisabled = (start: string, end: string) =>
+    (min != null && min !== "" && end < min) ||
+    (max != null && max !== "" && start > max);
+  const dayDisabled = (ds: string) => intervalDisabled(ds, ds);
   const monthDisabled = (y: number, m: number) =>
-    dayDisabled(fmt(y, m, daysInMonth(y, m))) && dayDisabled(fmt(y, m, 1));
+    intervalDisabled(fmt(y, m, 1), fmt(y, m, daysInMonth(y, m)));
   const yearDisabled = (y: number) =>
-    dayDisabled(`${y}-12-31`) && dayDisabled(`${y}-01-01`);
+    intervalDisabled(`${y}-01-01`, `${y}-12-31`);
 
   const minY = min && min !== "" ? +min.slice(0, 4) : viewYear - 6;
   const maxY = max && max !== "" ? +max.slice(0, 4) : viewYear + 5;

--- a/client/components/admin/AdminDatePicker.tsx
+++ b/client/components/admin/AdminDatePicker.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * 어드민용 커스텀 날짜 선택기 (네이티브 input 대체).
+ * - 일 → 월 → 년 드릴다운: 헤더("YYYY년 M월") 클릭 시 년 목록, 년 클릭 시 월,
+ *   월 뷰의 년도 헤더를 다시 클릭하면 달력(일 뷰)으로 닫힌다.
+ * - min/max 범위 밖 날짜는 비활성(선택 불가).
+ * - 외부 클릭 시 팝업 닫힘.
+ */
+
+type View = "day" | "month" | "year";
+
+const WEEKDAYS = ["일", "월", "화", "수", "목", "금", "토"];
+const MONTHS = Array.from({ length: 12 }, (_, i) => i + 1);
+
+const pad = (n: number) => String(n).padStart(2, "0");
+const fmt = (y: number, m: number, d: number) => `${y}-${pad(m)}-${pad(d)}`;
+const daysInMonth = (y: number, m: number) => new Date(y, m, 0).getDate();
+const firstWeekday = (y: number, m: number) => new Date(y, m - 1, 1).getDay();
+
+function parse(value: string): { y: number; m: number; d: number } {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (match) {
+    return { y: +match[1], m: +match[2], d: +match[3] };
+  }
+  const now = new Date();
+  return { y: now.getFullYear(), m: now.getMonth() + 1, d: now.getDate() };
+}
+
+interface Props {
+  value: string;
+  onChange: (value: string) => void;
+  min?: string;
+  max?: string;
+}
+
+export default function AdminDatePicker({ value, onChange, min, max }: Props) {
+  const [open, setOpen] = useState(false);
+  const [view, setView] = useState<View>("day");
+  const sel = parse(value);
+  const [viewYear, setViewYear] = useState(sel.y);
+  const [viewMonth, setViewMonth] = useState(sel.m);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  // 팝업 열 때 선택값 기준으로 보기 위치 초기화 + 일 뷰부터 시작
+  const openPicker = () => {
+    const p = parse(value);
+    setViewYear(p.y);
+    setViewMonth(p.m);
+    setView("day");
+    setOpen(true);
+  };
+
+  // 외부 클릭 시 닫기
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [open]);
+
+  const dayDisabled = (ds: string) =>
+    (min != null && min !== "" && ds < min) ||
+    (max != null && max !== "" && ds > max);
+  const monthDisabled = (y: number, m: number) =>
+    dayDisabled(fmt(y, m, daysInMonth(y, m))) && dayDisabled(fmt(y, m, 1));
+  const yearDisabled = (y: number) =>
+    dayDisabled(`${y}-12-31`) && dayDisabled(`${y}-01-01`);
+
+  const minY = min && min !== "" ? +min.slice(0, 4) : viewYear - 6;
+  const maxY = max && max !== "" ? +max.slice(0, 4) : viewYear + 5;
+  const years: number[] = [];
+  for (let y = minY; y <= maxY; y += 1) years.push(y);
+
+  const shiftMonth = (delta: number) => {
+    let m = viewMonth + delta;
+    let y = viewYear;
+    if (m < 1) {
+      m = 12;
+      y -= 1;
+    } else if (m > 12) {
+      m = 1;
+      y += 1;
+    }
+    setViewYear(y);
+    setViewMonth(m);
+  };
+
+  const cellBase =
+    "h-7 w-7 rounded text-xs grid place-items-center disabled:opacity-30 disabled:cursor-not-allowed";
+  const pickBase =
+    "rounded px-2 py-1.5 text-xs disabled:opacity-30 disabled:cursor-not-allowed hover:bg-slate-100 dark:hover:bg-slate-700";
+
+  const leadingBlanks = firstWeekday(viewYear, viewMonth);
+  const totalDays = daysInMonth(viewYear, viewMonth);
+
+  return (
+    <div className="relative inline-block" ref={rootRef}>
+      <button
+        type="button"
+        onClick={() => (open ? setOpen(false) : openPicker())}
+        className="rounded border border-slate-300 bg-white px-2 py-1 text-xs text-slate-700 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200"
+      >
+        {value || "날짜 선택"}
+      </button>
+
+      {open && (
+        <div className="absolute left-0 z-50 mt-1 w-56 rounded-md border border-slate-200 bg-white p-2 shadow-lg dark:border-slate-700 dark:bg-slate-800">
+          {/* 헤더 */}
+          <div className="mb-1 flex items-center justify-between">
+            {view === "day" && (
+              <>
+                <button
+                  type="button"
+                  onClick={() => shiftMonth(-1)}
+                  className="rounded px-1 text-sm text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-700"
+                  aria-label="이전 달"
+                >
+                  ‹
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setView("year")}
+                  className="rounded px-2 py-0.5 text-xs font-semibold hover:bg-slate-100 dark:hover:bg-slate-700"
+                >
+                  {viewYear}년 {viewMonth}월
+                </button>
+                <button
+                  type="button"
+                  onClick={() => shiftMonth(1)}
+                  className="rounded px-1 text-sm text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-700"
+                  aria-label="다음 달"
+                >
+                  ›
+                </button>
+              </>
+            )}
+            {view === "month" && (
+              <button
+                type="button"
+                // 월 뷰의 년도 헤더를 다시 누르면 달력(일 뷰)으로 닫힘
+                onClick={() => setView("day")}
+                className="mx-auto rounded px-2 py-0.5 text-xs font-semibold hover:bg-slate-100 dark:hover:bg-slate-700"
+              >
+                {viewYear}년
+              </button>
+            )}
+            {view === "year" && (
+              <span className="mx-auto px-2 py-0.5 text-xs font-semibold text-slate-500">
+                년도 선택
+              </span>
+            )}
+          </div>
+
+          {/* 일 뷰 */}
+          {view === "day" && (
+            <>
+              <div className="mb-1 grid grid-cols-7">
+                {WEEKDAYS.map((w, i) => (
+                  <div
+                    key={w}
+                    className={`grid h-6 place-items-center text-[10px] ${
+                      i === 0
+                        ? "text-rose-500"
+                        : i === 6
+                          ? "text-blue-500"
+                          : "text-slate-400"
+                    }`}
+                  >
+                    {w}
+                  </div>
+                ))}
+              </div>
+              <div className="grid grid-cols-7 gap-y-0.5">
+                {Array.from({ length: leadingBlanks }).map((_, i) => (
+                  <div key={`b${i}`} />
+                ))}
+                {Array.from({ length: totalDays }, (_, i) => i + 1).map((d) => {
+                  const ds = fmt(viewYear, viewMonth, d);
+                  const selected = ds === value;
+                  return (
+                    <button
+                      key={d}
+                      type="button"
+                      disabled={dayDisabled(ds)}
+                      onClick={() => {
+                        onChange(ds);
+                        setOpen(false);
+                      }}
+                      className={`${cellBase} mx-auto ${
+                        selected
+                          ? "bg-blue-600 text-white"
+                          : "hover:bg-slate-100 dark:hover:bg-slate-700"
+                      }`}
+                    >
+                      {d}
+                    </button>
+                  );
+                })}
+              </div>
+            </>
+          )}
+
+          {/* 월 뷰 */}
+          {view === "month" && (
+            <div className="grid grid-cols-3 gap-1">
+              {MONTHS.map((m) => (
+                <button
+                  key={m}
+                  type="button"
+                  disabled={monthDisabled(viewYear, m)}
+                  onClick={() => {
+                    setViewMonth(m);
+                    setView("day");
+                  }}
+                  className={`${pickBase} ${
+                    m === viewMonth ? "bg-blue-600 text-white hover:bg-blue-600" : ""
+                  }`}
+                >
+                  {m}월
+                </button>
+              ))}
+            </div>
+          )}
+
+          {/* 년 뷰 */}
+          {view === "year" && (
+            <div className="grid max-h-40 grid-cols-3 gap-1 overflow-y-auto">
+              {years.map((y) => (
+                <button
+                  key={y}
+                  type="button"
+                  disabled={yearDisabled(y)}
+                  onClick={() => {
+                    setViewYear(y);
+                    setView("month");
+                  }}
+                  className={`${pickBase} ${
+                    y === viewYear ? "bg-blue-600 text-white hover:bg-blue-600" : ""
+                  }`}
+                >
+                  {y}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/server/src/admin/admin-monitoring.controller.ts
+++ b/server/src/admin/admin-monitoring.controller.ts
@@ -107,6 +107,12 @@ export class AdminMonitoringController {
     return this.monitoring.getPageLoadSeries(from, to);
   }
 
+  @UseGuards(AdminGuard)
+  @Get('admin/monitoring/page-load-earliest')
+  pageLoadEarliest() {
+    return this.monitoring.getPageLoadEarliest();
+  }
+
   @Post('telemetry/page-load')
   pageLoad(
     @Req() req: Request,

--- a/server/src/admin/admin-monitoring.controller.ts
+++ b/server/src/admin/admin-monitoring.controller.ts
@@ -103,10 +103,8 @@ export class AdminMonitoringController {
 
   @UseGuards(AdminGuard)
   @Get('admin/monitoring/page-load-series')
-  pageLoadSeries(@Query('days') days?: string) {
-    const parsed = Number(days);
-    const rangeDays = Number.isFinite(parsed) ? parsed : 7;
-    return this.monitoring.getPageLoadSeries(rangeDays);
+  pageLoadSeries(@Query('from') from?: string, @Query('to') to?: string) {
+    return this.monitoring.getPageLoadSeries(from, to);
   }
 
   @Post('telemetry/page-load')

--- a/server/src/admin/admin-monitoring.service.ts
+++ b/server/src/admin/admin-monitoring.service.ts
@@ -153,15 +153,29 @@ export class AdminMonitoringService implements OnModuleInit {
     }));
   }
 
-  /** 페이지 로딩 추이(실사용자 RUM). days에 따라 버킷 크기 자동 선택. */
-  async getPageLoadSeries(days: number) {
-    const safeDays = Math.max(1, Math.min(30, Math.trunc(days)));
-    // 1일: 1시간 단위, 7일/30일: 1일(24시간) 단위
-    const bucketHours = safeDays <= 1 ? 1 : 24;
-    const rows = await this.monitoringRepo.findPageLoadSeries(
-      safeDays,
-      bucketHours,
-    );
+  /**
+   * 페이지 로딩 추이(실사용자 RUM). 달력(from~to, KST) 기준.
+   * from===to면 그날 시간별, 아니면 일별. 잘못된/누락 입력은 오늘 하루로 폴백.
+   */
+  async getPageLoadSeries(from?: string, to?: string) {
+    const dateRe = /^\d{4}-\d{2}-\d{2}$/;
+    // KST(UTC+9) 오늘 날짜 문자열
+    const todayKst = new Date(Date.now() + 9 * 3600 * 1000)
+      .toISOString()
+      .slice(0, 10);
+    let start = from && dateRe.test(from) ? from : todayKst;
+    let end = to && dateRe.test(to) ? to : start;
+    if (start > end) [start, end] = [end, start];
+    // 범위 상한 90일 (일별 버킷 과다 방지)
+    const MAX_DAYS = 90;
+    const startMs = Date.parse(`${start}T00:00:00Z`);
+    const endMs = Date.parse(`${end}T00:00:00Z`);
+    if ((endMs - startMs) / 86_400_000 > MAX_DAYS - 1) {
+      start = new Date(endMs - (MAX_DAYS - 1) * 86_400_000)
+        .toISOString()
+        .slice(0, 10);
+    }
+    const rows = await this.monitoringRepo.findPageLoadSeries(start, end);
     return rows.map((row) => ({
       bucket: row.bucket,
       ttfb: row.avg_ttfb ?? null,

--- a/server/src/admin/admin-monitoring.service.ts
+++ b/server/src/admin/admin-monitoring.service.ts
@@ -178,6 +178,7 @@ export class AdminMonitoringService implements OnModuleInit {
     const rows = await this.monitoringRepo.findPageLoadSeries(start, end);
     return rows.map((row) => ({
       bucket: row.bucket,
+      date: row.date,
       ttfb: row.avg_ttfb ?? null,
       dcl: row.avg_dcl ?? null,
       lcp: row.avg_lcp ?? null,

--- a/server/src/admin/admin-monitoring.service.ts
+++ b/server/src/admin/admin-monitoring.service.ts
@@ -187,6 +187,11 @@ export class AdminMonitoringService implements OnModuleInit {
     }));
   }
 
+  /** 로딩 추이 달력의 하한(첫 데이터 날짜). 이 이전은 선택/표시 안 함. */
+  async getPageLoadEarliest(): Promise<{ earliest: string | null }> {
+    return { earliest: await this.monitoringRepo.findEarliestPageLoadDate() };
+  }
+
   @Cron('0 0 * * * *')
   async probeApis() {
     const base =

--- a/server/src/admin/repositories/monitoring.repository.ts
+++ b/server/src/admin/repositories/monitoring.repository.ts
@@ -50,6 +50,7 @@ type RetentionTable = 'apm_request_timings' | 'apm_page_load_timings';
 
 export interface PageLoadSeriesRow {
   bucket: string;
+  date: string;
   avg_ttfb: number | null;
   avg_dcl: number | null;
   avg_lcp: number | null;
@@ -391,6 +392,7 @@ export class MonitoringRepository {
                  ) AS bucket_start
         )
         SELECT TO_CHAR(b.bucket_start, 'HH24:MI') AS bucket,
+               TO_CHAR(b.bucket_start::date, 'YYYY-MM-DD') AS date,
                CASE WHEN b.bucket_start <= date_trunc('hour', NOW() AT TIME ZONE 'Asia/Seoul')
                     THEN COALESCE(ROUND(AVG(s.ttfb_ms))::int, 0) END AS avg_ttfb,
                CASE WHEN b.bucket_start <= date_trunc('hour', NOW() AT TIME ZONE 'Asia/Seoul')
@@ -422,6 +424,7 @@ export class MonitoringRepository {
         FROM generate_series(${from}::date, ${to}::date, INTERVAL '1 day') AS g
       )
       SELECT TO_CHAR(b.bucket_start, 'MM-DD') AS bucket,
+             TO_CHAR(b.bucket_start, 'YYYY-MM-DD') AS date,
              CASE WHEN b.bucket_start <= (NOW() AT TIME ZONE 'Asia/Seoul')::date
                   THEN COALESCE(ROUND(AVG(s.ttfb_ms))::int, 0) END AS avg_ttfb,
              CASE WHEN b.bucket_start <= (NOW() AT TIME ZONE 'Asia/Seoul')::date

--- a/server/src/admin/repositories/monitoring.repository.ts
+++ b/server/src/admin/repositories/monitoring.repository.ts
@@ -441,6 +441,21 @@ export class MonitoringRepository {
     `;
   }
 
+  /** RUM 페이지 로딩 데이터가 처음 생긴 날짜(KST, YYYY-MM-DD). 없으면 null. */
+  async findEarliestPageLoadDate(): Promise<string | null> {
+    const rows = await this.prisma.$queryRaw<
+      Array<{ earliest: string | null }>
+    >`
+      SELECT TO_CHAR(
+               MIN((created_at AT TIME ZONE 'Asia/Seoul')::date),
+               'YYYY-MM-DD'
+             ) AS earliest
+      FROM apm_page_load_timings
+      WHERE source = 'rum'
+    `;
+    return rows[0]?.earliest ?? null;
+  }
+
   async findSummary(slowThresholdMs: number) {
     const rows = await this.prisma.$queryRaw<SummaryRow[]>`
       SELECT

--- a/server/src/admin/repositories/monitoring.repository.ts
+++ b/server/src/admin/repositories/monitoring.repository.ts
@@ -365,30 +365,40 @@ export class MonitoringRepository {
   }
 
   /** 시간버킷 평균(ttfb/dcl/lcp/load). 빈 버킷도 채워 반환. */
-  async findPageLoadSeries(rangeDays: number, bucketHours: number) {
-    // 버킷/라벨은 한국시간(KST) 달력 기준. 빈 버킷도 generate_series로 채워 축이 끊기지 않게 함.
-    if (bucketHours < 24) {
-      // 1일 보기: 오늘(KST) 00:00~23:00 시간별 (밤12시~다음날밤12시 24칸 고정)
+  /**
+   * 페이지 로딩 추이. from===to면 그날 시간별(00~23시 24칸), 아니면 from~to 일별.
+   * 버킷/라벨은 한국시간(KST) 달력 기준. 빈 버킷도 generate_series로 채운다.
+   * 이미 지난 버킷(현재시각 이하)은 데이터가 없어도 0으로 채워 점을 찍고,
+   * 아직 안 온 미래 버킷은 NULL로 둬서 점을 안 찍는다.
+   */
+  async findPageLoadSeries(from: string, to: string) {
+    if (from === to) {
+      // 선택한 하루 시간별 (KST 00:00~23:00 24칸 고정)
       return this.prisma.$queryRaw<PageLoadSeriesRow[]>`
         WITH samples AS (
           SELECT date_trunc('hour', created_at AT TIME ZONE 'Asia/Seoul') AS bucket_start,
                  ttfb_ms, dcl_ms, lcp_ms, load_ms
           FROM apm_page_load_timings
           WHERE source = 'rum'
-            AND created_at >= (date_trunc('day', NOW() AT TIME ZONE 'Asia/Seoul')) AT TIME ZONE 'Asia/Seoul'
+            AND created_at >= (${from}::date) AT TIME ZONE 'Asia/Seoul'
+            AND created_at <  (${from}::date + INTERVAL '1 day') AT TIME ZONE 'Asia/Seoul'
         ),
         buckets AS (
           SELECT generate_series(
-                   date_trunc('day', NOW() AT TIME ZONE 'Asia/Seoul'),
-                   date_trunc('day', NOW() AT TIME ZONE 'Asia/Seoul') + INTERVAL '23 hours',
+                   ${from}::timestamp,
+                   ${from}::timestamp + INTERVAL '23 hours',
                    INTERVAL '1 hour'
                  ) AS bucket_start
         )
         SELECT TO_CHAR(b.bucket_start, 'HH24:MI') AS bucket,
-               ROUND(AVG(s.ttfb_ms))::int AS avg_ttfb,
-               ROUND(AVG(s.dcl_ms))::int  AS avg_dcl,
-               ROUND(AVG(s.lcp_ms))::int  AS avg_lcp,
-               ROUND(AVG(s.load_ms))::int AS avg_load,
+               CASE WHEN b.bucket_start <= date_trunc('hour', NOW() AT TIME ZONE 'Asia/Seoul')
+                    THEN COALESCE(ROUND(AVG(s.ttfb_ms))::int, 0) END AS avg_ttfb,
+               CASE WHEN b.bucket_start <= date_trunc('hour', NOW() AT TIME ZONE 'Asia/Seoul')
+                    THEN COALESCE(ROUND(AVG(s.dcl_ms))::int, 0) END AS avg_dcl,
+               CASE WHEN b.bucket_start <= date_trunc('hour', NOW() AT TIME ZONE 'Asia/Seoul')
+                    THEN COALESCE(ROUND(AVG(s.lcp_ms))::int, 0) END AS avg_lcp,
+               CASE WHEN b.bucket_start <= date_trunc('hour', NOW() AT TIME ZONE 'Asia/Seoul')
+                    THEN COALESCE(ROUND(AVG(s.load_ms))::int, 0) END AS avg_load,
                COUNT(s.bucket_start) AS count
         FROM buckets b
         LEFT JOIN samples s ON s.bucket_start = b.bucket_start
@@ -397,32 +407,29 @@ export class MonitoringRepository {
       `;
     }
 
-    // 7/30일 보기: 최근 rangeDays 일(KST 달력, 오늘 포함) 일별
+    // from~to 일별 (KST 달력)
     return this.prisma.$queryRaw<PageLoadSeriesRow[]>`
       WITH samples AS (
         SELECT (created_at AT TIME ZONE 'Asia/Seoul')::date AS bucket_start,
                ttfb_ms, dcl_ms, lcp_ms, load_ms
         FROM apm_page_load_timings
         WHERE source = 'rum'
-          AND created_at >= (
-            (NOW() AT TIME ZONE 'Asia/Seoul')::date
-            - ((${rangeDays}::int - 1) * INTERVAL '1 day')
-          ) AT TIME ZONE 'Asia/Seoul'
+          AND created_at >= (${from}::date) AT TIME ZONE 'Asia/Seoul'
+          AND created_at <  (${to}::date + INTERVAL '1 day') AT TIME ZONE 'Asia/Seoul'
       ),
       buckets AS (
         SELECT g::date AS bucket_start
-        FROM generate_series(
-               ((NOW() AT TIME ZONE 'Asia/Seoul')::date
-                - ((${rangeDays}::int - 1) * INTERVAL '1 day'))::date,
-               (NOW() AT TIME ZONE 'Asia/Seoul')::date,
-               INTERVAL '1 day'
-             ) AS g
+        FROM generate_series(${from}::date, ${to}::date, INTERVAL '1 day') AS g
       )
       SELECT TO_CHAR(b.bucket_start, 'MM-DD') AS bucket,
-             ROUND(AVG(s.ttfb_ms))::int AS avg_ttfb,
-             ROUND(AVG(s.dcl_ms))::int  AS avg_dcl,
-             ROUND(AVG(s.lcp_ms))::int  AS avg_lcp,
-             ROUND(AVG(s.load_ms))::int AS avg_load,
+             CASE WHEN b.bucket_start <= (NOW() AT TIME ZONE 'Asia/Seoul')::date
+                  THEN COALESCE(ROUND(AVG(s.ttfb_ms))::int, 0) END AS avg_ttfb,
+             CASE WHEN b.bucket_start <= (NOW() AT TIME ZONE 'Asia/Seoul')::date
+                  THEN COALESCE(ROUND(AVG(s.dcl_ms))::int, 0) END AS avg_dcl,
+             CASE WHEN b.bucket_start <= (NOW() AT TIME ZONE 'Asia/Seoul')::date
+                  THEN COALESCE(ROUND(AVG(s.lcp_ms))::int, 0) END AS avg_lcp,
+             CASE WHEN b.bucket_start <= (NOW() AT TIME ZONE 'Asia/Seoul')::date
+                  THEN COALESCE(ROUND(AVG(s.load_ms))::int, 0) END AS avg_load,
              COUNT(s.bucket_start) AS count
       FROM buckets b
       LEFT JOIN samples s ON s.bucket_start = b.bucket_start


### PR DESCRIPTION
로딩 속도 추이를 달력 기반으로 개편하고 탐색·가독성을 개선.

- 달력 조회: 날짜 1개=시간별 / 여러 날=일별 자동 전환 (1·7·30일 버튼 대체), 지난 시간 0채움 점 표시
- 일별 점 클릭 시 그날 시간별로 드릴다운(recharts v3), 시작>끝 자동 정렬
- 커스텀 달력(년→월→일, 첫 데이터 날짜 이전 비활성) + 어드민 "메인 사이트 바로가기" 새 탭

🤖 Generated with [Claude Code](https://claude.com/claude-code)