### PR TITLE
fix: PM2 cluster monitoring 스키마 초기화 DDL 경쟁 방지

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,8 @@ stress/
 
 tseting.md
 cluster.md
+fix.md
+
+review-log/
+work-log/
+search+plan-log/

--- a/server/src/admin/admin-monitoring.service.ts
+++ b/server/src/admin/admin-monitoring.service.ts
@@ -56,6 +56,9 @@ export class AdminMonitoringService implements OnModuleInit {
   constructor(private readonly monitoringRepo: MonitoringRepository) {}
 
   async onModuleInit() {
+    // PM2 cluster: 스키마 부트스트랩은 0번 워커만(또는 비클러스터=undefined). 동시 DDL 경쟁 방지.
+    const inst = process.env.NODE_APP_INSTANCE;
+    if (inst !== undefined && inst !== '0') return;
     await this.monitoringRepo.ensureMonitoringTables();
   }
 


### PR DESCRIPTION
## Summary
- PM2 cluster 2워커 기동 시 `onModuleInit`이 동시에 실행되며 `DROP VIEW + CREATE VIEW` 경쟁 → 워커 1에서 42P07 에러 발생하던 문제 수정
- 크론 가드와 동일한 패턴으로 `NODE_APP_INSTANCE === '0'`(또는 undefined)인 워커만 `ensureMonitoringTables()` 실행

## 변경 파일
- `server/src/admin/admin-monitoring.service.ts`: `onModuleInit`에 인스턴스 가드 추가
- `.gitignore`: fix.md, review-log/, work-log/, search+plan-log/ 추가

## 검증 방법
```powershell
docker exec lomoa-nest pm2 logs --lines 200 | findstr 42P07  # 결과 없어야 함
docker exec lomoa-nest pm2 list                               # 두 워커 online, restart 0
docker exec lomoa-postgres psql -U lomoa -d lost_ark -c "select count(*) from lost_ark.apm_page_visit_daily;"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)