### PR TITLE
chore: loa_class_summaries 모델 제거 (AI 한줄평 폐기 후속)

### DIFF
--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -95,13 +95,6 @@ model loa_class {
   loa_users       loa_users[]
 }
 
-model loa_class_summaries {
-  class_name String    @id(map: "idx_16570_primary")
-  summary    String?
-  updated_at DateTime? @db.Timestamptz(6)
-  title_hash String?
-}
-
 model loa_sites {
   seq         BigInt    @id(map: "idx_16576_primary") @default(autoincrement())
   name        String


### PR DESCRIPTION
AI 직업 한줄평(class-summary) 기능 제거(#347·#348)의 후속으로, 미사용된 Prisma 모델을 정리합니다.

- `loa_class_summaries` Prisma 모델 삭제 (단독 테이블 → 공유 테이블 영향 없음)
- 로컬 DB 테이블 DROP 완료
- 운영 DB 테이블은 별도 수동 DROP 진행

🤖 Generated with [Claude Code](https://claude.com/claude-code)