### PR TITLE
feat: PM2 cluster 2워커 기본 가드 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,5 +90,6 @@ review-log/
 work-log/
 search+plan-log/
 check-log/
+qa-log/
 
 CLAUDE.md

--- a/server/src/streamers/streamers.service.ts
+++ b/server/src/streamers/streamers.service.ts
@@ -165,6 +165,10 @@ export class StreamersService implements OnModuleInit {
   }
 
   async onModuleInit() {
+    // PM2 cluster: 워커0(또는 비클러스터=undefined)만 실행. 동시 YouTube API 호출/UPSERT 방지.
+    const inst = process.env.NODE_APP_INSTANCE;
+    if (inst !== undefined && inst !== '0') return;
+
     if (this.youtubeRedisReadOnly) {
       this.logger.log(
         'YOUTUBE_REDIS_READONLY 활성화 — 시작 시 YouTube 갱신 스킵',


### PR DESCRIPTION
## Summary
PM2 cluster 환경에서 중복 초기화 방지를 위한 워커0-only 가드 패턴 통합

- `streamers.service.ts`: YouTube API 호출, `snapshotViewCounts()` UPSERT를 워커0에서만 실행
- `admin-monitoring.service.ts`: `ensureMonitoringTables()` DDL을 워커0에서만 실행 (PR #340)
- `.gitignore`: 로그 디렉터리(check-log/, qa-log/), CLAUDE.md 추가

## 포함 PR
- #340: PM2 cluster monitoring DDL 경쟁 방지
- #343: StreamersService onModuleInit 가드 추가

## 검증 완료
- ✅ 로컬 2워커 기동: 크론 1회만 실행, 중복 초기화 없음
- ✅ 상태 안정화: restart 0 유지, DB 커넥션 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)