### PR TITLE
fix: PM2 cluster 환경에서 StreamersService onModuleInit 워커0만 실행

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,5 +90,6 @@ review-log/
 work-log/
 search+plan-log/
 check-log/
+qa-log/
 
 CLAUDE.md

--- a/server/src/streamers/streamers.service.ts
+++ b/server/src/streamers/streamers.service.ts
@@ -165,6 +165,10 @@ export class StreamersService implements OnModuleInit {
   }
 
   async onModuleInit() {
+    // PM2 cluster: 워커0(또는 비클러스터=undefined)만 실행. 동시 YouTube API 호출/UPSERT 방지.
+    const inst = process.env.NODE_APP_INSTANCE;
+    if (inst !== undefined && inst !== '0') return;
+
     if (this.youtubeRedisReadOnly) {
       this.logger.log(
         'YOUTUBE_REDIS_READONLY 활성화 — 시작 시 YouTube 갱신 스킵',


### PR DESCRIPTION
## 배경

PR #338(PM2 cluster 2워커), #340(monitoring DDL 경쟁 fix)에 이은 동일 계열 수정.

EC2 재시작 시 PM2 2워커가 동시에 `StreamersService.onModuleInit` 진입 → `refresh()` 직접 호출 → YouTube API 2회 호출(쿼터 2배) + `snapshotViewCounts()` UPSERT 2회 발생.

`@Cron refresh`는 PR #338의 `ScheduleModule` 조건부 등록으로 워커0만 실행되지만, `onModuleInit`이 부르는 `refresh`는 크론과 무관하게 모든 워커에서 동작 — 이게 갭.

## 변경 사항

- `server/src/streamers/streamers.service.ts:167` — `onModuleInit` 최상단에 `NODE_APP_INSTANCE` 가드 추가

```ts
const inst = process.env.NODE_APP_INSTANCE;
if (inst !== undefined && inst !== '0') return;
```

## 로컬 검증

2워커 기동 후 `pm2 logs` 확인:
- ✅ 워커 0: `[StreamersService] YOUTUBE_REDIS_READONLY 활성화 — 시작 시 YouTube 갱신 스킵` (onModuleInit 진입)
- ✅ 워커 1: StreamersService 기동 로그 없음 (가드에서 즉시 return)

## 범위 외 (후속 PR)

- `AdminAuthService` 가드: `ensureTable()` 멱등, `seedAccounts` TOCTOU는 UNIQUE 제약으로 안전 → correctness 이슈 아님
- `isPrimaryWorker()` 헬퍼 추출: 별도 `chore/is-primary-worker-util` PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)