### PR TITLE
fix(monitoring): 로딩/클릭 추이 날짜 경계 타임존 버그 (프로덕션 hotfix)

### DIFF
--- a/server/src/admin/repositories/monitoring.repository.ts
+++ b/server/src/admin/repositories/monitoring.repository.ts
@@ -371,6 +371,11 @@ export class MonitoringRepository {
    * 버킷/라벨은 한국시간(KST) 달력 기준. 빈 버킷도 generate_series로 채운다.
    * 이미 지난 버킷(현재시각 이하)은 데이터가 없어도 0으로 채워 점을 찍고,
    * 아직 안 온 미래 버킷은 NULL로 둬서 점을 안 찍는다.
+   *
+   * 경계는 반드시 `${x}::timestamp AT TIME ZONE 'Asia/Seoul'`로 쓴다.
+   * `::date AT TIME ZONE`는 date→timestamptz 암묵 캐스팅이 끼어 경계가 어긋나
+   * (세션 TZ에 따라 timestamp-without-tz가 반환됨) 프로덕션에서 오늘 데이터가
+   * 통째로 필터에서 빠지는 버그가 있었다.
    */
   async findPageLoadSeries(from: string, to: string) {
     if (from === to) {
@@ -381,8 +386,8 @@ export class MonitoringRepository {
                  ttfb_ms, dcl_ms, lcp_ms, load_ms
           FROM apm_page_load_timings
           WHERE source = 'rum'
-            AND created_at >= (${from}::date) AT TIME ZONE 'Asia/Seoul'
-            AND created_at <  (${from}::date + INTERVAL '1 day') AT TIME ZONE 'Asia/Seoul'
+            AND created_at >= (${from}::timestamp) AT TIME ZONE 'Asia/Seoul'
+            AND created_at <  (${from}::timestamp + INTERVAL '1 day') AT TIME ZONE 'Asia/Seoul'
         ),
         buckets AS (
           SELECT generate_series(
@@ -416,8 +421,8 @@ export class MonitoringRepository {
                ttfb_ms, dcl_ms, lcp_ms, load_ms
         FROM apm_page_load_timings
         WHERE source = 'rum'
-          AND created_at >= (${from}::date) AT TIME ZONE 'Asia/Seoul'
-          AND created_at <  (${to}::date + INTERVAL '1 day') AT TIME ZONE 'Asia/Seoul'
+          AND created_at >= (${from}::timestamp) AT TIME ZONE 'Asia/Seoul'
+          AND created_at <  (${to}::timestamp + INTERVAL '1 day') AT TIME ZONE 'Asia/Seoul'
       ),
       buckets AS (
         SELECT g::date AS bucket_start
@@ -509,7 +514,7 @@ export class MonitoringRepository {
              INTERVAL '1 day'
            ) AS d(day)
       LEFT JOIN apm_site_clicks c
-        ON c.created_at >= d.day AT TIME ZONE 'Asia/Seoul'
+        ON c.created_at >= d.day::timestamp AT TIME ZONE 'Asia/Seoul'
        AND c.created_at < (d.day + INTERVAL '1 day') AT TIME ZONE 'Asia/Seoul'
       GROUP BY d.day
       ORDER BY d.day ASC
@@ -529,7 +534,7 @@ export class MonitoringRepository {
              INTERVAL '1 day'
            ) AS d(day)
       LEFT JOIN apm_youtube_clicks c
-        ON c.created_at >= d.day AT TIME ZONE 'Asia/Seoul'
+        ON c.created_at >= d.day::timestamp AT TIME ZONE 'Asia/Seoul'
        AND c.created_at < (d.day + INTERVAL '1 day') AT TIME ZONE 'Asia/Seoul'
       GROUP BY d.day
       ORDER BY d.day ASC


### PR DESCRIPTION
## 증상
프로덕션(EC2) 어드민 "메인페이지 로딩 속도 추이"에 **오늘 데이터가 안 뜸**(0 점만). 로컬은 정상.

## 원인
WHERE 날짜 경계를 `(x::date) AT TIME ZONE 'Asia/Seoul'`로 작성 → Postgres가 `date`를 `timestamptz`로 암묵 캐스팅한 뒤 `AT TIME ZONE`을 적용해 **timestamp-without-tz**(예: `2026-06-17 09:00:00`)를 반환. 이를 `created_at`(timestamptz)과 비교하면 세션 TZ로 재해석되어 경계가 ~9~18h 어긋남 → 오늘 RUM(09·13시)이 통째로 필터에서 제외됨.
- 로컬(session TZ UTC)에선 우연히 맞아 드러나지 않았고, EC2에서만 발생.

## 수정
- `findPageLoadSeries`(시간/일별) WHERE 경계: `x::date` → **`x::timestamp` AT TIME ZONE**
- 사이트/유튜브 클릭 일별: `d.day AT TIME ZONE` → **`d.day::timestamp AT TIME ZONE**` (같은 버그, 클릭이 ~18h 어긋난 날짜로 집계되던 것)

## 검증 (EC2 실데이터)
- 수정 전: 09·13시 cnt=0 (필터 제외)
- 수정 후: **09시 1117ms(1건)·13시 473ms(4건)** 정상 집계 ✅
- server tsc/eslint 통과

> 머지 후 nest 재배포되어야 프로덕션 반영됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)