### PR TITLE
feat: PM2 cluster 환경 워커0만 실행 가드 통합

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,5 +90,6 @@ review-log/
 work-log/
 search+plan-log/
 check-log/
+qa-log/
 
 CLAUDE.md

--- a/server/src/streamers/streamers.service.ts
+++ b/server/src/streamers/streamers.service.ts
@@ -165,6 +165,10 @@ export class StreamersService implements OnModuleInit {
   }
 
   async onModuleInit() {
+    // PM2 cluster: 워커0(또는 비클러스터=undefined)만 실행. 동시 YouTube API 호출/UPSERT 방지.
+    const inst = process.env.NODE_APP_INSTANCE;
+    if (inst !== undefined && inst !== '0') return;
+
     if (this.youtubeRedisReadOnly) {
       this.logger.log(
         'YOUTUBE_REDIS_READONLY 활성화 — 시작 시 YouTube 갱신 스킵',


### PR DESCRIPTION
## 배경

PM2 cluster 2워커 환경에서 리소스 중복 사용 문제 해결:
- PR #338: 크론 중복 실행 방지 (ScheduleModule 조건부 등록)
- PR #340: monitoring DDL 경쟁 방지 (onModuleInit 가드)
- PR #345: YouTube API 중복 호출 방지 (StreamersService onModuleInit 가드)

## 변경 사항

### PR #345 — StreamersService onModuleInit 가드
`server/src/streamers/streamers.service.ts:167` — `onModuleInit` 최상단에 `NODE_APP_INSTANCE` 가드 추가

EC2 재시작 시 워커 2개가 동시 진입 → YouTube API 2회 호출(쿼터 2배) + UPSERT 2회 발생 → 가드로 워커0만 실행

## 검증

- ✅ 로컬 2워커: 워커0만 onModuleInit 진입, 워커1은 가드로 즉시 return
- ✅ 커밋 5a22928

🤖 Generated with [Claude Code](https://claude.com/claude-code)