### PR TITLE
어드민 라우트 우회/게스트 로그인 + 모니터링 레이아웃·범위 정리

### DIFF
--- a/client/app/admin/layout.tsx
+++ b/client/app/admin/layout.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 
@@ -7,7 +8,6 @@ const NAV = [
   { href: "/admin/monitoring", label: "모니터링" },
   { href: "/admin/containers", label: "컨테이너 현황" },
   { href: "/admin/sites", label: "사이트 관리" },
-  { href: "/admin/youtube", label: "유튜브" },
   { href: "/admin/inven", label: "사이트 추천" },
 ];
 
@@ -18,6 +18,17 @@ export default function AdminLayout({
 }) {
   const pathname = usePathname();
   const router = useRouter();
+
+  // 어드민은 항상 라이트 테마. 메인 사이트의 다크모드(html.dark)가 어드민의
+  // dark: variant 클래스에 적용되지 않도록, 어드민 진입 동안 dark를 제거하고 이탈 시 복원한다.
+  useEffect(() => {
+    const html = document.documentElement;
+    const wasDark = html.classList.contains("dark");
+    html.classList.remove("dark");
+    return () => {
+      if (wasDark) html.classList.add("dark");
+    };
+  }, []);
 
   async function logout() {
     await fetch("/api/admin/auth/logout", { method: "POST" });

--- a/client/app/admin/monitoring/page.tsx
+++ b/client/app/admin/monitoring/page.tsx
@@ -193,7 +193,7 @@ export default function MonitoringPage() {
     async function loadSectionOnly() {
       try {
         const res = await fetch(
-          `/api/admin/monitoring/dashboard?days=10&pvDays=${pageVisitDays}`,
+          `/api/admin/monitoring/dashboard?days=7&pvDays=${pageVisitDays}`,
           { cache: "no-store" },
         );
         if (!alive || !res.ok) return;
@@ -382,7 +382,9 @@ export default function MonitoringPage() {
         </div>
       )}
 
-      <div className="grid grid-cols-1 gap-4">
+      <div className="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,2.3fr)_minmax(0,1fr)] xl:items-stretch">
+        {/* 왼쪽: 그래프 영역 (좌측 컬럼) */}
+        <div className="flex min-w-0 flex-col gap-4">
         <div className="admin-card p-3">
           <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
             <div className="flex items-center gap-2">
@@ -436,7 +438,7 @@ export default function MonitoringPage() {
               )}
             </div>
           </div>
-          <div className="h-48">
+          <div className="h-56">
             {pageLoadLoading ? (
               <div className="grid h-full place-items-center text-sm text-[color:var(--admin-text-muted)]">
                 불러오는 중...
@@ -506,7 +508,7 @@ export default function MonitoringPage() {
                 누적 {siteClickTotal.toLocaleString()}회
               </span>
             </div>
-            <div className="h-40">
+            <div className="h-52">
               {loading ? (
                 <div className="grid h-full place-items-center text-sm text-[color:var(--admin-text-muted)]">
                   불러오는 중...
@@ -552,12 +554,12 @@ export default function MonitoringPage() {
 
           <div className="admin-card p-3">
             <div className="mb-2 flex items-center justify-between">
-              <p className="text-sm font-semibold">유튜브 클릭 타임라인 (일)</p>
+              <p className="text-sm font-semibold">스트림 클릭 타임라인 (일)</p>
               <span className="text-xs text-[color:var(--admin-text-muted)]">
                 누적 {(data.youtubeClickTotal ?? 0).toLocaleString()}회
               </span>
             </div>
-            <div className="h-40">
+            <div className="h-52">
               {loading ? (
                 <div className="grid h-full place-items-center text-sm text-[color:var(--admin-text-muted)]">
                   불러오는 중...
@@ -593,7 +595,7 @@ export default function MonitoringPage() {
                       dataKey="count"
                       stroke="#ef4444"
                       fill="#fecaca"
-                      name="유튜브 클릭"
+                      name="스트림 클릭"
                     />
                   </AreaChart>
                 </ResponsiveContainer>
@@ -673,7 +675,7 @@ export default function MonitoringPage() {
               </p>
               <div className="flex items-center gap-2">
                 <span className="text-xs text-[color:var(--admin-text-muted)]">
-                  최근 10일
+                  최근 7일
                 </span>
                 <div className="flex gap-1">
                   {(["sites", "stat-builds", "youtube"] as const).map(
@@ -762,7 +764,13 @@ export default function MonitoringPage() {
           </div>
         </div>
 
-        <div className="grid auto-rows-min content-start gap-4 xl:grid-cols-4">
+        </div>
+        {/* 오른쪽: 통계 목록 (우측 세로 컬럼)
+            xl에서는 relative 래퍼(높이는 grid stretch로 왼쪽 그래프 높이에 맞춰짐) 안에
+            내부 그리드를 absolute inset-0으로 띄워, 오른쪽 콘텐츠가 행 높이를 늘리지 못하게 한다.
+            → 행 높이는 왼쪽 그래프 높이로만 결정되고, 넘치는 항목은 각 카드 내부 스크롤로 처리. */}
+        <div className="xl:relative xl:min-w-0">
+        <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 xl:absolute xl:inset-0 xl:grid-cols-1 xl:grid-rows-4 xl:[&>div]:min-h-0 xl:[&>div]:overflow-y-auto">
           <div className="admin-card p-3">
             <div className="mb-2 flex items-center justify-between">
               <p className="text-sm font-semibold">사이트 클릭 상위</p>
@@ -904,6 +912,7 @@ export default function MonitoringPage() {
               )}
             </div>
           </div>
+        </div>
         </div>
       </div>
     </div>

--- a/client/app/globals.css
+++ b/client/app/globals.css
@@ -119,6 +119,9 @@ body {
 .admin-shell {
   background: var(--admin-bg);
   color: var(--admin-text);
+  /* 어드민은 항상 라이트 테마. OS/브라우저 다크모드가 native 컨트롤
+     (date picker, select 등)에 적용되는 것을 막는다. */
+  color-scheme: light;
 }
 .admin-sidebar {
   background: var(--admin-sidebar-bg);

--- a/client/components/stream/StreamList.tsx
+++ b/client/components/stream/StreamList.tsx
@@ -37,6 +37,29 @@ export default function StreamList({
     setLoadedImages(new Set());
   }, [initialItems]);
 
+  // SSR/ISR 캐시가 비었거나 stale일 수 있어, 마운트 시 클라이언트에서 현재 치지직 라이브를
+  // 한 번 보정 조회한다. (백엔드는 14개 반환해도 SSR 캐시 때문에 "없음"으로 보이던 문제 방지)
+  React.useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch(
+          `/api/streamers/live?platform=chzzk&minViewers=0`,
+        );
+        const data = (await res.json()) as ChzzkLiveItem[];
+        if (!cancelled && Array.isArray(data) && data.length > 0) {
+          setDisplayItems(data);
+        }
+      } catch {
+        // best-effort 보정
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // 마운트 시 1회만 (초기 플랫폼은 chzzk)
+  }, []);
+
   const handleRefresh = React.useCallback(async () => {
     setIsRefreshing(true);
     setRefreshSpin(true);
@@ -92,6 +115,27 @@ export default function StreamList({
       label: item.channelName,
       value: item.viewerCount,
     });
+    // 스트림 클릭 텔레메트리 — 모니터링 "스트림 클릭 타임라인"에 집계
+    // (기존 youtube-click 인프라 재활용: videoId 자리에 channelId)
+    try {
+      const payload = JSON.stringify({
+        type: "youtube-click",
+        videoId: item.channelId,
+        videoTitle: item.title,
+        channelTitle: item.channelName,
+      });
+      const blob = new Blob([payload], { type: "application/json" });
+      if (!navigator.sendBeacon("/api/telemetry", blob)) {
+        void fetch("/api/telemetry", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: payload,
+          keepalive: true,
+        }).catch(() => {});
+      }
+    } catch {
+      // best-effort telemetry
+    }
     window.open(item.liveUrl, "_blank");
   };
 

--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -28,8 +28,11 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  // afterFiles: app router의 route handler(/api/admin/* 등 쿠키·인증 처리)를 먼저 매칭하고,
+  // 매칭되는 핸들러가 없는 경로(예: /api/streamers/live)만 Nest 백엔드로 프록시한다.
+  // beforeFiles로 두면 이 rewrite가 모든 route handler를 가로채 admin 인증 쿠키가 깨진다.
   rewrites: async () => ({
-    beforeFiles: [
+    afterFiles: [
       {
         source: "/api/:path*",
         destination: `${process.env.NEST_API_URL || "http://localhost:3001"}/api/:path*`,

--- a/server/src/admin/admin-monitoring.service.ts
+++ b/server/src/admin/admin-monitoring.service.ts
@@ -274,8 +274,8 @@ export class AdminMonitoringService implements OnModuleInit {
       youtubeClickTotal,
     ] = await Promise.all([
       this.monitoringRepo.findSummary(this.SLOW_THRESHOLD_MS),
-      this.monitoringRepo.findSiteClickSeriesDays(14),
-      this.monitoringRepo.findYoutubeClickSeriesDays(14),
+      this.monitoringRepo.findSiteClickSeriesDays(7),
+      this.monitoringRepo.findYoutubeClickSeriesDays(7),
       this.monitoringRepo.findSectionSeries(bucketHours, safeRangeDays),
       this.monitoringRepo.findPageVisits(),
       this.monitoringRepo.findDimensionVisits(),


### PR DESCRIPTION
## 변경 요약

### 어드민 인증/라우팅
- `next.config` rewrite를 `beforeFiles`→`afterFiles`로 변경하여 admin route handler(쿠키·인증)가 먼저 매칭되도록 수정 → 게스트 로그인/모니터링 진입 정상화
- 어드민 항상 라이트 테마(진입 시 `.dark` 제거, 이탈 시 복원) + 날짜피커 `color-scheme: light`
- 어드민 네비에서 유튜브 탭 제거

### 모니터링 대시보드
- 2단 레이아웃: 좌측 그래프 / 우측 통계. 우측을 `relative` 래퍼 + 내부 `absolute`로 띄워 **좌측 그래프 높이에 맞춰 4등분**, 넘치는 항목은 카드 내부 스크롤
- "유튜브 클릭 타임라인" → "스트림 클릭 타임라인" (홈 라이브 클릭 텔레메트리로 집계)
- 사이트/스트림 클릭 · 기능별 응답 타임라인 범위를 **오늘(KST) 기준 최근 7일**로 통일

### 라이브(StreamList)
- 마운트 시 치지직 라이브 클라이언트 보정 조회(SSR 캐시로 "없음" 표시되던 문제 방지)
- 스트림 클릭 텔레메트리 전송

🤖 Generated with [Claude Code](https://claude.com/claude-code)
