### PR TITLE
fix: PM2 cluster monitoring DDL 경쟁 방지

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,8 @@ stress/
 
 tseting.md
 cluster.md
+fix.md
+
+review-log/
+work-log/
+search+plan-log/

--- a/server/src/admin/admin-monitoring.service.ts
+++ b/server/src/admin/admin-monitoring.service.ts
@@ -56,6 +56,9 @@ export class AdminMonitoringService implements OnModuleInit {
   constructor(private readonly monitoringRepo: MonitoringRepository) {}
 
   async onModuleInit() {
+    // PM2 cluster: 스키마 부트스트랩은 0번 워커만(또는 비클러스터=undefined). 동시 DDL 경쟁 방지.
+    const inst = process.env.NODE_APP_INSTANCE;
+    if (inst !== undefined && inst !== '0') return;
     await this.monitoringRepo.ensureMonitoringTables();
   }
 


### PR DESCRIPTION
PM2 2워커 기동 시 `onModuleInit`이 동시 실행되며 발생하던 `CREATE VIEW` 42P07 에러 수정

- `admin-monitoring.service.ts`: `NODE_APP_INSTANCE === '0'`(또는 undefined)인 워커만 `ensureMonitoringTables()` 실행하도록 인스턴스 가드 추가
- 크론 중복 방지(`ScheduleModule.forRoot()` 가드, PR #338)와 동일한 패턴 적용
- `.gitignore`: fix.md, 로그 디렉터리(review-log/, work-log/, search+plan-log/) 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)