### PR TITLE
feat: PM2 cluster 2워커 운영 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,11 @@ workRecord/
 study/
 
 .claude/
+
+portfolio/
+
+# 부하테스트 산출물만 제외 (스크립트·기록 마크다운은 추적)
+stress/
+
+tseting.md
+cluster.md

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -9,10 +9,12 @@ RUN apk add --no-cache docker-cli python3 py3-pip && pip install --break-system-
 
 COPY package*.json ./
 RUN npm ci --omit=dev
+RUN npm i -g pm2
 
 COPY generated ./generated
 COPY dist ./dist
+COPY ecosystem.config.js ./
 
 EXPOSE 3001
 
-CMD ["node", "dist/main"]
+CMD ["pm2-runtime", "start", "ecosystem.config.js"]

--- a/server/ecosystem.config.js
+++ b/server/ecosystem.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  apps: [{
+    name: 'lomoa-nest',
+    script: 'dist/main.js',
+    instances: 2,
+    exec_mode: 'cluster',
+    max_memory_restart: '300M',
+    env: { NODE_ENV: 'production' },
+    // DATABASE_URL/REDIS_URL 등 민감 변수는 여기 넣지 말 것 — docker-compose env_file로 주입됨
+  }],
+};

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -14,11 +14,16 @@ import { AdminModule } from './admin/admin.module';
 import { RevalidateService } from './revalidate/revalidate.service';
 import { PrismaModule } from './prisma/prisma.module';
 
+// NODE_APP_INSTANCE: PM2가 워커마다 '0','1'... 자동 주입. 로컬/비클러스터는 undefined.
+const runScheduler =
+  process.env.NODE_APP_INSTANCE === '0' ||
+  process.env.NODE_APP_INSTANCE === undefined;
+
 @Module({
   imports: [
     SentryModule.forRoot(),
     ConfigModule.forRoot({ isGlobal: true }),
-    ScheduleModule.forRoot(),
+    ...(runScheduler ? [ScheduleModule.forRoot()] : []),
     LostarkModule,
     CharactersModule,
     SitesModule,


### PR DESCRIPTION
## Summary
- `server/Dockerfile`: pm2 글로벌 설치, `ecosystem.config.js` COPY, CMD를 `pm2-runtime`으로 교체
- `server/ecosystem.config.js` 신규 생성: instances 2, cluster 모드, max_memory_restart 300M
- `server/src/app.module.ts`: `NODE_APP_INSTANCE === '0'` 가드로 0번 워커만 `@Cron` 실행 (크론 중복 방지)
- `.gitignore`: portfolio/, stress/, cluster.md, tseting.md 추가

## 로컬 도커 검증 결과 (tseting.md 기준)
| 항목 | 결과 |
|---|---|
| 워커 2개 online (id 0, 1) | ✅ |
| NODE_APP_INSTANCE 0/1 주입 | ✅ |
| 크론 가드 — 00:00:00에 docker_metrics_nest 1행만 삽입 | ✅ |
| restart 0 유지 | ✅ |
| DB 커넥션 수 (2개, max_connections 100 안쪽) | ✅ |

## 남은 검증 (EC2에서만 가능)
- 5분 지속 부하로 처리량 ~200→300/초 여부
- nest CPU ~200%(2코어) 도달 여부
- CPU 크레딧 소진 곡선

🤖 Generated with [Claude Code](https://claude.com/claude-code)