### PR TITLE
fix: PM2 cluster 환경에서 StreamersService onModuleInit 워커0만 실행

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,5 +90,6 @@ review-log/
 work-log/
 search+plan-log/
 check-log/
+qa-log/
 
 CLAUDE.md

--- a/server/src/streamers/streamers.service.ts
+++ b/server/src/streamers/streamers.service.ts
@@ -165,6 +165,10 @@ export class StreamersService implements OnModuleInit {
   }
 
   async onModuleInit() {
+    // PM2 cluster: 워커0(또는 비클러스터=undefined)만 실행. 동시 YouTube API 호출/UPSERT 방지.
+    const inst = process.env.NODE_APP_INSTANCE;
+    if (inst !== undefined && inst !== '0') return;
+
     if (this.youtubeRedisReadOnly) {
       this.logger.log(
         'YOUTUBE_REDIS_READONLY 활성화 — 시작 시 YouTube 갱신 스킵',


### PR DESCRIPTION
## Summary
- EC2 재시작 시 PM2 워커 2개가 동시에 `onModuleInit` 실행 → YouTube API 2회 호출(쿼터 2배) + `snapshotViewCounts()` UPSERT 2회 문제 수정
- `streamers.service.ts` `onModuleInit` 최상단에 `NODE_APP_INSTANCE` 가드 추가 — 워커0(또는 비클러스터=undefined)만 실행
- `.gitignore`에 `qa-log/` 추가

## 변경 파일
- `server/src/streamers/streamers.service.ts`: `onModuleInit` 인스턴스 가드 추가
- `.gitignore`: `qa-log/` 추가

## 검증 예정
로컬 2워커 기동 후 `pm2 logs`에서 'YouTube 영상 목록 갱신 시작'이 워커0에서만 찍히는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)